### PR TITLE
Add support for the "yield from" Python construct

### DIFF
--- a/h_program-lang/ast_generic.ml
+++ b/h_program-lang/ast_generic.ml
@@ -223,7 +223,7 @@ and expr =
   | MatchPattern of expr * action list
   (* less: TryFunctional *)
 
-  | Yield of expr
+  | Yield of expr * bool
   | Await of expr
 
   | Cast of type_ * expr

--- a/lang_GENERIC/analyze/lrvalue.ml
+++ b/lang_GENERIC/analyze/lrvalue.ml
@@ -179,7 +179,8 @@ let rec visit_expr hook lhs expr =
 
   | AnonClass _ -> ()
 
-  | Yield e | Await e -> recr e
+  | Yield (e, _is_yield_from) -> recr e
+  | Await e -> recr e
 
   | Record xs -> 
      xs |> List.iter (fun field ->

--- a/lang_GENERIC/parsing/map_ast.ml
+++ b/lang_GENERIC/parsing/map_ast.ml
@@ -158,7 +158,7 @@ and map_expr x =
       let v1 = map_expr v1
       and v2 = map_of_list map_action v2
       in MatchPattern ((v1, v2))
-  | Yield v1 -> let v1 = map_expr v1 in Yield ((v1))
+  | Yield ((v1, v2)) -> let v1 = map_expr v1 and v2 = map_of_bool v2 in Yield ((v1, v2))
   | Await v1 -> let v1 = map_expr v1 in Await ((v1))
   | Cast ((v1, v2)) ->
       let v1 = map_type_ v1 and v2 = map_expr v2 in Cast ((v1, v2))

--- a/lang_GENERIC/parsing/meta_ast.ml
+++ b/lang_GENERIC/parsing/meta_ast.ml
@@ -130,7 +130,7 @@ and vof_expr =
       let v1 = vof_expr v1
       and v2 = Ocaml.vof_list vof_action v2
       in Ocaml.VSum (("MatchPattern", [ v1; v2 ]))
-  | Yield v1 -> let v1 = vof_expr v1 in Ocaml.VSum (("Yield", [ v1 ]))
+  | Yield ((v1, v2)) -> let v1 = vof_expr v1 and v2 = Ocaml.vof_bool v2 in Ocaml.VSum (("Yield", [ v1; v2 ]))
   | Await v1 -> let v1 = vof_expr v1 in Ocaml.VSum (("Await", [ v1 ]))
   | Cast ((v1, v2)) ->
       let v1 = vof_type_ v1

--- a/lang_GENERIC/parsing/visitor_ast.ml
+++ b/lang_GENERIC/parsing/visitor_ast.ml
@@ -163,7 +163,7 @@ and v_expr x =
         v_list
           (fun (v1, v2) -> let v1 = v_pattern v1 and v2 = v_expr v2 in ()) v2
       in ()
-  | Yield v1 -> let v1 = v_expr v1 in ()
+  | Yield ((v1, v2)) -> let v1 = v_expr v1 and v2 = v_bool v2 in ()
   | Await v1 -> let v1 = v_expr v1 in ()
   | Cast ((v1, v2)) -> let v1 = v_type_ v1 and v2 = v_expr v2 in ()
   | Seq v1 -> let v1 = v_list v_expr v1 in ()

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -97,7 +97,7 @@ let special (x, tok) =
   | Spread -> SR_Special G.Spread
   | Yield -> SR_NeedArgs (fun args -> 
           match args with
-          | [e] -> G.Yield e
+          | [e] -> G.Yield (e, false)
           | _ -> error tok "Impossible: Too many arguments to Yield"
           )
   | YieldStar -> SR_Other G.OE_YieldStar

--- a/lang_python/analyze/python_to_generic.ml
+++ b/lang_python/analyze/python_to_generic.ml
@@ -202,8 +202,10 @@ let rec expr (x: expr) =
   | IfExp ((v1, v2, v3)) ->
       let v1 = expr v1 and v2 = expr v2 and v3 = expr v3 in
       G.Conditional (v1, v2, v3)
-  | Yield v1 -> let v1 = option expr v1 in
-      G.Yield (G.opt_to_nop v1)
+  | Yield ((v1, v2)) ->
+      let v1 = option expr v1
+      and v2 = v2 in
+      G.Yield (G.opt_to_nop v1, v2)
   | Await v1 -> let v1 = expr v1 in
       G.Await v1
   | Repr v1 -> let v1 = expr v1 in

--- a/lang_python/parsing/ast_python.ml
+++ b/lang_python/parsing/ast_python.ml
@@ -130,7 +130,7 @@ type expr =
 
   | IfExp of expr (* test *) * expr (* body *) * expr (* orelse *)
 
-  | Yield of expr option (* value *)
+  | Yield of expr option (* value *) * bool (* is_yield_from *)
   (* python3: *)
   | Await of expr
 

--- a/lang_python/parsing/meta_ast_python.ml
+++ b/lang_python/parsing/meta_ast_python.ml
@@ -93,8 +93,10 @@ let rec vof_expr =
       and v2 = vof_expr v2
       and v3 = vof_expr v3
       in Ocaml.VSum (("IfExp", [ v1; v2; v3 ]))
-  | Yield v1 ->
-      let v1 = Ocaml.vof_option vof_expr v1 in Ocaml.VSum (("Yield", [ v1 ]))
+  | Yield ((v1, v2)) ->
+      let v1 = Ocaml.vof_option vof_expr v1
+      and v2 = Ocaml.vof_bool v2
+      in Ocaml.VSum (("Yield", [ v1; v2 ]))
   | Await v1 -> let v1 = vof_expr v1 in Ocaml.VSum (("Await", [ v1 ]))
   | Repr v1 -> let v1 = vof_expr v1 in Ocaml.VSum (("Repr", [ v1 ]))
   | Attribute ((v1, v2, v3)) ->

--- a/lang_python/parsing/parser_python.mly
+++ b/lang_python/parsing/parser_python.mly
@@ -726,8 +726,9 @@ star_expr: MULT expr { ExprStar $2 }
 
 
 yield_expr:
-  | YIELD          { Yield (None) }
-  | YIELD testlist { Yield (Some (tuple_expr $2)) }
+  | YIELD           { Yield (None, false) }
+  | YIELD FROM test { Yield (Some $3, true) }
+  | YIELD testlist  { Yield (Some (tuple_expr $2), false) }
 
 lambdadef: LAMBDA varargslist COLON test { Lambda ($2, $4) }
 

--- a/lang_python/parsing/visitor_python.ml
+++ b/lang_python/parsing/visitor_python.ml
@@ -121,7 +121,7 @@ and v_expr (x: expr) =
   | Lambda ((v1, v2)) -> let v1 = v_parameters v1 and v2 = v_expr v2 in ()
   | IfExp ((v1, v2, v3)) ->
       let v1 = v_expr v1 and v2 = v_expr v2 and v3 = v_expr v3 in ()
-  | Yield v1 -> let v1 = v_option v_expr v1 in ()
+  | Yield ((v1, v2)) -> let v1 = v_option v_expr v1 and v2 = v_bool v2 in ()
   | Await v1 -> let v1 = v_expr v1 in ()
   | Repr v1 -> let v1 = v_expr v1 in ()
   | Attribute ((v1, v2, v3)) ->

--- a/tests/python/parsing/yield.py
+++ b/tests/python/parsing/yield.py
@@ -1,0 +1,14 @@
+def generate_to_ten():
+    x = 0
+    while x <= 10:
+        yield x
+        x += 1
+
+def defer_to_generate_to_ten():
+    yield from generate_to_ten()
+
+def use_yield_expr():
+    await (yield 3)
+
+def use_yield_from_expr():
+    await (yield from defer_to_generate_to_ten())


### PR DESCRIPTION
Adds support for the "yield from" construct in Python.

This change uses the same Yield node as a regular Python yield, but sets a boolean indicating that the node represents a yield from.