### PR TITLE
Make Python grammar handle keyword-only arg syntax correctly

### DIFF
--- a/lang_python/parsing/parser_python.mly
+++ b/lang_python/parsing/parser_python.mly
@@ -318,10 +318,19 @@ return_type_opt:
 parameters: LPAREN typedargslist RPAREN { $2 }
 
 /*(* typing-ext: *)*/
+/*(* Note: Python allows separating positional arguments from keyword
+   * arguments that MUST be specified as keywords with a single asterisk then
+   * a comma.
+   *
+   * We place the consumption of this single asterisk in typedargslist rather
+   * than typed_parameter as it does not generate a parameter for our
+   * parameter list.
+   * TODO: Enforce that only keyword args come after the asterisk. *)*/
 typedargslist:
   | /*(*empty*)*/                       { [] }
   | typed_parameter                     { [$1] }
   | typed_parameter COMMA typedargslist { $1::$3 }
+  | MULT COMMA typedargslist            { $3 }
 
 /*(* the original grammar enforces more restrictions on the order between
    * Param, ParamStar, and ParamPow, but each language version relaxed it *)*/

--- a/tests/python/parsing/anon-star-param.py
+++ b/tests/python/parsing/anon-star-param.py
@@ -1,0 +1,8 @@
+def regular_fn(param1, param2):
+    return param1 + param2
+
+def has_named_varargs_param(param1, param2, *varargs, a_kwarg = 3):
+    return param1 + param2 + a_kwarg
+
+def has_anon_varargs_param(param1, param2, *, a_kwarg = 3):
+    return param1 + param2 + a_kwarg


### PR DESCRIPTION
Python allows indicating the end of positional arguments and the start of
arguments that must be specified with a keyword using a parameter that is just
a bare star (PEP 3102). This commit causes pfff to handle that case. This gets
airflow and zulip to be 100% parsed.