### PR TITLE
Added Java parsing capability via tree-sitter/babelfish

### DIFF
--- a/lang_java/CONTRIBUTING.md
+++ b/lang_java/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# External Java Parsers
+
+We are working on incorporating tree-sitter-java grammar into pfff. 
+
+### Writing OCaml
+
+To compile OCaml code
+
+```
+$ ocamlc -o <executable> <filename>.ml
+$ ./<executable>
+```
+
+### Running
+
+You can run the following commands to output a JSON of the AST parsed from a `.java` file by tree-sitter.
+
+```
+$ cd tree_sitter
+$ npm install tree-sitter
+$ git clone https://github.com/tree-sitter/tree-sitter-java/
+$ cd tree-sitter-java && npm install 
+$ cd ..
+$ node tree-sitter-parser.js <path/to/java/file>
+```
+
+You can run the following commands to output a JSON of the AST parsed from a `.java` file by Babelfish. Since we no longer support Babelfish, this may not be complete. You must have Docker already installed.
+
+```
+$ cd tree_sitter
+$ pip3 install bblfsh
+$ docker run --privileged --rm -it -p 9432:9432 -v bblfsh_cache:/var/lib/bblfshd --name bblfshd bblfsh/bblfshd
+$ docker exec -it bblfshd bblfshctl driver install python bblfsh/python-driver
+$ python bblfsh-parser.py <path/to/java/file>
+```
+
+The following command allows you to run tree-sitter-java across a repository and outputs the number of `.java` files that fails parsing. It also generates a corpus of JSON files from the files that were parsed.
+
+```
+bash tree-sitter-parser <FILES_TO_SEARCH>
+```
+
+### Todo
+
+- Include support for language selection
+
+### Sources
+
+- [Babelfish Python Client](https://github.com/bblfsh/python-client)
+- [tree-sitter](https://github.com/tree-sitter/tree-sitter)
+- [tree-sitter-java](https://github.com/tree-sitter/tree-sitter-java/)

--- a/lang_java/parsing/test_parsing_java.ml
+++ b/lang_java/parsing/test_parsing_java.ml
@@ -15,6 +15,7 @@ open Ast_java
 module PI = Parse_info
 module V = Visitor_java
 module Flag = Flag_parsing
+module Ast = Ast_java
 
 (*****************************************************************************)
 (* Subsystem testing *)
@@ -88,6 +89,10 @@ let test_dump file =
   let str = Ocaml.string_of_v v in
   pr str
 
+let test_dump_tree_sitter file =
+  let sysline =  "node lang_java/tree_sitter/tree-sitter-parser.js " ^ file in 
+  Sys.command sysline |> ignore
+
 let test_visitor file = 
   let visitor = V.mk_visitor { V.default_visitor with
     V.kexpr = (fun (k, _) e -> 
@@ -105,6 +110,30 @@ let test_visitor file =
   let ast = Parse_java.parse_program file in
   visitor (AProgram ast);
   ()
+
+let test_visitor_print file = 
+  let ast = Parse_java.parse_program file in
+
+  (* prints out tokens as they are visited *)
+  let hooks = { Visitor_java.default_visitor with
+    Visitor_java.kinfo = (fun (_k, _) info ->
+      let s = Parse_info.str_of_info info in
+      pr2 s;
+    );
+
+    Visitor_java.kexpr = (fun (k, _) e -> 
+      match e with
+      | Ast_java.Literal (Ast_java.Int (s,_)) -> 
+          pr2 ("int:" ^ s);
+          k e
+      | Ast_java.Dot (e, (_s,_)) -> 
+          pr2 "dot: s";
+          k e
+      | _ -> k e
+    );
+  } in
+  let visitor = Visitor_java.mk_visitor hooks in
+  visitor (Ast.AProgram ast)
 
 let test_parse_json_tree_sitter file =
   let json = Json_io.load_json file in
@@ -127,7 +156,6 @@ let test_parse_json_babelfish file =
   let str = Ocaml.string_of_v v in
   pr str
 
-
 (*****************************************************************************)
 (* Main entry for Arg *)
 (*****************************************************************************)
@@ -139,10 +167,12 @@ let actions () = [
   Common.mk_action_n_arg test_parse;
   "-dump_java", "   <file>", 
   Common.mk_action_1_arg test_dump;
-
+  "-dump_java_tree_sitter", "   <file>", 
+  Common.mk_action_1_arg test_dump_tree_sitter;
   "-visitor_java", "   <file>", 
   Common.mk_action_1_arg test_visitor;
-
+  "-visitor_java_print", "   <file>", 
+  Common.mk_action_1_arg test_visitor_print;
   "-parse_json_tree_sitter", "   <file>", 
   Common.mk_action_1_arg test_parse_json_tree_sitter;
   "-parse_json_babelfish", "   <file>", 

--- a/lang_java/tree_sitter/bblfsh-parser.py
+++ b/lang_java/tree_sitter/bblfsh-parser.py
@@ -1,0 +1,7 @@
+import bblfsh
+import sys
+import json
+
+client = bblfsh.BblfshClient("localhost:9432")
+ctx = str(client.parse(str(sys.argv[1])))
+print(ctx)

--- a/lang_java/tree_sitter/tree-sitter-parser
+++ b/lang_java/tree_sitter/tree-sitter-parser
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+example_count=$(find $1 -name '*.java' | wc -l)
+
+echo "$example_count files found"
+
+declare -i count
+declare -i error
+
+mkdir corpus
+
+for file in $(find $1 -name '*.java');  do
+    node tree-sitter-parser.js "$file" > corpus/results$count.json
+    if grep -qF "ERROR" corpus/results$count.json;then
+        if grep -qF "ERROR" "$file";then
+            error+=0
+        else 
+            echo "Error found"
+            error+=1
+        fi
+    fi 
+    count+=1
+    echo "Parsed: $count/$example_count"
+done
+
+echo "Errors: $error/$example_count"

--- a/lang_java/tree_sitter/tree-sitter-parser.js
+++ b/lang_java/tree_sitter/tree-sitter-parser.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+const Parser = require('tree-sitter');
+const Java = require('../tree_sitter/tree-sitter-java'); 
+
+var args = process.argv.slice(2);
+
+var fs = require("fs");
+const sourceCode = fs.readFileSync(args[0]).toString();
+
+const parser = new Parser();
+parser.setLanguage(Java); 
+const tree = parser.parse(sourceCode);
+
+console.log(JSON.stringify(tree.rootNode, ["type", "startPosition", "endPosition", "row", "column", "children"]))


### PR DESCRIPTION
Added support for invoking Java parse dump from tree-sitter, as well as a CONTRIBUTING.md file that details how to run the parsers from command line.

The following commands are also now available:

```
./pfff -dump_java_new FILENAME.java
./pfff -visitor_java_new FILENAME.java
```

The first allows you to use tree-sitter-java for parsing, and the second prints out tokens as they are parsed.