### PR TITLE
Added documentation for codegen

### DIFF
--- a/lang_java/CONTRIBUTING.md
+++ b/lang_java/CONTRIBUTING.md
@@ -11,6 +11,14 @@ $ ocamlc -o <executable> <filename>.ml
 $ ./<executable>
 ```
 
+To compile all of pfff, make sure you have OCaml 4.07.1 and ran `eval $(opam env)`. 
+
+```
+$ cd ../..
+$ ./configure && make depend && make && make opt
+$ ./pfff <your commands>
+```
+
 ### Running
 
 You can run the following commands to output a JSON of the AST parsed from a `.java` file by tree-sitter.

--- a/lang_java/parsing/parse_java_with_external_program.ml
+++ b/lang_java/parsing/parse_java_with_external_program.ml
@@ -118,55 +118,47 @@ let program_of_tree_sitter_json _file json =
      "type", J.String "class_declaration";
      "startPosition", _;
       "endPosition", _;
-     "children", xs;
-    ] -> Class { 
-          cl_name = ident xs;
+     "children", J.Array xs;
+    ] -> let identity = 
+      match xs with 
+        | _::J.Object ["type", J.String "identifier"; "startPosition", _; "endPosition", _; "children", _;]::_ ->  wrap "void" 
+        | _ -> wrap "void"
+      in 
+      let bodies = 
+      match xs with
+        | _::J.Object ["type", J.String "class_body"; "startPosition", _; "endPosition", _; "children", b;]::_ -> list "decl" method_decl b
+        | _ -> []
+      in
+        Class { 
+          cl_name = identity;
           cl_kind = ClassRegular;
-          cl_body = class_body xs;
+          cl_body = bodies;
           cl_mods = []; cl_extends = None; cl_impls = []; cl_tparams = [];
           } 
    | x -> error "decl" x
-
-  and ident = function
-   | J.Object [
-     "type", J.String "identifier";
-     "startPosition", _;
-      "endPosition", _;
-     "children", _;
-    ] -> wrap "void"
-   | x -> error "ident" x 
-
-  and class_body = function
-   | J.Object [
-     "type", J.String "class_body";
-     "startPosition", _;
-      "endPosition", _;
-     "children", xs;
-    ] ->  list "decl" method_decl xs
-   | x -> error "class_body" x
 
   and method_decl = function
   | J.Object [
      "type", J.String "method_declaration";
      "startPosition", _;
       "endPosition", _;
-     "children", xs;
+     "children", _;
     ] ->  Method {
-      m_var = { name = ident xs; mods = []; type_ = Some (typ xs); };
+      m_var = { name = wrap "str"; mods = []; type_ = None; };
       m_formals = [];
       m_throws = [];
-      m_body = block xs;
+      m_body = Empty;
     }
-   | x -> error "class_body" x
+   | x -> error "method_decl" x
 
-  and typ = function
+  (* and typ = function
   | J.Object [
      "type", J.String "void_type";
      "startPosition", _;
       "endPosition", _;
      "children", _;
     ] ->  TBasic (wrap "void")
-   | x -> error "class_body" x
+   | x -> error "typ" x
 
   and block = function
   | J.Object [
@@ -175,7 +167,7 @@ let program_of_tree_sitter_json _file json =
       "endPosition", _;
      "children", xs;
     ] ->  Return (Some (expr xs))
-   | x -> error "class_body" x
+   | x -> error "block" x
 
   and expr = function
   | J.Object [
@@ -184,7 +176,7 @@ let program_of_tree_sitter_json _file json =
       "endPosition", _;
      "children", _;
     ] ->  Literal (Int (wrap "str"))
-   | x -> error "class_body" x
+   | x -> error "expr" x *)
 
 
   (* and package_declaration = function

--- a/lang_java/parsing/parse_java_with_external_program.ml
+++ b/lang_java/parsing/parse_java_with_external_program.ml
@@ -12,10 +12,12 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
  * license.txt for more details.
  *)
-open Common
 
+open Common
 open Ast_java
 module J = Json_type
+module JI = Json_io
+
 (* module PI = Parse_info *)
 
 (*****************************************************************************)
@@ -50,8 +52,12 @@ let json_of_filename_with_external_prog _file =
    * temporary JSON output, and read this JSON output
    * (or use a pipe to the external program to avoid using an
    *  intermediate temporary file)
-   *)
-  raise Todo
+   *) 
+  let file = "results.json" in 
+  let line = "node lang_java/tree_sitter/tree-sitter-parser.js " ^ _file ^ " > " ^ file in
+  let _ = Sys.command line in
+  let json = JI.load_json file in
+  json
 
 (*****************************************************************************)
 (* JSON boilerplate (we should find a way to generate this code) *)

--- a/lang_java/parsing/test_parsing_java.ml
+++ b/lang_java/parsing/test_parsing_java.ml
@@ -145,6 +145,14 @@ let test_parse_json_tree_sitter file =
   let str = Ocaml.string_of_v v in
   pr str
 
+let test_parse_file_tree_sitter file =
+  let ast = Parse_java_with_external_program.parse file in
+
+  (* just dump it back, to double check *)
+  let v = Meta_ast_java.vof_any (Ast_java.AProgram ast) in
+  let str = Ocaml.string_of_v v in
+  pr str
+
 (*****************************************************************************)
 (* Main entry for Arg *)
 (*****************************************************************************)
@@ -162,6 +170,8 @@ let actions () = [
   Common.mk_action_1_arg test_visitor;
   "-visitor_java_print", "   <file>", 
   Common.mk_action_1_arg test_visitor_print;
-  "-parse_json_tree_sitter_new", "   <file>", 
+  "-parse_json_tree_sitter", "   <file>", 
   Common.mk_action_1_arg test_parse_json_tree_sitter;
+  "-parse_file_tree_sitter", "   <file>", 
+  Common.mk_action_1_arg test_parse_file_tree_sitter;
 ]

--- a/lang_java/parsing/tree_sitter_ast_java.ml
+++ b/lang_java/parsing/tree_sitter_ast_java.ml
@@ -447,8 +447,8 @@ and enum_body_declarations = ( _class_body_declaration list)
 and enum_constant = {
   mods4: modifiers option;
   name7: identifier;
-  arguments4: argument_list;
-  body11: class_body;
+  arguments4: argument_list option;
+  body11: class_body option;
 }
 
 and class_declaration = {

--- a/lang_java/parsing/tree_sitter_ast_java.ml
+++ b/lang_java/parsing/tree_sitter_ast_java.ml
@@ -73,22 +73,31 @@ and cast_expression = {
 }
 
 and assignment_expression = {
-  left: _ambiguous_name * field_access * array_access;
+  left: interm17;
   operator: string wrap;
   right: _expression;
 }
 
-and binary_expression = string wrap
+and interm17 = 
+ | Ambiguous5 of _ambiguous_name
+ | Field4 of field_access
+ | Array3 of array_access
+
+and binary_expression = {
+  left2: _expression;
+  right2: _expression;
+}
 
 
 and instanceof_expression = {
   left1: _expression;
+  operator1: string wrap;
   right1: _type;
 }
 
 and lambda_expression = {
-  body: interm15 option;
-  parameters1: interm16 option;
+  body: interm15;
+  parameters1: interm16;
 }
 
 and interm15 =
@@ -109,9 +118,12 @@ and ternary_expression = {
   alternative: _expression;
 }
 
-and unary_expression = string wrap
+and unary_expression = {
+  operator2: string wrap;
+  operand: _expression;
+}
 
-and update_expression = string wrap
+and update_expression = _expression
  
 and _primary =
 | Literal of _literal
@@ -154,7 +166,7 @@ and object_creation_expression =
 
 
 and _unqualified_object_creation_expression = {
-  type_arguments1: type_arguments;
+  type_arguments1: type_arguments option;
   t_type1: _simple_type;
   arguments1: argument_list;
   class_body: class_body option;

--- a/lang_java/tree_sitter/Toy.java
+++ b/lang_java/tree_sitter/Toy.java
@@ -1,0 +1,4 @@
+class Bar {
+
+void main() { return 1;  } 
+} 

--- a/lang_java/tree_sitter/codegen_grammar.py
+++ b/lang_java/tree_sitter/codegen_grammar.py
@@ -1,36 +1,13 @@
 #!/usr/bin/python3
 
 import json
+import templates
 
 with open("grammar.json", 'r') as fs:
     data = json.load(fs)
 
-codegen = '''
-(* 
- * Yoann Padioleau, Sharon Lin
- * 2020 initial draft
- *)
+codegen = templates.ast_header
 
-(*****************************************************************************)
-(* Prelude *)
-(*****************************************************************************)
-(*
- * An AST for Java.
- *
- * (Not yet complete, this requires further manual edits in order to compile)
- *
- *)
- (*****************************************************************************)
-(* The Tree-sitter AST java related types *)
-(*****************************************************************************)
-(* ------------------------------------------------------------------------- *)
-(* Token/info *)
-(* ------------------------------------------------------------------------- *)
-
-type 'a wrap  = 'a * string
-'''
-
-IGNORE_TYPES = ["PREC_DYNAMIC", "PREC_LEFT", "PREC", "PREC_RIGHT", "SEQ", "STRING", "ALIAS"]
 PREC = ['PREC_LEFT', 'PREC_RIGHT', 'PREC_DYNAMIC']
 
 # Finding type from field
@@ -142,6 +119,8 @@ def makeConstructor(b):
 
 def removeToken(b):
     return b[:-2] if b[-2] in ['|', '*'] else b
+
+# Handling top-level types 
 
 for a, aval in data["rules"].items():
     if aval["type"] == "CHOICE":

--- a/lang_java/tree_sitter/codegen_json_parser.py
+++ b/lang_java/tree_sitter/codegen_json_parser.py
@@ -1,72 +1,12 @@
+#!/usr/bin/python3
+
 import json
+import templates
 
 with open("grammar.json", 'r') as fs:
     data = json.load(fs)
 
-codegen = '''
-(* Yoann Padioleau, Sharon Lin
- *
- * Copyright (C) 2020 r2c
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public License
- * version 2.1 as published by the Free Software Foundation, with the
- * special exception on linking described in file license.txt.
- *
- * This library is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
- * license.txt for more details.
- *)
-open Common
-
-open Ast_java
-module J = Json_type
-module PI = Parse_info
-
-(*****************************************************************************)
-(* Call external program *)
-(*****************************************************************************)
-let json_of_filename_with_external_prog _file =
-  (* should call tree-sitter or babelfish on _file, generate
-   * temporary JSON output, and read this JSON output
-   * (or use a pipe to the external program to avoid using an
-   *  intermediate temporary file)
-   *)
-  let lines = "node ../tree-sitter/tree-sitter-parser.js " ^ _file ^ " > results.json"
-  Sys.command lines
-  raise Todo
-
-(*****************************************************************************)
-(* JSON boilerplate (we should find a way to generate this code) *)
-(*****************************************************************************)
-
-let error str json =
-  pr2 (spf "bad json: was expecting a %s (got %s)" str 
-        (Json_io.string_of_json json));
-  failwith "BAD JSON"
-
-let todo str json = 
-  pr2 (spf "TODO: in %s need to handle this JSON: %s" str 
-    (Json_io.string_of_json json));
-  failwith "TODO"
-
-(* this can not be in the recursive 'let rec ... and ...' below because
- * of weird OCaml restrictions too long to explain
- *)
-let list str f = function
-    | J.Array xs -> List.map f xs
-    | J.String "None" -> []
-    | x -> error (spf "list[%s]" str) x
-let option str _f = function
-    | J.String "None" -> None
-    | x -> todo (spf "option[%s]" str) x
-
-let wrap str = 
-  let tok = Parse_info.fake_info str in
-  str, tok
-
-'''
+codegen = templates.json_header
 
 interm_count = 0
 PREC = ['PREC_LEFT', 'PREC_RIGHT', 'PREC_DYNAMIC']
@@ -343,16 +283,7 @@ for a, aval in data["rules"].items():
         codegen += handleGeneric(a, aval)
 
 
-codegen += '''
-(*****************************************************************************)
-(* Main entry point *)
-(*****************************************************************************)
-let parse file = 
-  let json = json_of_filename_with_external_prog file in
-  (* to decide wether this or program_of_babelfish_json *)
-  let program = program_of_tree_sitter_json file json in
-  program
-'''
+codegen += templates.json_footer
 
 with open("parse_with_external_n.ml", "w") as f:
     f.write(codegen)

--- a/lang_java/tree_sitter/templates.py
+++ b/lang_java/tree_sitter/templates.py
@@ -1,0 +1,98 @@
+ast_header = '''
+(* 
+ * Yoann Padioleau, Sharon Lin
+ * 2020 initial draft
+ *)
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(*
+ * An AST for Java.
+ *
+ *)
+ (*****************************************************************************)
+(* The Tree-sitter AST java related types *)
+(*****************************************************************************)
+(* ------------------------------------------------------------------------- *)
+(* Token/info *)
+(* ------------------------------------------------------------------------- *)
+
+type 'a wrap  = 'a * string
+'''
+
+json_header = '''
+(* Yoann Padioleau, Sharon Lin
+ *
+ * Copyright (C) 2020 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+ *)
+open Common
+
+open Ast_java
+module J = Json_type
+module PI = Parse_info
+
+(*****************************************************************************)
+(* Call external program *)
+(*****************************************************************************)
+let json_of_filename_with_external_prog _file =
+  (* should call tree-sitter or babelfish on _file, generate
+   * temporary JSON output, and read this JSON output
+   * (or use a pipe to the external program to avoid using an
+   *  intermediate temporary file)
+   *)
+  let lines = "node ../tree-sitter/tree-sitter-parser.js " ^ _file ^ " > results.json"
+  Sys.command lines
+  raise Todo
+
+(*****************************************************************************)
+(* JSON boilerplate (we should find a way to generate this code) *)
+(*****************************************************************************)
+
+let error str json =
+  pr2 (spf "bad json: was expecting a %s (got %s)" str 
+        (Json_io.string_of_json json));
+  failwith "BAD JSON"
+
+let todo str json = 
+  pr2 (spf "TODO: in %s need to handle this JSON: %s" str 
+    (Json_io.string_of_json json));
+  failwith "TODO"
+
+(* this can not be in the recursive 'let rec ... and ...' below because
+ * of weird OCaml restrictions too long to explain
+ *)
+let list str f = function
+    | J.Array xs -> List.map f xs
+    | J.String "None" -> []
+    | x -> error (spf "list[%s]" str) x
+let option str _f = function
+    | J.String "None" -> None
+    | x -> todo (spf "option[%s]" str) x
+
+let wrap str = 
+  let tok = Parse_info.fake_info str in
+  str, tok
+
+'''
+
+json_footer = '''
+(*****************************************************************************)
+(* Main entry point *)
+(*****************************************************************************)
+let parse file = 
+  let json = json_of_filename_with_external_prog file in
+  (* to decide wether this or program_of_babelfish_json *)
+  let program = program_of_tree_sitter_json file json in
+  program
+'''

--- a/lang_java/tree_sitter/toy_new.json
+++ b/lang_java/tree_sitter/toy_new.json
@@ -1,0 +1,247 @@
+{
+  "type": "program",
+  "startPosition": {
+    "row": 0,
+    "column": 0
+  },
+  "endPosition": {
+    "row": 3,
+    "column": 2
+  },
+  "children": [
+    {
+      "type": "class_declaration",
+      "startPosition": {
+        "row": 0,
+        "column": 0
+      },
+      "endPosition": {
+        "row": 3,
+        "column": 1
+      },
+      "children": [
+        {
+          "type": "class",
+          "startPosition": {
+            "row": 0,
+            "column": 0
+          },
+          "endPosition": {
+            "row": 0,
+            "column": 5
+          },
+          "children": []
+        },
+        {
+          "type": "identifier",
+          "startPosition": {
+            "row": 0,
+            "column": 6
+          },
+          "endPosition": {
+            "row": 0,
+            "column": 9
+          },
+          "children": []
+        },
+        {
+          "type": "class_body",
+          "startPosition": {
+            "row": 0,
+            "column": 10
+          },
+          "endPosition": {
+            "row": 3,
+            "column": 1
+          },
+          "children": [
+            {
+              "type": "{",
+              "startPosition": {
+                "row": 0,
+                "column": 10
+              },
+              "endPosition": {
+                "row": 0,
+                "column": 11
+              },
+              "children": []
+            },
+            {
+              "type": "method_declaration",
+              "startPosition": {
+                "row": 2,
+                "column": 0
+              },
+              "endPosition": {
+                "row": 2,
+                "column": 26
+              },
+              "children": [
+                {
+                  "type": "void_type",
+                  "startPosition": {
+                    "row": 2,
+                    "column": 0
+                  },
+                  "endPosition": {
+                    "row": 2,
+                    "column": 4
+                  },
+                  "children": []
+                },
+                {
+                  "type": "identifier",
+                  "startPosition": {
+                    "row": 2,
+                    "column": 5
+                  },
+                  "endPosition": {
+                    "row": 2,
+                    "column": 9
+                  },
+                  "children": []
+                },
+                {
+                  "type": "formal_parameters",
+                  "startPosition": {
+                    "row": 2,
+                    "column": 9
+                  },
+                  "endPosition": {
+                    "row": 2,
+                    "column": 11
+                  },
+                  "children": [
+                    {
+                      "type": "(",
+                      "startPosition": {
+                        "row": 2,
+                        "column": 9
+                      },
+                      "endPosition": {
+                        "row": 2,
+                        "column": 10
+                      },
+                      "children": []
+                    },
+                    {
+                      "type": ")",
+                      "startPosition": {
+                        "row": 2,
+                        "column": 10
+                      },
+                      "endPosition": {
+                        "row": 2,
+                        "column": 11
+                      },
+                      "children": []
+                    }
+                  ]
+                },
+                {
+                  "type": "block",
+                  "startPosition": {
+                    "row": 2,
+                    "column": 12
+                  },
+                  "endPosition": {
+                    "row": 2,
+                    "column": 26
+                  },
+                  "children": [
+                    {
+                      "type": "{",
+                      "startPosition": {
+                        "row": 2,
+                        "column": 12
+                      },
+                      "endPosition": {
+                        "row": 2,
+                        "column": 13
+                      },
+                      "children": []
+                    },
+                    {
+                      "type": "return_statement",
+                      "startPosition": {
+                        "row": 2,
+                        "column": 14
+                      },
+                      "endPosition": {
+                        "row": 2,
+                        "column": 23
+                      },
+                      "children": [
+                        {
+                          "type": "return",
+                          "startPosition": {
+                            "row": 2,
+                            "column": 14
+                          },
+                          "endPosition": {
+                            "row": 2,
+                            "column": 20
+                          },
+                          "children": []
+                        },
+                        {
+                          "type": "decimal_integer_literal",
+                          "startPosition": {
+                            "row": 2,
+                            "column": 21
+                          },
+                          "endPosition": {
+                            "row": 2,
+                            "column": 22
+                          },
+                          "children": []
+                        },
+                        {
+                          "type": ";",
+                          "startPosition": {
+                            "row": 2,
+                            "column": 22
+                          },
+                          "endPosition": {
+                            "row": 2,
+                            "column": 23
+                          },
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "type": "}",
+                      "startPosition": {
+                        "row": 2,
+                        "column": 25
+                      },
+                      "endPosition": {
+                        "row": 2,
+                        "column": 26
+                      },
+                      "children": []
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "}",
+              "startPosition": {
+                "row": 3,
+                "column": 0
+              },
+              "endPosition": {
+                "row": 3,
+                "column": 1
+              },
+              "children": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This change addresses many of the comments in [#7](https://github.com/returntocorp/pfff/pull/7), namely creating a file for templates, editing the `Tree_sitter_ast_java` file, and improving naming in the codegen files.

### Overview of Codegen
- `codegen-node.py`: After reviewing, tree-sitter `node-type.json` isn't as accurate as `grammar.json`, so `codegen-node.py` is mostly here for posterity (although it does generate pretty good OCaml).
- `codegen_grammar.py`: This is the codegen that we are going to continue working on. The state isn't great right now, a lot of the `tree_sitter_ast_java.ml` file had to be manually edited and there may still need to be diffed against `grammar.json` to make sure it is error-free.
- `codegen_json_parser.py`: I started working on a codegen for JSON parsing, but then went back to work on manually building out the JSON parser first, so this is effectively not workable right now. I've also included it for posterity, but ideally a new codegen for the JSON parser should be built.


### Test Plan

```
make clean && make depend && make && make opt
./pfff -parse_json_tree_sitter_new lang_java/tree_sitter/toy_new.json
./pfff -parse_file_tree_sitter_new lang_java/tree_sitter/Toy.java
```

Possibly will need if the above fails

```
npm install tree-sitter
git clone https://github.com/tree-sitter/tree-sitter-java
cd tree-sitter-java
npm install
cd ..
```