### PR TITLE
Support "javascript" in Find_source for sgrep.

### DIFF
--- a/lang_GENERIC/parsing/find_source.ml
+++ b/lang_GENERIC/parsing/find_source.ml
@@ -1,3 +1,7 @@
+(* UPDATE: this is mostly obsolete. You should use Lang.files_of_dirs_or_files
+ * instead.
+ *)
+
 open Common
 
 let finder lang = 
@@ -14,7 +18,7 @@ let finder lang =
     Lib_parsing_ml.find_source_files_of_dir_or_files
   | "java" | "javafuzzy" -> 
     Lib_parsing_java.find_source_files_of_dir_or_files
-  | "js" | "jsfuzzy" | "jsgen"  -> 
+  | "js" | "javascript" | "jsfuzzy" | "jsgen"  -> 
     Lib_parsing_js.find_source_files_of_dir_or_files ~include_scripts:false
   | "py" | "python"  -> 
     Lib_parsing_python.find_source_files_of_dir_or_files

--- a/lang_GENERIC/parsing/find_source.mli
+++ b/lang_GENERIC/parsing/find_source.mli
@@ -1,3 +1,6 @@
+(* UPDATE: this is mostly obsolete. You should use Lang.files_of_dirs_or_files
+ * instead.
+ *)
 
 (* will manage optional skip list at root *)
 val files_of_root: 

--- a/lang_GENERIC/parsing/lang.ml
+++ b/lang_GENERIC/parsing/lang.ml
@@ -65,26 +65,16 @@ let string_of_lang = function
   | Go -> "Golang"
 
 
+let find_source lang xs = 
+  Common.files_of_dir_or_files_no_vcs_nofilter xs 
+   |> List.filter (fun filename ->
+     lang_of_filename_opt filename =*= Some lang
+  ) |> Common.sort
 
-(* copy-paste: very similar to pfff/find_source.ml *)
-let finder lang =
-  match lang with
-  | Python  -> 
-    Lib_parsing_python.find_source_files_of_dir_or_files
-  | Javascript  -> 
-    Lib_parsing_js.find_source_files_of_dir_or_files ~include_scripts:false
-  | C
-  | Java
-  | ML
-  | Go
-   -> raise Todo
-
-
+(* this is used by sgrep, so it is probably better to keep the logic 
+ * simple and not perform any Skip_code filtering (bento already does that)
+ *) 
 let files_of_dirs_or_files lang xs =
-  let finder = finder lang in
   let xs = List.map Common.fullpath xs in
-  finder xs
- (* |> Skip_code.filter_files_if_skip_list *)
-
-
+  find_source lang xs
 


### PR DESCRIPTION
Also support iterating over Java/Go/... in Lang.files_of_...

This should help fix https://github.com/returntocorp/sgrep/issues/66

Test plan:
make test
make install-libs and then in sgrep repo:
./_build/default/bin/main_sgrep.exe -lang javascript -e foo tests/js/
does not raise any exn.