### PR TITLE
BIG refactoring, add far more tokens in the different ASTs and AST ge…

### DIFF
--- a/lang_GENERIC/analyze/controlflow.ml
+++ b/lang_GENERIC/analyze/controlflow.ml
@@ -109,7 +109,7 @@ type node = {
          | ExprStmt of expr
          | DefStmt of definition
          | DirectiveStmt of directive
-         | Assert of expr * expr option
+         | Assert of tok * expr * expr option
          | OtherStmt of other_stmt_operator * any list
          (* not part of Ast.stmt but useful to have in CFG for 
           * dataflow analysis purpose *)
@@ -182,21 +182,22 @@ let short_string_of_node node =
 let simple_node_of_stmt_opt stmt =
   match stmt with
   | A.ExprStmt e      -> Some (ExprStmt e)
-  | A.Assert (e1, e2) -> Some (Assert (e1, e2))
+  | A.Assert (t, e1, e2) -> Some (Assert (t, e1, e2))
   | A.DefStmt x       -> Some (DefStmt x)
   | A.DirectiveStmt x -> Some (DirectiveStmt x)
   | A.OtherStmt (a,b) -> Some (OtherStmt (a,b))
 
-  | (A.Block _|A.If (_, _, _)|A.While (_, _)|A.DoWhile (_, _)|A.For (_, _)
+  | (A.Block _|A.If (_, _, _, _)|A.While (_, _, _)|A.DoWhile (_, _, _)
+    |A.For (_, _, _)
     |A.Switch (_, _, _)
     |A.Return _|A.Continue _|A.Break _|A.Label (_, _)|A.Goto _
-    |A.Throw _|A.Try (_, _, _)
+    |A.Throw _|A.Try (_, _, _, _)
     |A.OtherStmtWithStmt _
     ) -> None
 
 let any_of_simple_node = function
   | ExprStmt e      -> A.S (A.ExprStmt e)
-  | Assert (e1, e2) -> A.S (A.Assert (e1, e2))
+  | Assert (t, e1, e2) -> A.S (A.Assert (t, e1, e2))
   | DefStmt x       -> A.S (A.DefStmt x)
   | DirectiveStmt x -> A.S (A.DirectiveStmt x)
   | OtherStmt (a,b) -> A.S (A.OtherStmt (a,b))

--- a/lang_GENERIC/analyze/controlflow.mli
+++ b/lang_GENERIC/analyze/controlflow.mli
@@ -30,7 +30,7 @@ type node = {
       | ExprStmt of expr
       | DefStmt of definition
       | DirectiveStmt of directive
-      | Assert of expr * expr option
+      | Assert of tok * expr * expr option
       (* The 'any' below should not containt stmts, otherwise the CFG will
        * be incomplete. Use other_stmt_with_stmt_operator instead.
        *)

--- a/lang_GENERIC/analyze/controlflow_build.ml
+++ b/lang_GENERIC/analyze/controlflow_build.ml
@@ -145,9 +145,9 @@ let rec (cfg_stmt: state -> F.nodei option -> stmt -> F.nodei option) =
       *)
        let node, stmt = 
          (match stmt with 
-         | While (e, stmt) ->
+         | While (_, e, stmt) ->
              F.WhileHeader (e), stmt
-         | For (forheader, stmt) ->
+         | For (_, forheader, stmt) ->
              (match forheader with
              | ForClassic _ -> raise Todo
              | ForEach (pat, e) -> F.ForeachHeader (pat, e)
@@ -274,7 +274,7 @@ let rec (cfg_stmt: state -> F.nodei option -> stmt -> F.nodei option) =
    * (whereas While can't return None). But if we return None, certainly
    * sign of buggy code.
    *)
-   | DoWhile (st, e) ->
+   | DoWhile (_, st, e) ->
      (* previ -> doi ---> ... ---> finalthen (opt) ---> taili
       *          |--------- newfakethen ----------------| |-> newfakelse <rest>
       *)
@@ -303,7 +303,7 @@ let rec (cfg_stmt: state -> F.nodei option -> stmt -> F.nodei option) =
            Some newfakeelse
        )
 
-   | If (e, st_then, st_else) ->
+   | If (_, e, st_then, st_else) ->
      (* previ -> newi --->  newfakethen -> ... -> finalthen --> lasti -> <rest>
       *                |                                     |
       *                |->  newfakeelse -> ... -> finalelse -|
@@ -338,7 +338,7 @@ let rec (cfg_stmt: state -> F.nodei option -> stmt -> F.nodei option) =
            Some lasti
        )
 
-   | Return (e) ->
+   | Return (_, e) ->
        let newi = state.g#add_node { F.n = F.Return e;i=i() } in
        state.g |> add_arc_opt (previ, newi);
        state.g |> add_arc (newi, state.exiti);
@@ -346,7 +346,7 @@ let rec (cfg_stmt: state -> F.nodei option -> stmt -> F.nodei option) =
         * this new node *)
        None
 
-   | Continue (eopt) | Break (eopt) ->
+   | Continue (_, eopt) | Break (_, eopt) ->
 
        let is_continue, node =
          match stmt with
@@ -413,7 +413,7 @@ let rec (cfg_stmt: state -> F.nodei option -> stmt -> F.nodei option) =
             *)
            if (not (cases_and_body |> List.exists (fun (cases, _body) ->
                   cases |> List.exists (function 
-                    | Ast.Default -> true | _ -> false))))
+                    | Ast.Default _ -> true | _ -> false))))
            then begin
              state.g |> add_arc (newi, endi);
            end;
@@ -482,7 +482,7 @@ let rec (cfg_stmt: state -> F.nodei option -> stmt -> F.nodei option) =
     *   <tryend>
     *)
 
-   | Try(body, catches, _finallys) ->
+   | Try(_, body, catches, _finallys) ->
        (* TODO Task #3622443: Update the logic below to account for "finally"
           clauses *)
        let newi = state.g#add_node { F.n = F.TryHeader;i=i() } in
@@ -557,7 +557,7 @@ let rec (cfg_stmt: state -> F.nodei option -> stmt -> F.nodei option) =
     * path sensitive analysis to be more precise (so that we would remove
     * certain edges)
     *)
-   | Throw (e) ->
+   | Throw (_, e) ->
        let newi = state.g#add_node { F.n = F.Throw e; i=i() } in
        state.g |> add_arc_opt (previ, newi);
 
@@ -656,7 +656,7 @@ and (cfg_cases:
       let node =     
        (* TODO: attach expressions there *)
        match cases with
-       | [Default] -> F.Default
+       | [Default _] -> F.Default
        | _ -> F.Case
       in
 

--- a/lang_GENERIC/analyze/controlflow_visitor.ml
+++ b/lang_GENERIC/analyze/controlflow_visitor.ml
@@ -98,7 +98,7 @@ let exprs_of_node node =
   | SimpleNode x ->
       (match x with
       | ExprStmt e -> [e]
-      | Assert (e, eopt) -> e::Common.opt_to_list eopt
+      | Assert (_, e, eopt) -> e::Common.opt_to_list eopt
       (* TODO: should transform VarDef in it in Assign *)
       | DefStmt _ -> []
       | DirectiveStmt _ -> []

--- a/lang_c/analyze/datalog_c.ml
+++ b/lang_c/analyze/datalog_c.ml
@@ -116,6 +116,8 @@ let string_of_op _str =
 let is_local env s =
   (Common.find_opt (fun (x, _) -> x =$= s) !(env.locals)) <> None
 
+let unbracket (_, x, _) = x
+
 (*****************************************************************************)
 (* Normalize *)
 (*****************************************************************************)
@@ -169,7 +171,7 @@ let instrs_of_expr env e =
 
   (* todo: actually an alloc is hidden there! *)
   | A.Assign (op, e1, A.ArrayInit xs) ->
-    let ys = xs |> List.map (fun (idxopt, value) ->
+    let ys = xs |> unbracket |> List.map (fun (idxopt, value) ->
       (* less? recompute e1 each time? should store in intermediate val? *)
       let access =
         match idxopt with
@@ -184,7 +186,7 @@ let instrs_of_expr env e =
 
   (* todo: actually an alloc is hidden there! *)
   | A.Assign (op, e1, A.RecordInit xs) ->
-    let ys = xs |> List.map (fun (name, value) ->
+    let ys = xs |> unbracket |> List.map (fun (name, value) ->
       (* less? recompute e1 each time? should store in intermediate val? *)
       let access = 
         A.RecordPtAccess

--- a/lang_c/parsing/ast_c.ml
+++ b/lang_c/parsing/ast_c.ml
@@ -81,6 +81,10 @@ type tok = Parse_info.t
 type 'a wrap = 'a * tok
  (* with tarzan *)
 
+(* round(), square[], curly{}, angle<> brackets *)
+type 'a bracket = tok * 'a * tok
+ (* with tarzan *)
+
 (* ------------------------------------------------------------------------- *)
 (* Name *)
 (* ------------------------------------------------------------------------- *)
@@ -95,7 +99,7 @@ type name = string wrap
 (* less: qualifier (const/volatile) *)
 type type_ =
   | TBase of name (* int, float, etc *)
-  | TPointer of type_
+  | TPointer of tok * type_
   | TArray of const_expr option * type_
   | TFunction of function_type
   | TStructName of struct_kind * name
@@ -158,8 +162,8 @@ and expr =
   | SizeOf of (expr, type_) Common.either
 
   (* should appear only in a variable initializer, or after GccConstructor *)
-  | ArrayInit of (expr option * expr) list
-  | RecordInit of (name * expr) list
+  | ArrayInit of (expr option * expr) list bracket
+  | RecordInit of (name * expr) list bracket
   (* gccext: kenccext: *)
   | GccConstructor  of type_ * expr (* always an ArrayInit (or RecordInit?) *)
 
@@ -180,26 +184,26 @@ type stmt =
   | ExprSt of expr
   | Block of stmt list
 
-  | If of expr * stmt * stmt
+  | If of tok * expr * stmt * stmt
   | Switch of tok * expr * case list
 
-  | While of expr * stmt
-  | DoWhile of stmt * expr
-  | For of expr option * expr option * expr option * stmt
+  | While of tok * expr * stmt
+  | DoWhile of tok * stmt * expr
+  | For of tok * expr option * expr option * expr option * stmt
 
-  | Return of expr option
-  | Continue | Break
+  | Return of tok * expr option
+  | Continue of tok | Break of tok
 
   | Label of name * stmt
-  | Goto of name
+  | Goto of tok * name
 
   | Vars of var_decl list
   (* todo: it's actually a special kind of format, not just an expr *)
   | Asm of expr list
 
   and case =
-    | Case of expr * stmt list
-    | Default of stmt list
+    | Case of tok * expr * stmt list
+    | Default of tok * stmt list
 
 (* ------------------------------------------------------------------------- *)
 (* Variables *)
@@ -270,7 +274,7 @@ type define_body =
 (* Program *)
 (* ------------------------------------------------------------------------- *)
 type toplevel =
-  | Include of string wrap (* path *)
+  | Include of tok * string wrap (* path *)
   | Define of name * define_body 
   | Macro of name * (name list) * define_body
 

--- a/lang_cpp/parsing/cst_cpp.ml
+++ b/lang_cpp/parsing/cst_cpp.ml
@@ -654,6 +654,7 @@ and class_definition = {
 (* ------------------------------------------------------------------------- *)
 and cpp_directive =
   | Define of tok (* #define*) * simple_ident * define_kind * define_val
+  (* TODO: should split tok in 2 *)
   | Include of tok (* #include s *) * inc_kind * string (* path *)
   | Undef of simple_ident (* #undef xxx *)
   | PragmaAndCo of tok

--- a/lang_go/analyze/highlight_go.ml
+++ b/lang_go/analyze/highlight_go.ml
@@ -68,6 +68,8 @@ let builtin_functions = Common.hashset_of_list [
     "len";
 ]
 
+let unbracket (_, x, _) = x
+
 (*****************************************************************************)
 (* Code highlighter *)
 (*****************************************************************************)
@@ -124,7 +126,7 @@ let visit_program ~tag_hook _prefs (program, toks) =
 
     (* defs *)
     V.kprogram = (fun (k, _) x ->
-      tag_ident x.package (Entity (E.Module, def2));
+      tag_ident (snd x.package) (Entity (E.Module, def2));
       x.imports |> List.iter (fun import ->
         tag_ident import.i_path (Entity (E.Module, use2));
         match import.i_kind with
@@ -187,16 +189,16 @@ let visit_program ~tag_hook _prefs (program, toks) =
         ), ii]) -> tag ii TypeInt
       | TName qid -> tag_qid qid (Entity (E.Type, use2))
 
-      | TStruct flds ->
-        flds |> List.iter (fun (fld, tag_opt) ->
+      | TStruct (_, flds) ->
+        flds |> unbracket |> List.iter (fun (fld, tag_opt) ->
           tag_opt |> Common.do_option (fun tag -> tag_ident tag Attribute);
           (match fld with
           | Field (id, _) -> tag_ident id (Entity (E.Field, def2));
           | EmbeddedField (_, qid) -> tag_qid qid (Entity (E.Type, use2))
           );
         );
-      | TInterface flds ->
-        flds |> List.iter (function
+      | TInterface (_, flds) ->
+        flds |> unbracket |> List.iter (function
           | Method (id, _)        -> tag_ident id (Entity (E.Method, def2))
           | EmbeddedInterface qid -> tag_qid qid (Entity (E.Type, use2))
         );

--- a/lang_go/analyze/resolve_go.ml
+++ b/lang_go/analyze/resolve_go.ml
@@ -97,9 +97,10 @@ let resolve prog =
 
     (* defs *)
     V.kprogram = (fun (k, _) x ->
-      let file = Parse_info.file_of_info (snd x.package), snd x.package in
-      add_name_env x.package (G.ImportedModule (G.FileName file)) env;
-      x.imports |> List.iter (fun { i_path = (path, ii); i_kind = kind } ->
+      let file = Parse_info.file_of_info (fst x.package), fst x.package in
+      let packid = snd x.package in
+      add_name_env packid (G.ImportedModule (G.FileName file)) env;
+      x.imports |> List.iter (fun { i_path = (path, ii); i_kind = kind; _ } ->
           match kind with
           | ImportOrig -> 
             add_name_env (Filename.basename path, ii) 
@@ -144,7 +145,7 @@ let resolve prog =
     );
     V.kstmt = (fun (k, _) x ->
       (match x with
-      | SimpleStmt (DShortVars (xs, _, _)) | Range (Some (xs, _), _, _, _) ->
+      | SimpleStmt (DShortVars (xs, _, _)) | Range (_, Some (xs, _),_, _, _) ->
          xs |> List.iter (function
            | Id (id, _) -> env |> add_name_env id (local_or_global env id)
            | _ -> ()

--- a/lang_java/parsing/ast_java.ml
+++ b/lang_java/parsing/ast_java.ml
@@ -43,6 +43,10 @@ type 'a wrap  = 'a * tok
 type 'a list1 = 'a list (* really should be 'a * 'a list *)
   (* with tarzan *)
 
+(* round(), square[], curly{}, angle<> brackets *)
+type 'a bracket = tok * 'a * tok
+ (* with tarzan *)
+
 (* ------------------------------------------------------------------------- *)
 (* Ident, qualifier *)
 (* ------------------------------------------------------------------------- *)
@@ -223,22 +227,22 @@ and stmt =
   | Block of stmts
   | Expr of expr
 
-  | If of expr * stmt * stmt
+  | If of tok * expr * stmt * stmt
   | Switch of tok * expr * (cases * stmts) list
 
-  | While of expr * stmt
-  | Do of stmt * expr
-  | For of for_control * stmt
+  | While of tok * expr * stmt
+  | Do of tok * stmt * expr
+  | For of tok * for_control * stmt
 
-  | Break of ident option
-  | Continue of ident option
-  | Return of expr option
+  | Break of tok * ident option
+  | Continue of tok * ident option
+  | Return of tok * expr option
   | Label of ident * stmt
 
   | Sync of expr * stmt
 
-  | Try of stmt * catches * stmt option
-  | Throw of expr
+  | Try of tok * stmt * catches * stmt option
+  | Throw of tok * expr
 
   (* decl as statement *)
   | LocalVar of var_with_init
@@ -246,13 +250,13 @@ and stmt =
   | LocalClass of class_decl
 
   (* javaext: http://java.sun.com/j2se/1.4.2/docs/guide/lang/assert.html *)
-  | Assert of expr * expr option (* assert e or assert e : e2 *)
+  | Assert of tok * expr * expr option (* assert e or assert e : e2 *)
 
 and stmts = stmt list
 
 and case =
-  | Case of expr
-  | Default
+  | Case of (tok * expr)
+  | Default of tok
 and cases = case list
 
 and for_control =
@@ -292,7 +296,7 @@ and var_with_init = {
   (* less: could merge with expr *)
   and init =
     | ExprInit of expr
-    | ArrayInit of init list
+    | ArrayInit of init list bracket
 
 (* ------------------------------------------------------------------------- *)
 (* Methods, fields *)
@@ -379,11 +383,11 @@ and decls = decl list
 (* Toplevel *)
 (*****************************************************************************)
 type import = 
-  | ImportAll of qualified_ident * tok (* * *)
-  | ImportFrom of qualified_ident * ident
+  | ImportAll of tok * qualified_ident * tok (* * *)
+  | ImportFrom of tok * qualified_ident * ident
 
 type compilation_unit = {
-  package: qualified_ident option;
+  package: (tok * qualified_ident) option;
   (* The qualified ident can also contain "*" at the very end.
    * The bool is for static import (javaext:)
    *)

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -51,6 +51,8 @@ let wrap = fun _of_a (v1, v2) ->
   let v1 = _of_a v1 and v2 = info v2 in 
   (v1, v2)
 
+let bracket of_a (t1, x, t2) = (info t1, of_a x, info t2)
+
 let name v = wrap id v
 
 let filename v = wrap string v
@@ -97,13 +99,13 @@ let special (x, tok) =
   | Spread -> SR_Special G.Spread
   | Yield -> SR_NeedArgs (fun args -> 
           match args with
-          | [e] -> G.Yield (e, false)
+          | [e] -> G.Yield (tok, Some e, false)
           | _ -> error tok "Impossible: Too many arguments to Yield"
           )
   | YieldStar -> SR_Other G.OE_YieldStar
   | Await -> SR_NeedArgs (fun args ->
           match args with
-          | [e] -> G.Await e
+          | [e] -> G.Await (tok, e)
           | _ -> error tok "Impossible: Too many arguments to Await"
           )
   | Encaps v1 -> 
@@ -185,7 +187,7 @@ and expr (x: expr) =
       )
   | Apply ((v1, v2)) -> let v1 = expr v1 and v2 = list expr v2 in 
       G.Call (v1, v2 |> List.map (fun e -> G.Arg e))
-  | Arr ((v1)) -> let v1 = list expr v1 in G.Container (G.Array, v1)
+  | Arr ((v1)) -> let v1 = bracket (list expr) v1 in G.Container (G.Array, v1)
   | Conditional ((v1, v2, v3)) ->
       let v1 = expr v1 and v2 = expr v2 and v3 = expr v3 in
       G.Conditional (v1, v2, v3)
@@ -195,30 +197,32 @@ and stmt x =
   | VarDecl v1 -> let v1 = def_of_var v1 in G.DefStmt (v1)
   | Block v1 -> let v1 = list stmt v1 in G.Block v1
   | ExprStmt v1 -> let v1 = expr v1 in G.ExprStmt v1
-  | If ((v1, v2, v3)) ->
+  | If ((t, v1, v2, v3)) ->
       let v1 = expr v1 and v2 = stmt v2 and v3 = stmt v3 in 
-      G.If (v1, v2, v3)
-  | Do ((v1, v2)) -> let v1 = stmt v1 and v2 = expr v2 in 
-      G.DoWhile (v1, v2)
-  | While ((v1, v2)) -> let v1 = expr v1 and v2 = stmt v2 in
-      G.While (v1, v2)
-  | For ((v1, v2)) -> let v1 = for_header v1 and v2 = stmt v2 in
-      G.For (v1, v2)
+      G.If (t, v1, v2, v3)
+  | Do ((t, v1, v2)) -> let v1 = stmt v1 and v2 = expr v2 in 
+      G.DoWhile (t, v1, v2)
+  | While ((t, v1, v2)) -> let v1 = expr v1 and v2 = stmt v2 in
+      G.While (t, v1, v2)
+  | For ((t, v1, v2)) -> let v1 = for_header v1 and v2 = stmt v2 in
+      G.For (t, v1, v2)
   | Switch ((v0, v1, v2)) -> 
       let v0 = info v0 in
       let v1 = expr v1 and v2 = list case v2 in
       G.Switch (v0, v1, v2)
-  | Continue v1 -> let v1 = option label v1 in 
-     G.Continue (v1 |> option (fun n -> 
+  | Continue (t, v1) -> let v1 = option label v1 in 
+     G.Continue (t, v1 |> option (fun n -> 
        G.Name ((n, G.empty_name_info), G.empty_id_info ())))
-  | Break v1 -> let v1 = option label v1 in
-     G.Break (v1 |> option (fun n -> 
+  | Break (t, v1) -> let v1 = option label v1 in
+     G.Break (t, v1 |> option (fun n -> 
        G.Name ((n, G.empty_name_info), G.empty_id_info ())))
-  | Return v1 -> let v1 = expr v1 in G.Return (Some v1)
+  | Return (t, v1) -> 
+      let v1 = expr v1 in 
+      G.Return (t, Some v1)
   | Label ((v1, v2)) -> let v1 = label v1 and v2 = stmt v2 in
       G.Label (v1, v2)
-  | Throw v1 -> let v1 = expr v1 in G.Throw v1
-  | Try ((v1, v2, v3)) ->
+  | Throw (t, v1) -> let v1 = expr v1 in G.Throw (t, v1)
+  | Try ((t, v1, v2, v3)) ->
       let v1 = stmt v1
       and v2 =
         option (fun (v1, v2) -> 
@@ -226,7 +230,7 @@ and stmt x =
            G.PatVar (v1, G.empty_id_info()), v2
        ) v2
       and v3 = option stmt v3 in
-      G.Try (v1, Common.opt_to_list v2, v3)
+      G.Try (t, v1, Common.opt_to_list v2, v3)
 
 and for_header =
   function
@@ -261,10 +265,10 @@ and for_header =
 
 and case =
   function
-  | Case ((v1, v2)) -> let v1 = expr v1 and v2 = stmt v2 in
-      [G.Case (G.expr_to_pattern v1)], v2
-  | Default v1 -> let v1 = stmt v1 in
-      [G.Default], v1
+  | Case ((t, v1, v2)) -> let v1 = expr v1 and v2 = stmt v2 in
+      [G.Case (t, G.expr_to_pattern v1)], v2
+  | Default (t, v1) -> let v1 = stmt v1 in
+      [G.Default t], v1
 
 and def_of_var { v_name = x_name; v_kind = x_kind; 
                  v_init = x_init; v_resolved = x_resolved } =
@@ -327,7 +331,7 @@ and fun_prop (x, tok) =
   | Generator -> G.attr G.Generator tok 
   | Async -> G.attr G.Async tok
 
-and obj_ v = list property v
+and obj_ v = bracket (list property) v
 
 and class_ { c_extends = c_extends; c_body = c_body } =
   let v1 = option expr c_extends in
@@ -354,9 +358,9 @@ and property x =
       | Right e ->
         G.FieldDynamic (e, v2, v3)
       )
-  | FieldSpread v1 -> 
+  | FieldSpread (t, v1) -> 
       let v1 = expr v1 in 
-      G.FieldSpread v1
+      G.FieldSpread (t, v1)
 
 and property_prop (x, tok) =
   match x with
@@ -375,12 +379,12 @@ let rec toplevel x =
 
 and module_directive x = 
   match x with
-  | Import ((v1, v2, v3)) ->
+  | Import ((t, v1, v2, v3)) ->
       let v1 = name v1 and v2 = name v2 and v3 = filename v3 in 
-      G.ImportFrom (G.FileName v3, [v1, Some v2])
-  | ModuleAlias ((v1, v2)) ->
+      G.ImportFrom (t, G.FileName v3, [v1, Some v2])
+  | ModuleAlias ((t, v1, v2)) ->
       let v1 = name v1 and v2 = filename v2 in
-      G.ImportAs (G.FileName v2, Some v1)
+      G.ImportAs (t, G.FileName v2, Some v1)
   | ImportCss ((v1)) ->
       let v1 = name v1 in
       G.OtherDirective (G.OI_ImportCss, [G.Id v1])

--- a/lang_js/analyze/map_ast_js.ml
+++ b/lang_js/analyze/map_ast_js.ml
@@ -74,6 +74,10 @@ let rec map_tok v =
 
 and map_wrap:'a. ('a -> 'a) -> 'a wrap -> 'a wrap = fun _of_a (v1, v2) ->
   let v1 = _of_a v1 and v2 = map_tok v2 in (v1, v2)
+
+and map_bracket:'a. ('a -> 'a) -> 'a bracket -> 'a bracket = 
+  fun of_a (v1, v2, v3) ->
+  let v1 = map_tok v1 and v2 = of_a v2 and v3 = map_tok v3 in (v1, v2, v3)
   
 and map_name v = map_wrap map_of_string v
   
@@ -152,7 +156,7 @@ and map_expr =
       and v2 = map_property_name v2
       and t = map_tok t 
       in ObjAccess ((v1, t, v2))
-  | Arr v1 -> let v1 = map_of_list map_expr v1 in Arr ((v1))
+  | Arr v1 -> let v1 = map_bracket (map_of_list map_expr) v1 in Arr ((v1))
   | ArrAccess ((v1, v2)) ->
       let v1 = map_expr v1 and v2 = map_expr v2 in ArrAccess ((v1, v2))
   | Fun ((v1, v2)) ->
@@ -173,29 +177,42 @@ and map_stmt =
   | VarDecl v1 -> let v1 = map_var v1 in VarDecl ((v1))
   | Block v1 -> let v1 = map_of_list map_stmt v1 in Block ((v1))
   | ExprStmt v1 -> let v1 = map_expr v1 in ExprStmt ((v1))
-  | If ((v1, v2, v3)) ->
+  | If ((t, v1, v2, v3)) ->
+      let t = map_tok t in
       let v1 = map_expr v1
       and v2 = map_stmt v2
       and v3 = map_stmt v3
-      in If ((v1, v2, v3))
-  | Do ((v1, v2)) ->
-      let v1 = map_stmt v1 and v2 = map_expr v2 in Do ((v1, v2))
-  | While ((v1, v2)) ->
-      let v1 = map_expr v1 and v2 = map_stmt v2 in While ((v1, v2))
-  | For ((v1, v2)) ->
-      let v1 = map_for_header v1 and v2 = map_stmt v2 in For ((v1, v2))
+      in If ((t, v1, v2, v3))
+  | Do ((t, v1, v2)) ->
+      let t = map_tok t in
+      let v1 = map_stmt v1 and v2 = map_expr v2 in Do ((t, v1, v2))
+  | While ((t, v1, v2)) ->
+      let t = map_tok t in
+      let v1 = map_expr v1 and v2 = map_stmt v2 in While ((t, v1, v2))
+  | For ((t, v1, v2)) ->
+      let t = map_tok t in
+      let v1 = map_for_header v1 and v2 = map_stmt v2 in For ((t, v1, v2))
   | Switch ((v0, v1, v2)) ->
       let v0 = map_tok v0 in
       let v1 = map_expr v1
       and v2 = map_of_list map_case v2
       in Switch ((v0, v1, v2))
-  | Continue v1 -> let v1 = map_of_option map_label v1 in Continue ((v1))
-  | Break v1 -> let v1 = map_of_option map_label v1 in Break ((v1))
-  | Return v1 -> let v1 = map_expr v1 in Return ((v1))
+  | Continue (t, v1) -> 
+      let t = map_tok t in
+      let v1 = map_of_option map_label v1 in Continue ((t, v1))
+  | Break (t, v1) -> 
+      let t = map_tok t in
+      let v1 = map_of_option map_label v1 in Break ((t, v1))
+  | Return (t, v1) -> 
+      let t = map_tok t in
+      let v1 = map_expr v1 in Return ((t, v1))
   | Label ((v1, v2)) ->
       let v1 = map_label v1 and v2 = map_stmt v2 in Label ((v1, v2))
-  | Throw v1 -> let v1 = map_expr v1 in Throw ((v1))
-  | Try ((v1, v2, v3)) ->
+  | Throw (t, v1) -> 
+      let t = map_tok t in
+      let v1 = map_expr v1 in Throw ((t, v1))
+  | Try ((t, v1, v2, v3)) ->
+      let t = map_tok t in
       let v1 = map_stmt v1
       and v2 =
         map_of_option
@@ -203,7 +220,8 @@ and map_stmt =
              let v1 = map_name v1 and v2 = map_stmt v2 in (v1, v2))
           v2
       and v3 = map_of_option map_stmt v3
-      in Try ((v1, v2, v3))
+      in Try ((t, v1, v2, v3))
+
 and map_for_header =
   function
   | ForClassic ((v1, v2, v3)) ->
@@ -217,9 +235,12 @@ and map_for_header =
       in ForIn ((v1, v2))
 and map_case =
   function
-  | Case ((v1, v2)) ->
-      let v1 = map_expr v1 and v2 = map_stmt v2 in Case ((v1, v2))
-  | Default v1 -> let v1 = map_stmt v1 in Default ((v1))
+  | Case ((t, v1, v2)) ->
+      let t = map_tok t in
+      let v1 = map_expr v1 and v2 = map_stmt v2 in Case ((t, v1, v2))
+  | Default (t, v1) -> 
+      let t = map_tok t in
+      let v1 = map_stmt v1 in Default ((t, v1))
 and
   map_var {
             v_name = v_v_name;
@@ -258,7 +279,7 @@ and map_fun_prop =
   | Set -> Set
   | Generator -> Generator
   | Async -> Async
-and map_obj_ v = map_of_list map_property v
+and map_obj_ v = map_bracket (map_of_list map_property) v
 and map_class_ { c_extends = v_c_extends; c_body = v_c_body } =
   let v_c_body = map_of_list map_property v_c_body in
   let v_c_extends = map_of_option map_expr v_c_extends in 
@@ -270,7 +291,8 @@ and map_property =
       and v2 = map_of_list (map_wrap map_property_prop) v2
       and v3 = map_expr v3
       in Field ((v1, v2, v3))
-  | FieldSpread v1 -> let v1 = map_expr v1 in FieldSpread ((v1))
+  | FieldSpread (t, v1) -> 
+      let t = map_tok t in let v1 = map_expr v1 in FieldSpread ((t, v1))
 and map_property_prop =
   function
   | Static -> Static
@@ -286,21 +308,23 @@ and map_toplevel =
 
 and map_module_directive =
   function 
-  | Import ((v1, v2, v3)) ->
+  | Import ((t, v1, v2, v3)) ->
+      let t = map_tok t in
       let v1 = map_name v1
       and v2 = map_name v2
       and v3 = map_filename v3
-      in Import ((v1, v2, v3))
+      in Import ((t, v1, v2, v3))
   | ImportCss ((v1)) ->
       let v1 = map_name v1
       in ImportCss ((v1))
   | ImportEffect ((v1)) ->
       let v1 = map_name v1
       in ImportEffect ((v1))
-  | ModuleAlias ((v1, v2)) ->
+  | ModuleAlias ((t, v1, v2)) ->
+      let t = map_tok t in
       let v1 = map_name v1
       and v2 = map_filename v2
-      in ModuleAlias ((v1, v2))
+      in ModuleAlias ((t, v1, v2))
   | Export v1 -> let v1 = map_name v1 in Export ((v1))
   
 and map_program v = map_of_list map_toplevel v

--- a/lang_ml/analyze/ast_ml.ml
+++ b/lang_ml/analyze/ast_ml.ml
@@ -36,6 +36,10 @@ type tok = Parse_info.t
 type 'a wrap = 'a * tok
  (* with tarzan *)
 
+(* round(), square[], curly{}, angle<> brackets *)
+type 'a bracket = tok * 'a * tok
+ (* with tarzan *)
+
 (* ------------------------------------------------------------------------- *)
 (* Names  *)
 (* ------------------------------------------------------------------------- *)
@@ -74,7 +78,7 @@ type expr =
   | Constructor of name * expr option
   (* special case of Constr *)
   | Tuple of expr list
-  | List  of expr list
+  | List  of expr list bracket
 
   (* can be empty *) 
   | Sequence of expr list
@@ -92,7 +96,7 @@ type expr =
   | FieldAccess of expr * tok * name
   | FieldAssign of expr * tok * name * tok (* <- *) * expr
 
-  | Record of expr option (* with *) * (name * expr) list
+  | Record of expr option (* with *) * (name * expr) list bracket
 
   | New of tok * name
   | ObjAccess of expr * tok (* # *) * ident
@@ -105,13 +109,13 @@ type expr =
   (* statement-like expressions *)
   | Nop (* for empty else *)
 
-  | If of expr * expr * expr
+  | If of tok * expr * expr * expr
   | Match of expr * match_case list
 
-  | Try of expr * match_case list 
+  | Try of tok * expr * match_case list 
 
-  | While of expr * expr
-  | For of ident * expr * for_direction * expr *   expr
+  | While of tok * expr * expr
+  | For of tok * ident * expr * for_direction * expr *   expr
 
  and literal =
    | Int    of string wrap

--- a/lang_python/analyze/highlight_python.ml
+++ b/lang_python/analyze/highlight_python.ml
@@ -201,7 +201,7 @@ let visit_program ~tag_hook _prefs (program, toks) =
        tag_name name (Entity (kind, def2));
        Common.save_excursion in_class true (fun () -> 
           k x);
-     | ImportAs ((dotted_name, _dotsTODO), asname_opt) ->
+     | ImportAs (_, (dotted_name, _dotsTODO), asname_opt) ->
            let kind = E.Module in
            dotted_name |> List.iter (fun name ->
              tag_name name (Entity (kind, use2));
@@ -211,7 +211,7 @@ let visit_program ~tag_hook _prefs (program, toks) =
            );
          k x
 
-     | ImportFrom ((dotted_name, _dotsTODO), aliases) ->
+     | ImportFrom (_, (dotted_name, _dotsTODO), aliases) ->
          let kind = E.Module in
          dotted_name |> List.iter (fun name ->
            tag_name name (Entity (kind, use2));
@@ -225,7 +225,7 @@ let visit_program ~tag_hook _prefs (program, toks) =
          );
          k x
 
-     | With (_e, eopt, _stmts) ->
+     | With (_, _e, eopt, _stmts) ->
        eopt |> Common.do_option (fun e ->
           match e with
          | Name (name, _ctx, _res) ->
@@ -234,7 +234,7 @@ let visit_program ~tag_hook _prefs (program, toks) =
          | _ -> ()
        );
        k x
-     | TryExcept (_stmts1, excepts, _stmts2) ->
+     | TryExcept (_, _stmts1, excepts, _stmts2) ->
        excepts |> List.iter (fun (ExceptHandler (_typ, e, _)) ->
          match e with
          | None -> ()

--- a/lang_python/analyze/resolve_python.ml
+++ b/lang_python/analyze/resolve_python.ml
@@ -181,13 +181,13 @@ let resolve prog =
                k x              
             )
     
-     | ImportAs ((dotted_name, _dotsTODO), asname_opt) ->
+     | ImportAs (_, (dotted_name, _dotsTODO), asname_opt) ->
            asname_opt |> Common.do_option (fun asname ->
              env |> add_name_env asname (ImportedModule dotted_name)
            );
          k x
 
-     | ImportFrom ((dotted_name, _dotsTODO), aliases) ->
+     | ImportFrom (_, (dotted_name, _dotsTODO), aliases) ->
          aliases |> List.iter (fun (name, asname_opt) ->
            let entity = dotted_name @ [name] in
            (match asname_opt with
@@ -198,7 +198,7 @@ let resolve prog =
            );
          );
          k x
-     | With (e, eopt, stmts) ->
+     | With (_, e, eopt, stmts) ->
        v (Expr e);
        (match eopt with
        | None -> v (Stmts stmts)
@@ -218,7 +218,7 @@ let resolve prog =
            v (Expr e);
            v (Stmts stmts)
        )
-     | TryExcept (stmts1, excepts, stmts2) ->
+     | TryExcept (_, stmts1, excepts, stmts2) ->
        v (Stmts stmts1);
        excepts |> List.iter (fun (ExceptHandler (_typ, e, body)) ->
          match e with
@@ -235,7 +235,7 @@ let resolve prog =
        );
        v (Stmts stmts2);
 
-     | Global names ->
+     | Global (_, names) ->
        names |> List.iter (fun name -> env |> add_name_env name GlobalVar;)
     
      (* TODO: NonLocal!! *) 


### PR DESCRIPTION
…neric

Description: sgrep sometimes fails with an OCaml exception about an empty
list of tokens (either FakeTok error or min_max_ii error) because
a metavariable may match something (an expr or stmt) that does not contain
any token information. This in turns mean we can not display location
information for this matched thing.
This diff should help fix
https://github.com/returntocorp/sgrep/issues/73
and
https://github.com/returntocorp/sgrep/issues/52

because it adds lots of token information in the different ASTs.
I originally skipped those tokens because I wanted an AST, not a CST,
but in the ends it bites back and we want many of those tokens
(at least enough token so we never get the error above).

See ast_generic.ml for the rational.

test plan:
make test