### PR TITLE
* lang_go/parsing/parser_go.mly: we now use the parsing_hacks fix_tok…

### DIFF
--- a/lang_go/parsing/parser_go.mly
+++ b/lang_go/parsing/parser_go.mly
@@ -258,7 +258,7 @@ package: LPACKAGE sym LSEMICOLON { $1, $2 }
 
 sgrep_spatch_pattern: 
  | expr EOF       { E $1 }
- | stmt LSEMICOLON EOF       { S $1 }
+ | stmt EOF       { S $1 }
  | stmt LSEMICOLON stmt LSEMICOLON stmt_list EOF { Ss ($1::$3::List.rev $5) }
 
 /*(*************************************************************************)*/

--- a/tests/go/parsing/semicolon.go
+++ b/tests/go/parsing/semicolon.go
@@ -1,0 +1,3 @@
+package foo
+
+func foo() { if true { foo() } }


### PR DESCRIPTION
…ens in sgrep mode, and in this mode we do not anymore add a fake SEMICOLON before an EOF (to prevent to transform Expr pattern in Statement pattern).

No need to anticipiate an LSEMICOLON insertion (there will be no such
intertion)

This should fix
https://github.com/returntocorp/sgrep/issues/120

test plan:
in sgrep
/home/pad/github/sgrep/_build/default/bin/main_sgrep.exe -lang go -e if $X { ... } tests/go/
/home/pad/github/sgrep/tests/go/equivalence_eq.go:7
     if (a+b == a+b) {
         return 1