### PR TITLE
* lang_python/analyze/python_to_generic.ml: This should fix issue https://github.com/returntocorp/sgrep/issues/153

### DIFF
--- a/lang_python/parsing/ast_python.ml
+++ b/lang_python/parsing/ast_python.ml
@@ -90,7 +90,7 @@ type dotted_name = name list
 type module_name = 
  dotted_name * 
  (* https://realpython.com/absolute-vs-relative-python-imports/ *)
- int option (* levels, for relative imports *)
+ (tok (* . or ... toks *) list) option (* levels, for relative imports *)
 
 (* TODO: reuse ast_generic one? *)
 type resolved_name =

--- a/lang_python/parsing/meta_ast_python.ml
+++ b/lang_python/parsing/meta_ast_python.ml
@@ -16,7 +16,7 @@ let vof_dotted_name v = Ocaml.vof_list vof_name v
 
 let vof_module_name (v1, v2) = 
   let v1 = vof_dotted_name v1
-  and v2 = Ocaml.vof_option Ocaml.vof_int v2 in
+  and v2 = Ocaml.vof_option (Ocaml.vof_list vof_tok) v2 in
   Ocaml.VTuple [v1; v2]
 
 let vof_resolved_name =

--- a/lang_python/parsing/parser_python.mly
+++ b/lang_python/parsing/parser_python.mly
@@ -245,13 +245,13 @@ import_from:
 name_and_level:
   |           dotted_name { $1, None }
   | dot_level dotted_name { $2, Some $1 }
-  | DOT dot_level         { [("",$1(*TODO*))], Some (1 + $2) }
-  | ELLIPSES dot_level         { [("",$1(*TODO*))], Some (3 + $2) }
+  | DOT dot_level         { [("",$1(*TODO*))], Some ($1 :: $2) }
+  | ELLIPSES dot_level         { [("",$1(*TODO*))], Some ($1:: $2) }
 
 dot_level:
-  | /*(*empty *)*/ { 0 }
-  | DOT dot_level  { 1 + $2 }
-  | ELLIPSES dot_level { 3 + $2 }
+  | /*(*empty *)*/ { [] }
+  | DOT dot_level  { $1::$2 }
+  | ELLIPSES dot_level { $1::$2 }
 
 import_as_name:
   | NAME         { $1, None }

--- a/lang_python/parsing/visitor_python.ml
+++ b/lang_python/parsing/visitor_python.ml
@@ -75,7 +75,7 @@ and v_dotted_name v = v_list v_name v
 
 and v_module_name (v1, v2) = 
   let v1 = v_dotted_name v1 in
-  let v2 = v_option v_int v2 in
+  let v2 = v_option (v_list v_tok) v2 in
   ()
 
 and v_resolved_name =


### PR DESCRIPTION
Test plan:

$ cat misc_import.py
if __name__ == '__main__':
    from forget_mult import ForgetMult
else:
    from .forget_mult import ForgetMult
$ ~/pfff/pfff_test -dump_generic misc_import.py
Pr(
  [If((),
     Call(IdSpecial((ArithOp(Eq), ())),
       [Arg(
          Name(
            (("__name__", ()), {name_qualifier=None; name_typeargs=None; }),
            {id_resolved=Ref(None); id_type=Ref(None); }));
        Arg(L(String(("__main__", ()))))]),
     DirectiveStmt(
       ImportFrom((), DottedName([("forget_mult", ())]),
         [(("ForgetMult", ()), None)])),
     DirectiveStmt(
       ImportFrom((), FileName(("./forget_mult", ())),
         [(("ForgetMult", ()), None)])))])

We now have DottedName vs FileName (before this diff they were
both DottedName and equal.