### PR TITLE
* h_program-lang/ast_generic.ml: add support for EncodedString as in Python and fix Python lexer to record this information.

### DIFF
--- a/h_program-lang/ast_generic.ml
+++ b/h_program-lang/ast_generic.ml
@@ -302,6 +302,7 @@ and expr =
    | New  (* usually associated with Call(New, [ArgType _;...]) *)
 
    | Concat (* used for interpolated strings constructs *)
+   | EncodedString of string wrap (* only for Python for now (e.g., b"foo") *)
    | Spread (* inline list var, in Container or call context *)
 
    (* used for unary and binary operations *)

--- a/lang_GENERIC/parsing/map_ast.ml
+++ b/lang_GENERIC/parsing/map_ast.ml
@@ -260,6 +260,7 @@ and map_special =
   | Concat -> Concat
   | Spread -> Spread
   | ArithOp v1 -> let v1 = map_arithmetic_operator v1 in ArithOp ((v1))
+  | EncodedString v1 -> let v1 = map_wrap map_of_string v1 in EncodedString ((v1))
   | IncrDecr ((v1, v2)) ->
       let v1 = map_of_incdec v1 and v2 = map_of_prepost v2 in IncrDecr ((v1, v2))
 

--- a/lang_GENERIC/parsing/meta_ast.ml
+++ b/lang_GENERIC/parsing/meta_ast.ml
@@ -251,6 +251,9 @@ and vof_special =
   | New -> Ocaml.VSum (("New", []))
   | Concat -> Ocaml.VSum (("Concat", []))
   | Spread -> Ocaml.VSum (("Spread", []))
+  | EncodedString v1 ->
+      let v1 = vof_wrap Ocaml.vof_string v1 in
+      Ocaml.VSum (("EncodedString", [v1]))
   | ArithOp v1 ->
       let v1 = vof_arithmetic_operator v1 in Ocaml.VSum (("ArithOp", [ v1 ]))
   | IncrDecr (v) ->

--- a/lang_GENERIC/parsing/visitor_ast.ml
+++ b/lang_GENERIC/parsing/visitor_ast.ml
@@ -245,6 +245,7 @@ and v_special =
   | New -> ()
   | Concat -> ()
   | Spread -> ()
+  | EncodedString v1 -> let v1 = v_wrap v_string v1 in ()
   | ArithOp v1 -> let v1 = v_arithmetic_operator v1 in ()
   | IncrDecr ((v1, v2)) -> let v1 = v_incr_decr v1 and v2 = v_prepost v2 in ()
 and v_incr_decr _ = ()

--- a/lang_python/analyze/highlight_python.ml
+++ b/lang_python/analyze/highlight_python.ml
@@ -411,7 +411,7 @@ let visit_program ~tag_hook _prefs (program, toks) =
 
 
     (* values  *)
-    | T.STR (_s,ii) ->
+    | T.STR (_s,_pre, ii) ->
         tag ii String
     | T.FLOAT (_,ii) | T.INT (_,ii) | T.LONGINT (_,ii) ->
         tag ii Number

--- a/lang_python/analyze/python_to_generic.ml
+++ b/lang_python/analyze/python_to_generic.ml
@@ -114,6 +114,12 @@ let rec expr (x: expr) =
   | Str (v1) -> 
       let v1 = wrap string v1 in
       G.L (G.String (v1))
+  | EncodedStr (v1, pre) ->
+      let v1 = wrap string v1 in
+      (* reuse same tok *)
+      let tok = snd v1 in
+      G.Call (G.IdSpecial (G.EncodedString (pre, tok), tok),
+        [G.Arg (G.L (G.String (v1)))])
 
   | InterpolatedString xs ->
     G.Call (G.IdSpecial (G.Concat, fake "concat"), 

--- a/lang_python/parsing/ast_python.ml
+++ b/lang_python/parsing/ast_python.ml
@@ -113,6 +113,7 @@ type resolved_name =
 type expr =
   | Num of number (* n *)
   | Str of string wrap (* s *)
+  | EncodedStr of string wrap * string (* prefix *)
   (* python3: now officially reserved keywords *)
   | Bool of bool wrap
   | None_ of tok

--- a/lang_python/parsing/lexer_python.mll
+++ b/lang_python/parsing/lexer_python.mll
@@ -430,14 +430,14 @@ and _token state = parse
        FSTRING_START (tokinfo lexbuf)  
      }
 
-  | stringprefix '\''
-      { sq_shortstrlit state (tokinfo lexbuf) lexbuf }
-  | stringprefix '"'
-      { dq_shortstrlit state (tokinfo lexbuf) lexbuf }
-  | stringprefix "'''"
-      { sq_longstrlit state (tokinfo lexbuf) lexbuf }
-  | stringprefix "\"\"\""
-      { dq_longstrlit state (tokinfo lexbuf) lexbuf }
+  | stringprefix as pre '\''
+      { sq_shortstrlit state (tokinfo lexbuf) pre lexbuf }
+  | stringprefix as pre '"'
+      { dq_shortstrlit state (tokinfo lexbuf) pre lexbuf }
+  | stringprefix as pre "'''"
+      { sq_longstrlit state (tokinfo lexbuf) pre lexbuf }
+  | stringprefix as pre "\"\"\""
+      { dq_longstrlit state (tokinfo lexbuf) pre lexbuf }
 
   (* ----------------------------------------------------------------------- *)
   (* eof *)
@@ -452,35 +452,35 @@ and _token state = parse
 (* Rules on strings *)
 (*****************************************************************************)
 
-and sq_shortstrlit state pos = parse
+and sq_shortstrlit state pos pre = parse
   | (([^ '\\' '\r' '\n' '\''] | escapeseq)* as s) '\'' 
      { 
        let full_str = Lexing.lexeme lexbuf in
-       STR (unescaped s, PI.tok_add_s full_str pos) }
+       STR (unescaped s, pre, PI.tok_add_s full_str pos) }
  | eof { error "EOF in string" lexbuf; EOF (tokinfo lexbuf) }
  | _  { error "unrecognized symbol in string" lexbuf; TUnknown(tokinfo lexbuf)}
 
 (* because here we're using 'shortest', do not put a rule for '| _ { ... }' *)
-and sq_longstrlit state pos = shortest
+and sq_longstrlit state pos pre = shortest
 | (([^ '\\'] | escapeseq)* as s) "'''"
     { 
       let full_str = Lexing.lexeme lexbuf in
-      STR (unescaped s, PI.tok_add_s full_str pos) 
+      STR (unescaped s, pre, PI.tok_add_s full_str pos) 
     }
 
-and dq_shortstrlit state pos = parse
+and dq_shortstrlit state pos pre = parse
   | (([^ '\\' '\r' '\n' '\"'] | escapeseq)* as s) '"' 
      { 
        let full_str = Lexing.lexeme lexbuf in
-       STR (unescaped s, PI.tok_add_s full_str pos) }
+       STR (unescaped s, pre, PI.tok_add_s full_str pos) }
  | eof { error "EOF in string" lexbuf; EOF (tokinfo lexbuf) }
  | _  { error "unrecognized symbol in string" lexbuf; TUnknown(tokinfo lexbuf)}
 
-and dq_longstrlit state pos = shortest
+and dq_longstrlit state pos pre = shortest
   | (([^ '\\'] | escapeseq)* as s) "\"\"\""
       { 
         let full_str = Lexing.lexeme lexbuf in
-        STR (unescaped s, PI.tok_add_s full_str pos) }
+        STR (unescaped s, pre, PI.tok_add_s full_str pos) }
 
 (*****************************************************************************)
 (* Rules on interpolated strings *)

--- a/lang_python/parsing/meta_ast_python.ml
+++ b/lang_python/parsing/meta_ast_python.ml
@@ -37,6 +37,10 @@ let rec vof_expr =
   | Str v1 ->
       let v1 = (vof_wrap Ocaml.vof_string) v1
       in Ocaml.VSum (("Str", [ v1 ]))
+  | EncodedStr ((v1, v2)) ->
+      let v1 = (vof_wrap Ocaml.vof_string) v1
+      and v2 = Ocaml.vof_string v2
+      in Ocaml.VSum (("EncodedStr", [ v1; v2 ]))
   | InterpolatedString v1 ->
       let v1 = Ocaml.vof_list vof_expr v1 in
       Ocaml.VSum (("InterpolatedString", [v1]))

--- a/lang_python/parsing/parser_python.mly
+++ b/lang_python/parsing/parser_python.mly
@@ -108,7 +108,7 @@ let mk_str ii =
 %token <string    * Ast_python.tok> INT LONGINT
 %token <string  * Ast_python.tok> FLOAT
 %token <string * Ast_python.tok> IMAG
-%token <string * Ast_python.tok> STR
+%token <string * string * Ast_python.tok> STR
 
 /*(*-----------------------------------------*)*/
 /*(*2 Keyword tokens *)*/
@@ -681,7 +681,8 @@ atom_repr: BACKQUOTE testlist1 BACKQUOTE { Repr ($1, tuple_expr $2, $3) }
 /*(*----------------------------*)*/
 
 string:
-  | STR { Str $1 }
+  | STR { let (s, pre, tok) = $1 in 
+          if pre = "" then Str (s, tok) else EncodedStr ((s, tok), pre) }
   | FSTRING_START interpolated_list FSTRING_END { InterpolatedString $2 }
 
 interpolated:

--- a/lang_python/parsing/token_helpers_python.ml
+++ b/lang_python/parsing/token_helpers_python.ml
@@ -49,7 +49,7 @@ let visitor_info_of_tok f = function
   | LONGINT (x, ii) -> LONGINT (x, f ii)
   | FLOAT (x, ii) -> FLOAT (x, f ii)
   | IMAG (x, ii) -> IMAG (x, f ii)
-  | STR (x, ii) -> STR (x, f ii)
+  | STR (x, pre, ii) -> STR (x, pre, f ii)
 
   | NONE (ii) -> NONE (f ii)
   | TRUE (ii) -> TRUE (f ii)

--- a/lang_python/parsing/visitor_python.ml
+++ b/lang_python/parsing/visitor_python.ml
@@ -96,6 +96,7 @@ and v_expr (x: expr) =
   | Bool v1 -> let v1 = v_wrap v_bool v1 in ()
   | Num v1 -> let v1 = v_number v1 in ()
   | Str (v1) -> let v1 = v_wrap v_string v1 in ()
+  | EncodedStr (v1, v2) -> let v1 = v_wrap v_string v1 in let v2 = v_string v2 in ()
   | InterpolatedString v1 -> let v1 = v_list v_expr v1 in ()
   | Name ((v1, v2, v3)) ->
       let v1 = v_name v1

--- a/tests/python/parsing/string_prefix.py
+++ b/tests/python/parsing/string_prefix.py
@@ -1,0 +1,1 @@
+foo = b"a str"


### PR DESCRIPTION
This should help fix https://github.com/returntocorp/sgrep/issues/157
Test plan:
$ cat string_prefix.py
foo = b"a str"
$ ~/pfff/pfff -dump_python string_prefix.py
[Assign([Name(("foo", ()), Store, Ref(NotResolved))], (),
   EncodedStr(("a str", ()), "b"))]