### PR TITLE
Remove extra Block around vars, especially for sgrep patterns.

### DIFF
--- a/lang_python/analyze/python_to_generic.ml
+++ b/lang_python/analyze/python_to_generic.ml
@@ -615,6 +615,9 @@ let any =
   function
   | Expr v1 -> let v1 = expr v1 in G.E v1
   | Stmt v1 -> let v1 = stmt v1 in G.S v1
+  (* TODO? should use list stmt_aux here? Some intermediate Block
+   * could be inserted preventing some sgrep matching?
+   *)
   | Stmts v1 -> let v1 = list stmt v1 in G.Ss v1
   | Program v1 -> let v1 = program v1 in G.Pr v1
   | DictElem v1 -> let v1 = dictorset_elt v1 in G.E v1


### PR DESCRIPTION
This is related to https://github.com/returntocorp/sgrep/pull/193/files

Test plan:

BEFORE

+ /home/pad/github/sgrep/_build/default/bin/main_sgrep.exe -lang go -dump_pattern dots_stmts2.sgrep
Ss(
  [Block(
     [DefStmt(
        ({name=("$SOME", ()); attrs=[KeywordAttr((Var, ()))]; tparams=[
          ]; info={id_resolved=Ref(None); id_type=Ref(None); }; },
         VarDef({vinit=Some(L(String(("...", ())))); vtype=None; })))]);
   ExprStmt(Ellipsis(()));
   Block(
     [DefStmt(
        ({name=("$OTHER", ()); attrs=[KeywordAttr((Var, ()))]; tparams=[
          ]; info={id_resolved=Ref(None); id_type=Ref(None); }; },
         VarDef(
           {
            vinit=Some(Name(
                         (("$Z", ()),
                          {name_qualifier=None; name_typeargs=None; }),
                         {id_resolved=Ref(None); id_type=Ref(None); }));
            vtype=None; })))])])
bugfix/go-stmts/home/pad/github/sgrep/tests/go $

AFTER

+ /home/pad/github/sgrep/_build/default/bin/main_sgrep.exe -lang go -dump_pattern dots_stmts2.sgrep
Ss(
  [DefStmt(
     ({name=("$SOME", ()); attrs=[KeywordAttr((Var, ()))]; tparams=[];
       info={id_resolved=Ref(None); id_type=Ref(None); }; },
      VarDef({vinit=Some(L(String(("...", ())))); vtype=None; })));
   ExprStmt(Ellipsis(()));
   DefStmt(
     ({name=("$OTHER", ()); attrs=[KeywordAttr((Var, ()))]; tparams=[
       ]; info={id_resolved=Ref(None); id_type=Ref(None); }; },
      VarDef(
        {
         vinit=Some(Name(
                      (("$Z", ()),
                       {name_qualifier=None; name_typeargs=None; }),
                      {id_resolved=Ref(None); id_type=Ref(None); }));
         vtype=None; })))])
bugfix/go-stmts/home/pad/github/sgrep/tests/go $