### PR TITLE
Java Class Ellipsis in body

### DIFF
--- a/lang_java/analyze/graph_code_java.ml
+++ b/lang_java/analyze/graph_code_java.ml
@@ -400,6 +400,7 @@ and decl env = function
   | Method def, _ -> method_decl env def
   | Field def, _ -> field_decl env def
   | Enum def, _ -> enum_decl env def
+  | DeclEllipsis _, _-> ()
   | Init (_is_static, st), n ->
       let name = spf "__init__%d" n in
       let full_ident = env.current_qualifier @ [name, fakeInfo name] in

--- a/lang_java/analyze/highlight_java.ml
+++ b/lang_java/analyze/highlight_java.ml
@@ -87,6 +87,7 @@ let visit_toplevel ~tag_hook _prefs (ast, toks) =
           tag_ident ident (Entity (Class, (Def2 fake_no_def2)))
       | Ast.Init (_bool, _stmt) ->
           ()
+      | Ast.DeclEllipsis _ -> ()
       );
       k d
     );

--- a/lang_java/analyze/java_to_generic.ml
+++ b/lang_java/analyze/java_to_generic.ml
@@ -510,7 +510,7 @@ and decl decl =
       G.DefStmt (ent, G.TypeDef def)
   | Init ((v1, v2)) -> let _v1TODO = bool v1 and v2 = stmt v2 in
       v2
-
+  | DeclEllipsis v1 ->  G.ExprStmt (G.Ellipsis v1)
 and decls v = list decl v
 
 and import = function

--- a/lang_java/parsing/ast_java.ml
+++ b/lang_java/parsing/ast_java.ml
@@ -365,7 +365,6 @@ and class_decl = {
   cl_body: decls bracket;
 }
   and class_kind = ClassRegular | Interface
-
 (*****************************************************************************)
 (* Declaration *)
 (*****************************************************************************)
@@ -378,6 +377,8 @@ and decl =
   | Method of method_decl
   | Field of field
   | Init of bool (* static *) * stmt
+  (* sgrep-ext: allows ... inside interface, class declerations *)
+  | DeclEllipsis of tok
 
 and decls = decl list
 

--- a/lang_java/parsing/meta_ast_java.ml
+++ b/lang_java/parsing/meta_ast_java.ml
@@ -470,6 +470,7 @@ and vof_decl =
       let v1 = Ocaml.vof_bool v1
       and v2 = vof_stmt v2
       in Ocaml.VSum (("Init", [ v1; v2 ]))
+  | DeclEllipsis v1 -> let v1 = vof_tok v1 in Ocaml.VSum (("DeclEllipsis", [ v1 ]))
 and vof_decls v = (Ocaml.vof_list vof_decl) v
 
 and vof_import = function

--- a/lang_java/parsing/parse_java.ml
+++ b/lang_java/parsing/parse_java.ml
@@ -97,7 +97,6 @@ let parse2 filename =
       (Some xs, toks), stat
 
   | Right (_info_of_bads, line_error, cur) ->
-
       if not !Flag.error_recovery
       then raise (PI.Parsing_error (TH.info_of_tok cur));
 

--- a/lang_java/parsing/parser_java.mly
+++ b/lang_java/parsing/parser_java.mly
@@ -276,7 +276,11 @@ compilation_unit:
   |                                         type_declarations_opt
     { { package = None; imports = []; decls = $1; } }
 
-
+declaration:
+ | class_declaration     { Class $1 }
+ | interface_declaration  { Class $1 }
+ | enum_declaration       { Enum $1 }
+ | method_declaration  { Method $1 }
 
 sgrep_spatch_pattern:
  | expression         EOF { AExpr $1 }
@@ -285,8 +289,7 @@ sgrep_spatch_pattern:
 
 item_no_dots:
  | statement_no_dots { Init (false, $1) }
- /*(* TODO: add class_member_declaration, and its method_declaration here,
-    * but many conflicts *)*/
+ | declaration { $1 }
 
 /*(* coupling: copy paste of statement, without dots *)*/
 statement_no_dots:
@@ -1055,8 +1058,7 @@ class_body_declaration:
  | static_initializer  { [$1] }
  /* (* javaext: 1.? *)*/
  | instance_initializer  { [$1] }
-
-
+ 
 class_member_declaration:
  | field_declaration  { $1 }
  | method_declaration  { [Method $1] }
@@ -1072,6 +1074,9 @@ class_member_declaration:
  | annotation_type_declaration { ast_todo }
 
  | SM  { [] }
+ /* (* sgrep-ext: allows ... inside class body *) */
+ | DOTS { [DeclEllipsis $1] }
+
 
 static_initializer: STATIC block  { Init (true, $2) }
 

--- a/lang_java/parsing/visitor_java.ml
+++ b/lang_java/parsing/visitor_java.ml
@@ -385,6 +385,7 @@ and v_decl x =
   | Field v1 -> let v1 = v_field v1 in ()
   | Enum v1 -> let v1 = v_enum_decl v1 in ()
   | Init ((v1, v2)) -> let v1 = v_bool v1 and v2 = v_stmt v2 in ()
+  | DeclEllipsis v1 -> let v1 = v_tok v1 in ()
   in
   vin.kdecl (k, all_functions) x
 


### PR DESCRIPTION
As titled. Adds Ellipsis as a decl, so that it could 
used inside class, enum, interface body.
# Testing
1. make test
2. Cross compile to sgrep and run `dune runtest` there. See https://github.com/returntocorp/sgrep/pull/259

# Pattern parsing from SGREP:
```
ulziibayarotgonbaatar@ulziibayars-MacBook-Pro sgrep % ./_build/default/bin/main_sgrep.exe -dump_pattern tests/java/less_inheritance.sgrep -lang java                       
S(
  DefStmt(
    ({name=("A", ()); attrs=[]; tparams=[]; 
      info={id_resolved=Ref(None); id_type=Ref(None); 
            id_const_literal=Ref(None); };
      },
     ClassDef(
       {ckind=Class; cextends=[]; cimplements=[]; cmixins=[]; 
        cbody=[FieldStmt(ExprStmt(Ellipsis(())))]; }))))
```