### PR TITLE
JS import parsing for sgrep

### DIFF
--- a/lang_js/analyze/ast_js.ml
+++ b/lang_js/analyze/ast_js.ml
@@ -220,6 +220,8 @@ and stmt =
    * ES6 modules can appear only at the toplevel
   *  but CommonJS require() can be inside ifs
   *)
+  | ImportDecl of tok * name * name (* 'name1 as name2', often name1=name2 *) * 
+      filename
 
   (* less: could use some Special instead? *)
   and for_header = 

--- a/lang_js/analyze/ast_js_build.ml
+++ b/lang_js/analyze/ast_js_build.ml
@@ -295,7 +295,16 @@ and item default_opt env = function
     raise (UnhandledConstruct ("Typescript", x.C.i_tok))
   | C.ItemTodo tok ->
     raise (TodoConstruct ("ItemTodo", tok))
-
+  | C.ImportDecl (_, x, _) ->
+    match x with
+    | C.ImportFrom ((default_opt, _), (tok, path)) ->
+      let file = path_to_file path in
+      (match default_opt with
+      | Some n -> 
+        [A.ImportDecl (tok, (A.default_entity, snd n),  name env n, file)]
+      | None -> []
+      )
+    | C.ImportEffect ((_, _)) -> []
 (* ------------------------------------------------------------------------- *)
 (* Names *)
 (* ------------------------------------------------------------------------- *)

--- a/lang_js/analyze/graph_code_js.ml
+++ b/lang_js/analyze/graph_code_js.ml
@@ -429,7 +429,24 @@ and stmt env = function
      stmt env st
    );
    finalopt |> Common.opt (fun (_t, st) -> stmt env st);
-
+ | ImportDecl (_, name1, name2, (file, tok)) ->
+    if env.phase = Uses then begin
+      let str1 = s_of_n name1 in
+      let str2 = s_of_n name2 in
+      let path_opt = Module_path_js.resolve_path
+        ~root:env.root
+        ~pwd:(Filename.dirname env.file_readable)
+        file in
+      let readable = 
+        match path_opt with
+        | None -> 
+          env.pr2_and_log (spf "could not resolve path %s at %s" file
+                              (Parse_info.string_of_info tok));
+          spf "NOTFOUND-|%s|.js" file
+        | Some fullpath -> Common.readable env.root fullpath
+      in
+      Hashtbl.replace env.imports str2 (mk_qualified_name readable str1)
+    end
 and for_header env = function
  | ForClassic (e1, e2, e3) ->
    let env =

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -226,6 +226,9 @@ and stmt x =
        ) v2
       and v3 = option tok_and_stmt v3 in
       G.Try (t, v1, Common.opt_to_list v2, v3)
+  | ImportDecl ((t, v1, v2, v3)) ->
+      let v1 = name v1 and v2 = name v2 and v3 = filename v3 in 
+      G.DirectiveStmt (G.ImportFrom (t, G.FileName v3, (Some (v1, Some v2))))
 
 and tok_and_stmt (t, v) = 
   let v = stmt v in

--- a/lang_js/analyze/map_ast_js.ml
+++ b/lang_js/analyze/map_ast_js.ml
@@ -222,7 +222,12 @@ and map_stmt =
           v2
       and v3 = map_of_option map_tok_and_stmt v3
       in Try ((t, v1, v2, v3))
-
+  | ImportDecl ((t, v1, v2, v3)) ->
+      let t = map_tok t in
+      let v1 = map_name v1
+      and v2 = map_name v2
+      and v3 = map_filename v3
+      in ImportDecl ((t, v1, v2, v3))
 and map_tok_and_stmt (t, v) = 
   let t = map_tok t in
   let v = map_stmt v in

--- a/lang_js/analyze/meta_ast_js.ml
+++ b/lang_js/analyze/meta_ast_js.ml
@@ -184,6 +184,12 @@ and vof_stmt =
           v2
       and v3 = Ocaml.vof_option vof_tok_and_stmt v3
       in Ocaml.VSum (("Try", [ t; v1; v2; v3 ]))
+  | ImportDecl ((t, v1, v2, v3)) ->
+      let t =  vof_tok t in
+      let v1 = vof_name v1
+      and v2 = vof_name v2
+      and v3 = vof_filename v3
+      in Ocaml.VSum (("ImportDecl", [ t; v1; v2; v3 ]))
 and vof_tok_and_stmt (t, v) = 
   let t = vof_tok t in
   let v = vof_stmt v in

--- a/lang_js/analyze/visitor_ast_js.ml
+++ b/lang_js/analyze/visitor_ast_js.ml
@@ -182,6 +182,9 @@ and v_stmt x =
               let v1 = v_name v1 and v2 = v_stmt v2 in ()) v2
       and v3 = v_option v_tok_and_stmt v3
       in ()
+  | ImportDecl ((t, v1, v2, v3)) ->
+      let t = v_tok t in
+      let v1 = v_name v1 and v2 = v_name v2 and v3 = v_filename v3 in ()
   in
   vin.kstmt (k, all_functions) x
 

--- a/lang_js/parsing/cst_js.ml
+++ b/lang_js/parsing/cst_js.ml
@@ -572,6 +572,7 @@ and item =
   (* typing-ext: *)
   | InterfaceDecl of interface_decl
   | ItemTodo of tok (* last tok, needed for ASI to work *)
+  | ImportDecl of (tok (* import *) * import * sc)
 
 (* ------------------------------------------------------------------------- *)
 (* Module *)
@@ -619,7 +620,6 @@ and export =
   (* es6-ext: *)
   | Import of (tok (* import *) * import * sc)
   | Export of (tok (* export *) * export)
-
  and program = module_item list
  (* with tarzan *)
 

--- a/lang_js/parsing/meta_cst_js.ml
+++ b/lang_js/parsing/meta_cst_js.ml
@@ -747,6 +747,15 @@ and vof_item =
       let v1 = vof_class_decl v1 in Ocaml.VSum (("ClassDecl", [ v1 ]))
   | InterfaceDecl v1 ->
       let v1 = vof_interface_decl v1 in Ocaml.VSum (("InterfaceDecl", [ v1 ]))
+  | ImportDecl v1 ->
+      let v1 =
+        (match v1 with
+         | (v1, v2, v3) ->
+             let v1 = vof_tok v1
+             and v2 = vof_import v2
+             and v3 = vof_sc v3
+             in Ocaml.VTuple [ v1; v2; v3 ])
+      in Ocaml.VSum (("ImportDecl", [ v1 ]))
 
 and  vof_class_decl {
                    c_tok = v_c_tok;

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -260,6 +260,7 @@ sgrep_spatch_pattern:
 item_no_dots:
  | statement_no_dots { St $1 }
  | declaration { $1 }
+ | import_declaration { ImportDecl $1 }
 
 /*(* coupling: copy paste of statement, without dots *)*/
 statement_no_dots:

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -630,7 +630,12 @@ and v_item =
   | FunDecl v1 -> let v1 = v_func_decl v1 in ()
   | ClassDecl v1 -> let v1 = v_class_decl v1 in ()
   | InterfaceDecl v1 -> let v1 = v_interface_decl v1 in ()
-
+  | ImportDecl v1 ->
+      let v1 =
+        (match v1 with
+         | (v1, v2, v3) ->
+             let v1 = v_tok v1 and v2 = v_import v2 and v3 = v_sc v3 in ())
+      in ()
 and v_import =
   function
   | ImportFrom v1 ->


### PR DESCRIPTION
Fixes https://github.com/returntocorp/sgrep/issues/250, which is caused by "Import" node being at the top level and not part of Decl-s.
This solution attempts:
- Add ImportDecl node as statement to CST and AST of js
This is not working at the moment as it results in empty tree:
```
ulziibayarotgonbaatar@ulziibayars-MacBook-Pro sgrep % ./_build/default/bin/main_sgrep.exe -dump_pattern tests/js/misc_import.sgrep -lang js
S(Block([]))
```