### PR TITLE
Add ext of language

### DIFF
--- a/lang_GENERIC/parsing/lang.ml
+++ b/lang_GENERIC/parsing/lang.ml
@@ -72,6 +72,14 @@ let string_of_lang = function
   | ML -> "ML"
   | Go -> "Golang"
 
+(* Manually pulled from file_type_of_file2 in file_type.ml *)
+let ext_of_lang = function
+  | Python -> ["py"; "pyi"]
+  | Javascript -> ["js"]
+  | Java -> ["java"]
+  | C -> ["c"]
+  | ML -> ["mli"; "ml"; "mly"; "mll"]
+  | Go -> ["go"]
 
 let find_source lang xs = 
   Common.files_of_dir_or_files_no_vcs_nofilter xs 

--- a/lang_GENERIC/parsing/lang.mli
+++ b/lang_GENERIC/parsing/lang.mli
@@ -14,3 +14,4 @@ val files_of_dirs_or_files: t -> Common.path list ->
   Common.filename list
 
 val string_of_lang: t -> string
+val ext_of_lang: t -> string list


### PR DESCRIPTION
Used to print
```
Language ext to language mappings:
 c->c
go->go
golang->go
java->java
javascript->js
js->js
ml->mli, ml, mly, mll
ocaml->mli, ml, mly, mll
py->py, pyi
python->py, pyi

```
in sgrep. Addresses: https://github.com/returntocorp/sgrep/issues/246