### PR TITLE
Allow import declaration in JS sgrep pattern

### DIFF
--- a/lang_js/analyze/ast_js.ml
+++ b/lang_js/analyze/ast_js.ml
@@ -339,8 +339,8 @@ type program = toplevel list
 type any = 
   | Expr of expr
   | Stmt of stmt
-  | Stmts of stmt list
-  | Top of toplevel
+  | Item of toplevel
+  | Items of toplevel list
   | Program of program
  (* with tarzan *)
 

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -407,7 +407,7 @@ let any =
   function
   | Expr v1 -> let v1 = expr v1 in G.E v1
   | Stmt v1 -> let v1 = stmt v1 in G.S v1
-  | Stmts v1 -> let v1 = List.map stmt v1 in G.Ss v1
-  | Top v1 -> let v1 = toplevel v1 in G.S v1
+  | Item v1 -> let v1 = toplevel v1 in G.S v1
+  | Items v1 -> let v1 = List.map toplevel v1 in G.Ss v1
   | Program v1 -> let v1 = program v1 in G.Pr v1
 

--- a/lang_js/analyze/map_ast_js.ml
+++ b/lang_js/analyze/map_ast_js.ml
@@ -349,8 +349,8 @@ and map_any =
   function
   | Expr v1 -> let v1 = map_expr v1 in Expr ((v1))
   | Stmt v1 -> let v1 = map_stmt v1 in Stmt ((v1))
-  | Stmts v1 -> let v1 = map_of_list map_stmt v1 in Stmts ((v1))
-  | Top v1 -> let v1 = map_toplevel v1 in Top ((v1))
+  | Items v1 -> let v1 = map_of_list map_toplevel v1 in Items ((v1))
+  | Item v1 -> let v1 = map_toplevel v1 in Item ((v1))
   | Program v1 -> let v1 = map_program v1 in Program ((v1))
   
 

--- a/lang_js/analyze/meta_ast_js.ml
+++ b/lang_js/analyze/meta_ast_js.ml
@@ -341,8 +341,8 @@ let vof_program v = Ocaml.vof_list vof_toplevel v
 let vof_any =
   function
   | Expr v1 -> let v1 = vof_expr v1 in Ocaml.VSum (("Expr", [ v1 ]))
-  | Top v1 -> let v1 = vof_toplevel v1 in Ocaml.VSum (("Top", [ v1 ]))
+  | Item v1 -> let v1 = vof_toplevel v1 in Ocaml.VSum (("Item", [ v1 ]))
+  | Items v1 -> let v1 = Ocaml.vof_list vof_toplevel v1 in 
+      Ocaml.VSum (("Items", [ v1 ]))
   | Stmt v1 -> let v1 = vof_stmt v1 in Ocaml.VSum (("Stmt", [ v1 ]))
-  | Stmts v1 -> let v1 = Ocaml.vof_list vof_stmt v1 in 
-      Ocaml.VSum (("Stmt", [ v1 ]))
   | Program v1 -> let v1 = vof_program v1 in Ocaml.VSum (("Program", [ v1 ]))

--- a/lang_js/analyze/visitor_ast_js.ml
+++ b/lang_js/analyze/visitor_ast_js.ml
@@ -289,8 +289,8 @@ and v_any =
   function
   | Expr v1 -> let v1 = v_expr v1 in ()
   | Stmt v1 -> let v1 = v_stmt v1 in ()
-  | Stmts v1 -> let v1 = v_list v_stmt v1 in ()
-  | Top v1 -> let v1 = v_toplevel v1 in ()
+  | Item v1 -> let v1 = v_toplevel v1 in ()
+  | Items v1 -> let v1 = v_list v_toplevel v1 in ()
   | Program v1 -> let v1 = v_program v1 in ()
 
 and v_program v = v_list v_toplevel v

--- a/lang_js/parsing/cst_js.ml
+++ b/lang_js/parsing/cst_js.ml
@@ -629,10 +629,9 @@ and export =
 type any =
   | Expr of expr
   | Stmt of stmt
-  | Stmts of stmt list
   | Pattern of pattern
-  | Item of item
-  | Items of item list
+  | ModuleItem of module_item
+  | ModuleItems of module_item list
   | Program of program
  (* with tarzan *)
 

--- a/lang_js/parsing/meta_cst_js.ml
+++ b/lang_js/parsing/meta_cst_js.ml
@@ -948,9 +948,10 @@ let vof_any_orig =
   function
   | Expr v1 -> let v1 = vof_expr v1 in Ocaml.VSum (("Expr", [ v1 ]))
   | Stmt v1 -> let v1 = vof_st v1 in Ocaml.VSum (("Stmt", [ v1 ]))
-  | Stmts v1 -> let v1 = Ocaml.vof_list vof_st v1 in Ocaml.VSum (("Stmts", [ v1 ]))
-  | Item v1 -> let v1 = vof_item v1 in Ocaml.VSum (("Item",[v1 ]))
-  | Items v1 -> let v1 = Ocaml.vof_list vof_item v1 in Ocaml.VSum (("Items",[v1 ]))
+  | ModuleItem v1 -> let v1 = vof_module_item v1 in 
+      Ocaml.VSum (("ModuleItem",[v1 ]))
+  | ModuleItems v1 -> let v1 = Ocaml.vof_list vof_module_item v1 in 
+      Ocaml.VSum (("ModuleItems",[v1 ]))
   | Pattern v1 -> let v1 = vof_pattern v1 in Ocaml.VSum (("Pattern",[v1 ]))
   | Program v1 -> let v1 = vof_program_orig v1 in Ocaml.VSum (("Program",[v1]))
 

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -254,8 +254,13 @@ declaration:
 
 sgrep_spatch_pattern:
  | assignment_expression_no_statement EOF      { Expr $1 }
- | item_no_dots EOF                            { Item $1 }
- | item_no_dots statement_sgrep_list EOF       { Items ($1::$2) }
+ | module_item_no_dots EOF                          { ModuleItem $1 }
+ | module_item_no_dots module_item_sgrep_list EOF   { ModuleItems ($1::$2) }
+
+module_item_no_dots:
+ | item_no_dots { It $1 }
+ | import_declaration { Import $1 }
+ | export_declaration { Export $1 }
 
 item_no_dots:
  | statement_no_dots { St $1 }
@@ -278,13 +283,9 @@ statement_no_dots:
  | throw_statement      { $1 }
  | try_statement        { $1 }
 
-statement_sgrep:
- | statement { St $1 }
- | declaration  { $1 }
-
-statement_sgrep_list:
- | statement_sgrep { [$1] }
- | statement_sgrep_list statement_sgrep { $1 @ [$2] }
+module_item_sgrep_list:
+ | module_item { [$1] }
+ | module_item_sgrep_list module_item { $1 @ [$2] }
 
 /*(*************************************************************************)*/
 /*(*1 Namespace *)*/

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -711,10 +711,9 @@ and v_program v = v_list v_module_item v
 and v_any =  function
   | Expr v1 -> let v1 = v_expr v1 in ()
   | Stmt v1 -> let v1 = v_st v1 in ()
-  | Stmts v1 -> let v1 = v_list v_st v1 in ()
   | Pattern v1 -> let v1 = v_pattern v1 in ()
-  | Item v1 -> let v1 = v_item v1 in ()
-  | Items v1 -> let v1 = v_list v_item v1 in ()
+  | ModuleItem v1 -> let v1 = v_module_item v1 in ()
+  | ModuleItems v1 -> let v1 = v_list v_module_item v1 in ()
   | Program v1 -> let v1 = v_program v1 in ()
 
 and all_functions x = v_any x


### PR DESCRIPTION
This turned out to require some refactoring where we used to
just return a list of stmts, then a list of items,
and now we need to return a list of toplevel elements (module_items).

An alternative used by Ulzii was to add a new ImportDecl in the CST
and AST at the stmt level (or item level), but I prefer to have the
CST and AST enforce as much language restrictions as possible (Javascript
allows ES6 import declaration just at the toplevel!)

This should help fix https://github.com/returntocorp/sgrep/issues/250

Test plan:
make test work
relevant tests added in sgrep repo instead