### PR TITLE
Remove hidden Empty originally added by the Go Parser

### DIFF
--- a/tests/go/parsing/misc_empty.go
+++ b/tests/go/parsing/misc_empty.go
@@ -1,0 +1,16 @@
+package Foo
+
+// If you dump this file, you could have seen before
+// an hidden Empty stmt added at the end of a Block.
+// sgrep did not like that.
+
+// was not generating extra Empty
+func bar1() { bar() }
+
+// was generating extra Empty
+func bar2() { bar(); }
+
+// was generating extra Empty
+func bar3() {
+     bar();
+}


### PR DESCRIPTION
This should fix issue https://github.com/returntocorp/sgrep/issues/281

Test plan:
$ ~/pfff/pfff -dump_go ~/pfff/tests/go/parsing/misc_empty.go
{package=((), ("Foo", ())); imports=[];
 decls=[DFunc(("bar1", ()),
          ({fparams=[]; fresults=[]; },
           Block([SimpleStmt(ExprStmt(Call((Id(("bar", ())), []))))])));
        DFunc(("bar2", ()),
          ({fparams=[]; fresults=[]; },
           Block([SimpleStmt(ExprStmt(Call((Id(("bar", ())), []))))])));
        DFunc(("bar3", ()),
          ({fparams=[]; fresults=[]; },
           Block([SimpleStmt(ExprStmt(Call((Id(("bar", ())), []))))])))];
 }

No more Empty at the end of the Block