### PR TITLE
Use parsing JS hacks also for the sgrep pattern, fix arrow parsing

### DIFF
--- a/lang_js/parsing/parse_js.ml
+++ b/lang_js/parsing/parse_js.ml
@@ -332,7 +332,8 @@ let (program_of_string: string -> Cst_js.program) = fun s ->
 let any_of_string s = 
   Common2.with_tmp_file ~str:s ~ext:"js" (fun file ->
     let toks = tokens file in
-    (* TODO? run the parsing hack fixes? ASI  
+    let toks = Parsing_hacks_js.fix_tokens toks in
+    (* TODO? run the parsing hack ASI fix?  
      * introduce lots of regressions in sgrep make test?
      *)
     let _tr, lexer, lexbuf_fake = PI.mk_lexer_for_yacc toks TH.is_comment in


### PR DESCRIPTION
Some arrows using parenthesis, as in (a) => { ... } require
some parsing hacks to convert the open parenthesis in a special token.
I was not performing this hack for the sgrep pattern, which prevented
to parse certain arrows in a sgrep pattern.

This should help fix https://github.com/returntocorp/sgrep/issues/267

Test plan:
test files for sgrep included.