### PR TITLE
Allow JSX as first element in a file in sgrep mode.

### DIFF
--- a/lang_js/parsing/lexer_js.mll
+++ b/lang_js/parsing/lexer_js.mll
@@ -489,6 +489,11 @@ rule initial = parse
       ->
       push_mode (ST_IN_XHP_TAG tag);
       T_XHP_OPEN_TAG(tag, tokinfo lexbuf)
+
+    (* sgrep-ext: *)
+    | None when !Flag.sgrep_mode ->
+      push_mode (ST_IN_XHP_TAG tag);
+      T_XHP_OPEN_TAG(tag, tokinfo lexbuf)
     | _ ->
       Parse_info.yyback (String.length tag) lexbuf;
       T_LESS_THAN(tokinfo lexbuf)


### PR DESCRIPTION
This should help https://github.com/returntocorp/sgrep/issues/282

Test plan:
develop/home/pad/github/sgrep/sgrep/tests/js $ pwd
/home/pad/github/sgrep/sgrep/tests/js
develop/home/pad/github/sgrep/sgrep/tests/js $ ~/pfff/pfff -lang js -dump_pattern less_xml_attr.sgrep
E(
  Xml(
    {xml_tag=("div", ());
     xml_attrs=[(("dangerouslySetInnerHTML", ()), L(String(("...", ()))))];
     xml_body=[]; }))