### PR TITLE
lang_GENERIC/analyze/naming_ast.ml: port Go and Python aliasing to generic naming. Disable the pl-specific resolvers in parse_generic!

### DIFF
--- a/lang_GENERIC/analyze/naming_ast.ml
+++ b/lang_GENERIC/analyze/naming_ast.ml
@@ -270,6 +270,31 @@ let resolve _lang prog =
       | _ -> k x
     );
 
+    (* the import aliases *)
+    V.kdir = (fun (k, _v) x ->
+       (match x with
+       | ImportFrom (_, DottedName xs, id, Some (alias)) ->
+          (* for python *)
+          let sid = Ast.gensym () in
+          let resolved = ImportedEntity (xs @ [id]), sid in
+          add_ident_env alias resolved env;
+       | ImportAs (_, DottedName xs, Some alias) ->
+          (* for python *)
+          let sid = Ast.gensym () in
+          let resolved = ImportedModule (DottedName xs), sid in
+          add_ident_env alias resolved env;
+
+       | ImportAs (_, FileName (s, tok), Some alias) ->
+          (* for Go *)
+          let sid = Ast.gensym () in
+          let base = Filename.basename s, tok in
+          let resolved = ImportedModule (DottedName [base]), sid in
+          add_ident_env alias resolved env;
+
+       | _ -> ()
+       );
+       k x
+    );
 
     (* the uses *)
 

--- a/lang_GENERIC/parsing/parse_generic.ml
+++ b/lang_GENERIC/parsing/parse_generic.ml
@@ -29,11 +29,15 @@ let parse_with_lang lang file =
   match lang with
   | Lang.Python ->
     let ast = Parse_python.parse_program file in
-    Resolve_python.resolve ast;
+    (* old: Resolve_python.resolve ast; 
+     * switched to call naming_ast.ml in sgrep to correct def and use tagger
+     *)
     Python_to_generic.program ast
   | Lang.Javascript ->
     let cst = Parse_js.parse_program file in
-    (* does also the job of a Resolve_js.resolve ast *)
+    (* does also the job of a Resolve_js.resolve ast
+     * but Js_to_generic does not use the tags
+     *)
     let ast = Ast_js_build.program cst in
     Js_to_generic.program ast
   | Lang.C ->
@@ -45,7 +49,9 @@ let parse_with_lang lang file =
     Java_to_generic.program ast
   | Lang.Go ->
     let ast = Parse_go.parse_program file in
-    Resolve_go.resolve ast;
+    (* old: Resolve_go.resolve ast;
+     * switched to call naming_ast.ml in sgrep to correct def and use tagger
+     *)
     Go_to_generic.program ast
   | Lang.ML ->
     let cst = Parse_ml.parse_program file in

--- a/lang_go/analyze/resolve_go.ml
+++ b/lang_go/analyze/resolve_go.ml
@@ -22,6 +22,9 @@ module G = Ast_generic
 (*****************************************************************************)
 (* Identifiers tagger (so we can colorize them differently in codemap/efuns).
  *
+ * TODO: switch gradually the code to naming_ast.ml generic tagger.
+ * note: This is not called anymore from parse_generic.ml. This is not
+ * used anymore by sgrep (but still used by codemap/efuns)
  *)
 
 (*****************************************************************************)

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -60,13 +60,18 @@ let filename v = wrap string v
 
 let label v = wrap string v
 
-let qualified_name x = [x, fake "TODO qualified name"]
-
-let resolved_name = function
+(* note: we do not care anymore about the language-specific tagger.
+ * we use instead the generic naming_ast.ml *)
+let resolved_name _x = 
+(* old:
+  let _qualified_name x = [x, fake "TODO qualified name"] in
+  match x with
   | Local -> Some (G.Local, G.sid_TODO)
   | Param -> Some (G.Param, G.sid_TODO)
   | Global x -> Some (G.ImportedEntity (qualified_name x), G.sid_TODO)
   | NotResolved -> None
+*)
+  None
 
 type special_result = 
   | SR_Special of G.special

--- a/lang_python/analyze/resolve_python.ml
+++ b/lang_python/analyze/resolve_python.ml
@@ -21,6 +21,9 @@ module V = Visitor_python
 (*****************************************************************************)
 (* Identifiers tagger (so we can colorize them differently in codemap/efuns).
  *
+ * TODO: switch gradually the code to naming_ast.ml generic tagger.
+ * note: This is not called anymore from parse_generic.ml. This is not
+ * used anymore by sgrep (but still used by codemap/efuns)
  *)
 
 (*****************************************************************************)


### PR DESCRIPTION
This should fix issue https://github.com/returntocorp/sgrep/issues/260
by side effect

test plan:
make test in sgrep still work