### PR TITLE
[Go] modifies import stms with aliasing to be ImportEntity node in the generic AST

### DIFF
--- a/lang_GENERIC/analyze/naming_ast.ml
+++ b/lang_GENERIC/analyze/naming_ast.ml
@@ -400,8 +400,9 @@ let resolve lang prog =
        | ImportAs (_, FileName (s, tok), Some alias) ->
           (* for Go *)
           let sid = Ast.gensym () in
-          let base = Filename.basename s, tok in
-          let resolved = ImportedModule (DottedName [base]), sid in
+          let identities = Str.split (Str.regexp "/") s |>
+            List.map(fun name -> name, tok) in
+          let resolved = ImportedEntity identities, sid in
           add_ident_imported_scope alias resolved env.names;
 
        | _ -> ()


### PR DESCRIPTION
This matches python functionality of module resolution with fully
qualified path.

```
package Foo

import (
	htemplate "html/template"
)
tmpl := htemplate.ParseFiles("index.html")
```
is parsed as in generic AST
```

...
ExprStmt(
                    Assign(
                      Id(("tmpl", ()),
                        {id_resolved=Ref(None); id_type=Ref(None); 
                         id_const_literal=Ref(None); }), (),
                      Call(
                        DotAccess(
                          Id(("htemplate", ()),
                            {
                             id_resolved=Ref(Some((ImportedEntity(
                                                     [("html", ());
                                                      ("template", ())]),
                                                   2)));
                             id_type=Ref(None); id_const_literal=Ref(
                             None); }), (), FId(("ParseFiles", ()))),
                        [Arg(L(String(("index.html", ()))))
...
```