### PR TITLE
Do not use token list for int and float type, fix List.hd exn

### DIFF
--- a/lang_c/parsing/ast_c_build.ml
+++ b/lang_c/parsing/ast_c_build.ml
@@ -607,13 +607,13 @@ and full_type env x =
       let s, ii = 
         (match t with
         | Void ii -> "void", ii
-        | FloatType (ft, iis) ->
+        | FloatType (ft, ii) ->
             (match ft with
             | CFloat -> "float"
             | CDouble -> "double" 
             | CLongDouble -> "long_double"
-            ), List.hd iis
-        | IntType (it, iis) ->
+            ), ii
+        | IntType (it, ii) ->
             (match it with
             | CChar -> "char"
             | Si (si, base) ->
@@ -632,7 +632,7 @@ and full_type env x =
                 )
             | CBool | WChar_t ->
                 debug (Type x); raise CplusplusConstruct
-            ), List.hd iis
+            ), ii
         )
       in
       A.TBase (s, ii)

--- a/lang_c/parsing/test_parsing_c.ml
+++ b/lang_c/parsing/test_parsing_c.ml
@@ -6,6 +6,8 @@ module Stat = Parse_info
 (*****************************************************************************)
 
 let test_parse_c xs =
+  Parse_cpp.init_defs !Flag_parsing_cpp.macros_h;
+
   let fullxs = Lib_parsing_c.find_source_files_of_dir_or_files xs in
   let stat_list = ref [] in
 
@@ -22,6 +24,7 @@ let test_parse_c xs =
   ()
 
 let test_dump_c file =
+  Parse_cpp.init_defs !Flag_parsing_cpp.macros_h;
   let ast = Parse_c.parse_program file in
   let v = Meta_ast_c.vof_program ast in
   let s = Ocaml.string_of_v v in

--- a/lang_cpp/parsing/cst_cpp.ml
+++ b/lang_cpp/parsing/cst_cpp.ml
@@ -203,8 +203,8 @@ and type_ = typeQualifier * typeC
 
   and  baseType = 
     | Void of tok
-    | IntType   of intType * tok list
-    | FloatType of floatType * tok list
+    | IntType   of intType   * tok (* TOFIX there should be * tok list *)
+    | FloatType of floatType * tok (* TOFIX there should be * tok list *)
 
      (* stdC: type section. 'char' and 'signed char' are different *)
       and intType   = 

--- a/lang_cpp/parsing/flag_parsing_cpp.ml
+++ b/lang_cpp/parsing/flag_parsing_cpp.ml
@@ -16,7 +16,7 @@ let macros_h =
 
 let cmdline_flags_macrofile () = [
   "-macros", Arg.Set_string macros_h,
-  " <file>";
+  " <file> list of macros to expand";
 ]
 
 (*****************************************************************************)

--- a/lang_cpp/parsing/meta_cst_cpp.ml
+++ b/lang_cpp/parsing/meta_cst_cpp.ml
@@ -144,11 +144,11 @@ and vof_baseType =
   | Void v1 -> let v1 = vof_tok v1 in Ocaml.VSum (("Void", [ v1 ]))
   | IntType ((v1, v2)) ->
       let v1 = vof_intType v1
-      and v2 = Ocaml.vof_list vof_tok v2
+      and v2 = vof_tok v2
       in Ocaml.VSum (("IntType", [ v1; v2 ]))
   | FloatType ((v1, v2)) ->
       let v1 = vof_floatType v1
-      and v2 = Ocaml.vof_list vof_tok v2
+      and v2 = vof_tok v2
       in Ocaml.VSum (("FloatType", [ v1; v2 ]))
 and vof_intType =
   function

--- a/lang_cpp/parsing/parser_cpp.mly
+++ b/lang_cpp/parsing/parser_cpp.mly
@@ -909,7 +909,7 @@ simple_type_specifier:
  | type_cplusplus_id { Right3 (TypeName $1), noii }
 
  (* c++0x: *)
- | decltype_specifier { Middle3 Long, noii }
+ | decltype_specifier { Middle3 Long, [$1] }
 
 decltype_specifier:
  (* c++0x: TODO *)

--- a/lang_cpp/parsing/parser_cpp.mly
+++ b/lang_cpp/parsing/parser_cpp.mly
@@ -740,16 +740,16 @@ argument:
 const_expr: cond_expr { $1  }
 
 basic_type_2: 
- | Tchar_Constr    { (BaseType (IntType (CChar, [$1]))) }
- | Tint_Constr     { (BaseType (IntType (Si (Signed,CInt), [$1])))}
- | Tfloat_Constr   { (BaseType (FloatType (CFloat, [$1]))) }
- | Tdouble_Constr  { (BaseType (FloatType (CDouble, [$1]))) }
+ | Tchar_Constr    { (BaseType (IntType (CChar, $1))) }
+ | Tint_Constr     { (BaseType (IntType (Si (Signed,CInt), $1)))}
+ | Tfloat_Constr   { (BaseType (FloatType (CFloat, $1))) }
+ | Tdouble_Constr  { (BaseType (FloatType (CDouble, $1))) }
 
- | Twchar_t_Constr { (BaseType (IntType (WChar_t, [$1]))) }
+ | Twchar_t_Constr { (BaseType (IntType (WChar_t, $1))) }
 
- | Tshort_Constr   { (BaseType (IntType (Si (Signed, CShort), [$1]))) }
- | Tlong_Constr    { (BaseType (IntType (Si (Signed, CLong), [$1]))) }
- | Tbool_Constr    { (BaseType (IntType (CBool, [$1]))) }
+ | Tshort_Constr   { (BaseType (IntType (Si (Signed, CShort), $1))) }
+ | Tlong_Constr    { (BaseType (IntType (Si (Signed, CLong), $1))) }
+ | Tbool_Constr    { (BaseType (IntType (CBool, $1))) }
 
 (*************************************************************************)
 (* Statements *)
@@ -886,17 +886,17 @@ type_spec:
 
 simple_type_specifier:
  | Tvoid                { Right3 (BaseType (Void $1)),            noii }
- | Tchar                { Right3 (BaseType (IntType (CChar, [$1]))), noii}
- | Tint                 { Right3 (BaseType (IntType (Si (Signed,CInt), [$1]))), noii}
- | Tfloat               { Right3 (BaseType (FloatType (CFloat, [$1]))),  noii}
- | Tdouble              { Right3 (BaseType (FloatType (CDouble, [$1]))), noii }
+ | Tchar                { Right3 (BaseType (IntType (CChar, $1))), noii}
+ | Tint                 { Right3 (BaseType (IntType (Si (Signed,CInt), $1))), noii}
+ | Tfloat               { Right3 (BaseType (FloatType (CFloat, $1))),  noii}
+ | Tdouble              { Right3 (BaseType (FloatType (CDouble, $1))), noii }
  | Tshort               { Middle3 Short,  [$1]}
  | Tlong                { Middle3 Long,   [$1]}
  | Tsigned              { Left3 Signed,   [$1]}
  | Tunsigned            { Left3 UnSigned, [$1]}
  (*c++ext: *)
- | Tbool                { Right3 (BaseType (IntType (CBool, [$1]))), noii }
- | Twchar_t             { Right3 (BaseType (IntType (WChar_t, [$1]))), noii }
+ | Tbool                { Right3 (BaseType (IntType (CBool, $1))), noii }
+ | Twchar_t             { Right3 (BaseType (IntType (WChar_t, $1))), noii }
 
  (* gccext: *)
  | Ttypeof "(" assign_expr ")" { Right3(TypeOf ($1,($2,Right $3,$4))), noii}

--- a/lang_cpp/parsing/parser_cpp2.dyp
+++ b/lang_cpp/parsing/parser_cpp2.dyp
@@ -914,16 +914,16 @@ taction_list:
 const_expr: cond_expr { $1  }
 
 basic_type_2: 
- | Tchar_Constr    { (BaseType (IntType (CChar, [$1]))) }
- | Tint_Constr     { (BaseType (IntType (Si (Signed,CInt), [$1])))}
- | Tfloat_Constr   { (BaseType (FloatType (CFloat, [$1]))) }
- | Tdouble_Constr  { (BaseType (FloatType (CDouble, [$1]))) }
+ | Tchar_Constr    { (BaseType (IntType (CChar, $1))) }
+ | Tint_Constr     { (BaseType (IntType (Si (Signed,CInt), $1)))}
+ | Tfloat_Constr   { (BaseType (FloatType (CFloat, $1))) }
+ | Tdouble_Constr  { (BaseType (FloatType (CDouble, $1))) }
 
- | Twchar_t_Constr { (BaseType (IntType (WChar_t, [$1]))) }
+ | Twchar_t_Constr { (BaseType (IntType (WChar_t, $1))) }
 
- | Tshort_Constr   { (BaseType (IntType (Si (Signed, CShort), [$1]))) }
- | Tlong_Constr    { (BaseType (IntType (Si (Signed, CLong), [$1]))) }
- | Tbool_Constr    { (BaseType (IntType (CBool, [$1]))) }
+ | Tshort_Constr   { (BaseType (IntType (Si (Signed, CShort), $1))) }
+ | Tlong_Constr    { (BaseType (IntType (Si (Signed, CLong), $1))) }
+ | Tbool_Constr    { (BaseType (IntType (CBool, $1))) }
 
 /*(*************************************************************************)*/
 /*(*1 Statements *)*/
@@ -1092,17 +1092,17 @@ type_spec:
 
 simple_type_specifier:
  | Tvoid                { Right3 (BaseType (Void $1)),            noii }
- | Tchar                { Right3 (BaseType (IntType (CChar, [$1]))), noii}
- | Tint                 { Right3 (BaseType (IntType (Si (Signed,CInt), [$1]))), noii}
- | Tfloat               { Right3 (BaseType (FloatType (CFloat, [$1]))),  noii}
- | Tdouble              { Right3 (BaseType (FloatType (CDouble, [$1]))), noii }
+ | Tchar                { Right3 (BaseType (IntType (CChar, $1))), noii}
+ | Tint                 { Right3 (BaseType (IntType (Si (Signed,CInt), $1))), noii}
+ | Tfloat               { Right3 (BaseType (FloatType (CFloat, $1))),  noii}
+ | Tdouble              { Right3 (BaseType (FloatType (CDouble, $1))), noii }
  | Tshort               { Middle3 Short,  [$1]}
  | Tlong                { Middle3 Long,   [$1]}
  | Tsigned              { Left3 Signed,   [$1]}
  | Tunsigned            { Left3 UnSigned, [$1]}
  /*(*c++ext: *)*/
- | Tbool                { Right3 (BaseType (IntType (CBool, [$1]))),noii }
- | Twchar_t             { Right3 (BaseType (IntType (WChar_t, [$1]))), noii }
+ | Tbool                { Right3 (BaseType (IntType (CBool, $1))),noii }
+ | Twchar_t             { Right3 (BaseType (IntType (WChar_t, $1))), noii }
 
  /*(* gccext: *)*/
  | Ttypeof TOPar assign_expr TCPar { Right3(TypeOf ($1,($2,Right $3,$4))),noii}

--- a/lang_cpp/parsing/parser_cpp_mly_helper.ml
+++ b/lang_cpp/parsing/parser_cpp_mly_helper.ml
@@ -133,19 +133,39 @@ let type_and_storage_from_decl
    | _ ->
     (* mine (originally default to int, but this looks like bad style) *)
      let decl = 
-      { v_namei = None; v_type = qu, (BaseType (Void (List.hd iit))); v_storage = st } in
+      { v_namei = None; v_type = qu, (BaseType (Void (List.hd iit))); 
+        v_storage = st } 
+     in
      raise (Semantic ("no type (could default to 'int')", 
                     List.hd (Lib_parsing_cpp.ii_of_any (OneDecl decl))))
    )
- | (None, None, Some t)   -> t
- | (Some sign,   None, (None| Some (BaseType (IntType (Si (_,CInt), _)))))-> 
-     BaseType(IntType (Si (sign, CInt), noii))
- | ((None|Some Signed), Some x, (None|Some(BaseType(IntType (Si (_,CInt), _))))) -> 
-     BaseType(IntType (Si (Signed, [Short,CShort; Long, CLong; LongLong, CLongLong] |> List.assoc x), noii))
- | (Some UnSigned, Some x, (None| Some (BaseType (IntType (Si (_,CInt), _)))))-> 
-     BaseType(IntType (Si (UnSigned, [Short,CShort; Long, CLong; LongLong, CLongLong] |> List.assoc x), noii))
+ | (None, None, Some t)   -> 
+    t
+ | (Some sign,  None, None) ->
+     BaseType(IntType (Si (sign, CInt), List.hd iit))
+ | (Some sign,  None, Some (BaseType (IntType (Si (_,CInt), t1)))) -> 
+     BaseType(IntType (Si (sign, CInt), t1))
+
+ | ((None|Some Signed), Some x, None) ->
+     BaseType(IntType (Si (Signed, 
+       [Short,CShort; Long, CLong; LongLong, CLongLong] |> List.assoc x), 
+              List.hd iit))
+ | ((None|Some Signed), Some x, Some(BaseType(IntType (Si (_,CInt), t1)))) -> 
+     BaseType(IntType (Si (Signed, 
+        [Short,CShort; Long, CLong; LongLong, CLongLong] |> List.assoc x), t1))
+
+ | (Some UnSigned, Some x, None) ->
+     BaseType(IntType (Si (UnSigned, 
+       [Short,CShort; Long, CLong; LongLong, CLongLong] |> List.assoc x), 
+          List.hd iit))
+
+ | (Some UnSigned, Some x, Some (BaseType (IntType (Si (_,CInt), t1))))-> 
+     BaseType(IntType (Si (UnSigned, 
+       [Short,CShort; Long, CLong; LongLong, CLongLong] |> List.assoc x), t1))
+
  | (Some sign,   None, (Some (BaseType (IntType (CChar, ii)))))   -> 
      BaseType(IntType (Si (sign, CChar2), ii))
+
  | (None, Some Long,(Some(BaseType(FloatType (CDouble, ii)))))    -> 
      BaseType (FloatType (CLongDouble, ii))
 

--- a/tests/c/parsing_errors/error_recovery.c
+++ b/tests/c/parsing_errors/error_recovery.c
@@ -1,0 +1,18 @@
+void foo1() {
+  if (a == a) {
+    return 1;
+  }
+}
+
+void foo2() {
+  if (a == ) {
+    return 1;
+  }
+}
+
+
+void foo3() {
+  if (a == a) {
+    return 1;
+  }
+}


### PR DESCRIPTION
This can help a bit fix issue https://github.com/returntocorp/sgrep/issues/448

Test plan:
~/pfff/pfff -macros pfff_macros.h  -parse_c git/remote-curl.c
does not throw List.hd exn anymore (but throw no ifdef issue)