### PR TITLE
* lang_java/parsing/parser_java.mly: Add support for '...' in annotations

### DIFF
--- a/lang_java/parsing/parser_java.mly
+++ b/lang_java/parsing/parser_java.mly
@@ -1028,7 +1028,10 @@ element_value_array_initializer:
  | LC element_values CM RC { $2 }
 
 /*(* should be statically a constant expression; can contain '+', '*', etc.*)*/
-expr1: conditional_expression { $1 }
+expr1: 
+ | conditional_expression { $1 }
+ (* sgrep-et: *)
+ | DOTS { Flag_parsing.sgrep_guard (Ellipsis $1) }
 
 /*(*************************************************************************)*/
 /*(*1 Class *)*/


### PR DESCRIPTION
Test plan:
~/pfff/pfff -lang java -dump_pattern dots_attribute.sgrep
S(
  DefStmt(
    ({name=("$METHOD", ());
      attrs=[NamedAttr(("RequestMapping", ()),
               {id_resolved=Ref(None); id_type=Ref(None);
                id_const_literal=Ref(None); }, [Arg(Ellipsis(()))]);
             KeywordAttr((Public, ()))];
      tparams=[];
      info={id_resolved=Ref(None); id_type=Ref(None);
            id_const_literal=Ref(None); };
      },
     FuncDef(
       {fparams=[ParamEllipsis(())];
        frettype=Some(TyName(
                        (("$T", ()),
                         {name_qualifier=Some([]); name_typeargs=None; })));
        fbody=Block([ExprStmt(Ellipsis(()))]); }))))