### PR TITLE
* tests/js/parsing/void0.js: support!

### DIFF
--- a/lang_js/analyze/ast_js.ml
+++ b/lang_js/analyze/ast_js.ml
@@ -127,7 +127,11 @@ type special =
   (* Special apply *)
   | New | NewTarget
   | Eval (* builtin not in grammar *)
-  | Seq | Void
+  | Seq 
+  (* a kind of cast operator: 
+   * See https://stackoverflow.com/questions/7452341/what-does-void-0-mean
+   *)
+  | Void
   | Typeof | Instanceof
   | In | Delete 
   | Spread

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -99,7 +99,16 @@ let special (x, tok) =
   | Instanceof -> SR_Special (G.Instanceof, tok)
   | In -> SR_Other (G.OE_In, tok)
   | Delete -> SR_Other (G.OE_Delete, tok)
-  | Void -> SR_Literal (G.Unit tok)
+  (* a kind of cast operator: 
+   * See https://stackoverflow.com/questions/7452341/what-does-void-0-mean
+   *)
+  | Void -> SR_NeedArgs (fun args -> 
+          match args with
+          | [e] -> 
+              let tvoid = G.TyBuiltin ("void", tok) in
+              G.Cast(tvoid, e)
+          | _ -> error tok "Impossible: Too many arguments to Void"
+          ) 
   | Spread -> SR_Special (G.Spread, tok)
   | Yield -> SR_NeedArgs (fun args -> 
           match args with

--- a/lang_js/parsing/cst_js.ml
+++ b/lang_js/parsing/cst_js.ml
@@ -208,7 +208,7 @@ type expr =
      and unop =
        | U_new | U_delete
        | U_typeof
-       | U_void 
+       | U_void
        | U_pre_increment  | U_pre_decrement
        | U_post_increment | U_post_decrement
        | U_plus | U_minus | U_not | U_bitnot

--- a/tests/js/parsing/void0.js
+++ b/tests/js/parsing/void0.js
@@ -1,0 +1,6 @@
+function foo() {
+    if (x === void 0) {
+        return undefined;
+    }
+}
+


### PR DESCRIPTION
This closes https://github.com/returntocorp/sgrep/issues/492

Test plan:
~/pfff/pfff -dump_ast void0.js
Pr(
  [DefStmt(
     ({name=("foo", ()); attrs=[KeywordAttr((Const, ()))]; tparams=[];
       info={id_resolved=Ref(None); id_type=Ref(None);
             id_const_literal=Ref(None); };
       },
      FuncDef(
        {fparams=[]; frettype=None;
         fbody=If((),
                 Call(IdSpecial((ArithOp(PhysEq), ())),
                   [Arg(
                      Id(("x", ()),
                        {id_resolved=Ref(None); id_type=Ref(None);
                         id_const_literal=Ref(None); }));
                    Arg(Cast(TyBuiltin(("void", ())), L(Float(("0", ())))))]),
                 Return((), Some(L(Undefined(())))), Block([]));
         })))])