### PR TITLE
* tests/python/parsing/nonlocal.py: Support

### DIFF
--- a/lang_python/parsing/lexer_python.mll
+++ b/lang_python/parsing/lexer_python.mll
@@ -386,9 +386,9 @@ and _token python2 state = parse
         | "True"    -> TRUE (tokinfo lexbuf)
         | "False"    -> FALSE (tokinfo lexbuf)
 
-        | "async" when not python2 -> ASYNC (tokinfo lexbuf)
-        | "await" when not python2 -> AWAIT (tokinfo lexbuf)
-        | "nonlocal" when python2 -> NONLOCAL (tokinfo lexbuf)
+        | "async"    when not python2 -> ASYNC (tokinfo lexbuf)
+        | "await"    when not python2 -> AWAIT (tokinfo lexbuf)
+        | "nonlocal" when not python2 -> NONLOCAL (tokinfo lexbuf)
 
         (* python2: *)
         | "print" when python2 -> PRINT (tokinfo lexbuf)

--- a/tests/python/parsing/nonlocal.py
+++ b/tests/python/parsing/nonlocal.py
@@ -1,0 +1,2 @@
+def next_one() -> int:
+    nonlocal i


### PR DESCRIPTION
Oops ...

This should fix https://github.com/returntocorp/semgrep/issues/555

The python parser does switch to python2 mode when there is a parse
error in Python3 mode, so one could think that even with my typo
this should have worked, but it does so using an heuristic that looks
whether a python3 keyword was used, and this nonlocal was an
ID in python3 mode (the bug), and so it did not even try to go in python2 mode.

Test plan:
test file included