### PR TITLE
* lang_python/parsing/lexer_python.mll: File ending comment fix

### DIFF
--- a/lang_python/parsing/lexer_python.mll
+++ b/lang_python/parsing/lexer_python.mll
@@ -450,7 +450,7 @@ and _token python2 state = parse
   (* ----------------------------------------------------------------------- *)
   (* eof *)
   (* ----------------------------------------------------------------------- *)
-  | eof { EOF (tokinfo lexbuf) }
+  | (whitespace* comment?) eof { EOF (tokinfo lexbuf) }
 
   | _ { error (spf "unrecognized symbol: %s" (tok lexbuf)) lexbuf;
         TUnknown (tokinfo lexbuf)


### PR DESCRIPTION
pfff would fail to parse python code ending with a comment.
For example:

	if 2 == 2:
	    print('hello')
	#

Where the last line does not end with a newline.

Extend the eof pattern of the _token rule of the python lexer to
resolve this. The missing newline is already handled by a python parsing
hacks fix.

This is a fix for the issue returntocorp/semgrep#240.

Signed-off-by: Jaskaran Singh <jaskaransingh7654321@gmail.com>