### PR TITLE
Correctly parse tuples inside Python f-strings

### DIFF
--- a/lang_python/parsing/parser_python.mly
+++ b/lang_python/parsing/parser_python.mly
@@ -689,11 +689,19 @@ string:
 
 interpolated:
   | FSTRING_STRING { Str $1 }
-  | FSTRING_LBRACE test RBRACE { $2 }
-  | FSTRING_LBRACE test COLON format_specifier RBRACE 
+  | FSTRING_LBRACE interpolant RBRACE { $2 }
+  | FSTRING_LBRACE interpolant COLON format_specifier RBRACE
      { InterpolatedString ($2::mk_str $3::$4) }
-  | FSTRING_LBRACE test BANG format_specifier RBRACE 
+  | FSTRING_LBRACE interpolant BANG format_specifier RBRACE
      { InterpolatedString ($2::mk_str $3::$4) }
+
+interpolant:
+/*(* "interpolant" is the "value" inside one of:
+   * f"{value}"
+   * f"{value:format}"
+   * f"{value!format}"
+   *)*/
+  | testlist { tuple_expr $1 }
 
 /*(* todo: maybe need another lexing state when COLON inside FSTRING_LBRACE*)*/
 format_specifier: format_token_list { $1 }

--- a/lang_python/parsing/parser_python.mly
+++ b/lang_python/parsing/parser_python.mly
@@ -696,7 +696,16 @@ interpolated:
      { InterpolatedString ($2::mk_str $3::$4) }
 
 interpolant:
-/*(* "interpolant" is the "value" inside one of:
+/*(* Note that the f-string mini-language at
+   * https://docs.python.org/3/library/string.html#format-string-syntax
+   * simply states that this is parsed as an "expression"; we are now
+   * left trying to determine to which grammar rule an "expression"
+   * corresponds. However, testing with the cpython interpreter indicates
+   * that the testlist rule is what applies, as strings like:
+   *   f"{not True, 1}"
+   * are parsed by the interpreter.
+   *
+   * "interpolant" is the "value" inside one of:
    * f"{value}"
    * f"{value:format}"
    * f"{value!format}"

--- a/tests/python/parsing/fstrings.py
+++ b/tests/python/parsing/fstrings.py
@@ -12,6 +12,9 @@ def test():
    foo(f"this is {1+2 if True else 4}")
    foo(f'this can contain double quotes " {1+2 if True else 4}')
    foo(f"this is {{ not: an expr}}")
+   foo(f"this is a {tuple,}")
+   foo(f"this is also {a, tuple}")
+   foo(f"this is {also, a + tuple,}")
    echo_error(f"Error while running {tool_id}: {findings}")
    # what is that?
    echo_warning(f"{len(collapsed_findings)} findings in {elapsed:.2f} s\n")


### PR DESCRIPTION
Previously, f-strings could only accept expressions that could also
appear as Python statements. However, Python automatically converts
comma-separated lists in f-string interpolants into tuples.

This commit adds that behavior to pfff's Python parser as well.

This was trio-programmed with @brendongo and @minusworld 