### PR TITLE
Parse % in fstring format

### DIFF
--- a/lang_python/parsing/parser_python.mly
+++ b/lang_python/parsing/parser_python.mly
@@ -714,7 +714,7 @@ format_token:
   | EQ { mk_str $1 } | BITXOR { mk_str $1 }
   | ADD  { mk_str $1 } | SUB { mk_str $1 }
   | COMMA { mk_str $1 }
-  
+  | MOD { mk_str $1 }
 
   | LBRACE test RBRACE { $2 }
 

--- a/tests/python/parsing/format1.py
+++ b/tests/python/parsing/format1.py
@@ -1,2 +1,6 @@
 var = 17
 print(f"{var:+g}")
+
+f"{var:a^+10,3s}"
+
+search = f"SINCE {datetime.date.today():%d-%b-%Y}"


### PR DESCRIPTION
Previously, f-strings were failing to parse format syntax with `%` symbol in it.

This commit adds that behavior and includes tests.