### PR TITLE
Support more excaped sequences for Java in semgrep parsing mode

### DIFF
--- a/lang_java/parsing/lexer_java.mll
+++ b/lang_java/parsing/lexer_java.mll
@@ -209,6 +209,13 @@ let EscapeSequence =
 | OctalEscape
 | UnicodeEscape
 
+(* semgrep: we can use regexp in semgrep in strings and we want to
+ * support any escape characters there, e.g. eval("=~/.*dev\.corp/")
+ *)
+let EscapeSequence_semgrep =
+  '\\' _
+
+
 (* ugly: hardcoded stuff for fbandroid, error in SoundexTest.java *)
 let UnicodeX = "�"
 
@@ -270,6 +277,9 @@ rule token = parse
   | CharacterLiteral     { TChar (tok lexbuf, tokinfo lexbuf) }
   | '"' ( (StringCharacter | EscapeSequence)* as s) '"'
    { TString (s, tokinfo lexbuf) }
+  (* semgrep: *)
+  | '"' ( (StringCharacter | EscapeSequence | EscapeSequence_semgrep)* as s)'"'
+   { Flag.sgrep_guard (TString (s, tokinfo lexbuf)) }
   (* bool and null literals are keywords, see below *)
 
   (* ----------------------------------------------------------------------- *)

--- a/tests/java/semgrep/escape_char.sgrep
+++ b/tests/java/semgrep/escape_char.sgrep
@@ -1,0 +1,1 @@
+$SE.eval("=~/.*dev\.corp\.com.*/")


### PR DESCRIPTION
This fixes https://github.com/returntocorp/semgrep/issues/743

Test plan:
+ /home/pad/pfff/pfff -lang java -dump_pattern escape_char.sgrep
E(
  Call(
    DotAccess(
      Id(("$SE", ()),
        {id_resolved=Ref(None); id_type=Ref(None);
         id_const_literal=Ref(None); }), (), FId(("eval", ()))),
    [Arg(L(String(("=~/.*dev\.corp\.com.*/", ()))))]))

not anymore a parse error :)