### PR TITLE
Exclude Python from normalization

### DIFF
--- a/lang_GENERIC/analyze/Normalize_AST.ml
+++ b/lang_GENERIC/analyze/Normalize_AST.ml
@@ -32,13 +32,14 @@ open AST_generic
 (* Entry point *)
 (*****************************************************************************)
 
-let normalize2 any =
+let normalize2 any lang =
   let visitor = Map_AST.mk_visitor { Map_AST.default_visitor with Map_AST.
     kexpr = (fun (k, _) e ->
       (* apply on children *)
       let e = k e in
       match e with
-      | Call (IdSpecial (ArithOp op, tok), [a; b]) ->
+      | Call (IdSpecial (ArithOp op, tok), [a; b]) when lang <> Lang.Python ->
+        (* != can be a method call in Python *)
         let rewrite_opt =
           match op with
           | NotEq -> Some (Not, Eq)
@@ -55,5 +56,5 @@ let normalize2 any =
   } in
   visitor.Map_AST.vany any
 
-let normalize a = 
-  Common.profile_code "Normalize_ast.normalize" (fun () -> normalize2 a)
+let normalize a lang =
+  Common.profile_code "Normalize_ast.normalize" (fun () -> normalize2 a lang)

--- a/lang_GENERIC/analyze/Normalize_AST.mli
+++ b/lang_GENERIC/analyze/Normalize_AST.mli
@@ -1,3 +1,3 @@
 
 (* generate a canonical form to get some code equivalence for free in sgrep *)
-val normalize: AST.any -> AST.any
+val normalize: AST.any -> Lang.t -> AST.any


### PR DESCRIPTION
In some instances, Python != is not the same as (not ... == ...), as
Python will call `__ne__(...)` on objects.

To deal with this, we skip AST normalization for != nodes in Python.