### PR TITLE
Add checks so that number of grammar conflicts can't increase without notice

### DIFF
--- a/lang_cpp/parsing/Makefile
+++ b/lang_cpp/parsing/Makefile
@@ -34,6 +34,14 @@ INCLUDEDIRS= \
  $(TOP)/globals \
  $(TOP)/h_program-lang \
 
+NUM_PERMITTED_CONFLICTS= 2
+
+SCRIPTDIR= $(TOP)/scripts
+
+MENHIRLOG= menhir_out.log
+
+LANG= ml
+
 ##############################################################################
 # Generic variables
 ##############################################################################
@@ -64,9 +72,10 @@ beforedepend:: lexer_cpp.ml
 OCAMLYACC=menhir --unused-tokens --explain
 
 parser_cpp.ml parser_cpp.mli: parser_cpp.mly
-	$(OCAMLYACC) $<
+	$(OCAMLYACC) $< 2> $(MENHIRLOG) && $(SCRIPTDIR)/check_menhir_conflicts.sh $(MENHIRLOG) $(NUM_PERMITTED_CONFLICTS) $(LANG) parser_cpp.ml parser_cpp.mli
+
 clean::
-	rm -f parser_cpp.ml parser_cpp.mli parser_cpp.output parser_cpp.conflicts
+	rm -f parser_cpp.ml parser_cpp.mli parser_cpp.output parser_cpp.conflicts $(MENHIRLOG)
 beforedepend:: parser_cpp.ml parser_cpp.mli
 
 parser_cpp2.ml parser_cpp2.mli: parser_cpp2.dyp

--- a/lang_go/parsing/Makefile
+++ b/lang_go/parsing/Makefile
@@ -26,6 +26,14 @@ INCLUDEDIRS= $(TOP)/commons \
   $(TOP)/globals \
   $(TOP)/h_program-lang \
 
+NUM_PERMITTED_CONFLICTS= 1
+
+SCRIPTDIR= $(TOP)/scripts
+
+OCAMLYLOG= ocamlyacc_out.log
+
+LANG= go
+
 ##############################################################################
 # Generic variables
 ##############################################################################
@@ -56,7 +64,7 @@ beforedepend:: lexer_go.ml
 
 
 parser_go.ml parser_go.mli: parser_go.mly
-	$(OCAMLYACC) $<
+	$(OCAMLYACC) $< 2> $(OCAMLYLOG) && $(SCRIPTDIR)/check_ocamlyacc_conflicts.sh $(OCAMLYLOG) $(NUM_PERMITTED_CONFLICTS) $(LANG) parser_go.ml parser_go.mli
 clean::
 	rm -f parser_go.ml parser_go.mli parser_go.output
 beforedepend:: parser_go.ml parser_go.mli

--- a/lang_java/parsing/Makefile
+++ b/lang_java/parsing/Makefile
@@ -24,6 +24,14 @@ INCLUDEDIRS= $(TOP)/commons $(TOP)/commons_core \
   $(TOP)/h_program-lang \
   $(TOP)/globals
 
+NUM_PERMITTED_CONFLICTS= 0
+
+SCRIPTDIR= $(TOP)/scripts
+
+MENHIRLOG= menhir_out.log
+
+LANG= java
+
 ##############################################################################
 # Generic variables
 ##############################################################################
@@ -55,7 +63,8 @@ beforedepend:: lexer_java.ml
 OCAMLYACC=menhir --unused-tokens --explain --fixed-exception
 
 parser_java.ml parser_java.mli: parser_java.mly
-	$(OCAMLYACC) $<
+	$(OCAMLYACC) $< 2> $(MENHIRLOG) && $(SCRIPTDIR)/check_menhir_conflicts.sh $(MENHIRLOG) $(NUM_PERMITTED_CONFLICTS) $(LANG) parser_java.ml parser_java.mli
+
 clean::
-	rm -f parser_java.ml parser_java.mli parser_java.output
+	rm -f parser_java.ml parser_java.mli parser_java.output $(MENHIRLOG)
 beforedepend:: parser_java.ml parser_java.mli

--- a/lang_js/parsing/Makefile
+++ b/lang_js/parsing/Makefile
@@ -28,7 +28,7 @@ INCLUDEDIRS= $(TOP)/commons \
   $(TOP)/external/json-wheel \
   $(TOP)/h_program-lang \
 
-NUM_PERMITTED_CONFLICTS= 0
+NUM_PERMITTED_CONFLICTS= 2
 
 SCRIPTDIR= $(TOP)/scripts
 

--- a/lang_js/parsing/Makefile
+++ b/lang_js/parsing/Makefile
@@ -28,7 +28,7 @@ INCLUDEDIRS= $(TOP)/commons \
   $(TOP)/external/json-wheel \
   $(TOP)/h_program-lang \
 
-NUM_PERMITTED_CONFLICTS= 1
+NUM_PERMITTED_CONFLICTS= 2
 
 SCRIPTDIR= $(TOP)/scripts
 

--- a/lang_js/parsing/Makefile
+++ b/lang_js/parsing/Makefile
@@ -28,6 +28,14 @@ INCLUDEDIRS= $(TOP)/commons \
   $(TOP)/external/json-wheel \
   $(TOP)/h_program-lang \
 
+NUM_PERMITTED_CONFLICTS= 1
+
+SCRIPTDIR= $(TOP)/scripts
+
+MENHIRLOG= menhir_out.log
+
+LANG= js
+
 ##############################################################################
 # Generic variables
 ##############################################################################
@@ -59,7 +67,8 @@ beforedepend:: lexer_js.ml
 OCAMLYACC=menhir --unused-tokens --explain --fixed-exception
 
 parser_js.ml parser_js.mli: parser_js.mly
-	$(OCAMLYACC) $<
+	  $(OCAMLYACC) $< 2> $(MENHIRLOG); $(SCRIPTDIR)/check_menhir_conflicts.sh $(MENHIRLOG) $(NUM_PERMITTED_CONFLICTS) $(LANG) parser_js.ml parser_js.mli
+
 clean::
-	rm -f parser_js.ml parser_js.mli parser_js.output
+	rm -f parser_js.ml parser_js.mli parser_js.output $(MENHIRLOG)
 beforedepend:: parser_js.ml parser_js.mli

--- a/lang_js/parsing/Makefile
+++ b/lang_js/parsing/Makefile
@@ -28,7 +28,7 @@ INCLUDEDIRS= $(TOP)/commons \
   $(TOP)/external/json-wheel \
   $(TOP)/h_program-lang \
 
-NUM_PERMITTED_CONFLICTS= 2
+NUM_PERMITTED_CONFLICTS= 1
 
 SCRIPTDIR= $(TOP)/scripts
 
@@ -67,7 +67,7 @@ beforedepend:: lexer_js.ml
 OCAMLYACC=menhir --unused-tokens --explain --fixed-exception
 
 parser_js.ml parser_js.mli: parser_js.mly
-	  $(OCAMLYACC) $< 2> $(MENHIRLOG); $(SCRIPTDIR)/check_menhir_conflicts.sh $(MENHIRLOG) $(NUM_PERMITTED_CONFLICTS) $(LANG) parser_js.ml parser_js.mli
+	  $(OCAMLYACC) $< 2> $(MENHIRLOG) && $(SCRIPTDIR)/check_menhir_conflicts.sh $(MENHIRLOG) $(NUM_PERMITTED_CONFLICTS) $(LANG) parser_js.ml parser_js.mli
 
 clean::
 	rm -f parser_js.ml parser_js.mli parser_js.output $(MENHIRLOG)

--- a/lang_js/parsing/Makefile
+++ b/lang_js/parsing/Makefile
@@ -28,7 +28,7 @@ INCLUDEDIRS= $(TOP)/commons \
   $(TOP)/external/json-wheel \
   $(TOP)/h_program-lang \
 
-NUM_PERMITTED_CONFLICTS= 1
+NUM_PERMITTED_CONFLICTS= 0
 
 SCRIPTDIR= $(TOP)/scripts
 

--- a/lang_ml/parsing/Makefile
+++ b/lang_ml/parsing/Makefile
@@ -26,6 +26,15 @@ INCLUDEDIRS= $(TOP)/commons \
   $(TOP)/globals \
   $(TOP)/h_program-lang \
 
+NUM_PERMITTED_CONFLICTS= 0
+
+SCRIPTDIR= $(TOP)/scripts
+
+MENHIRLOG= menhir_out.log
+
+LANG= ml
+
+
 ##############################################################################
 # Generic variables
 ##############################################################################
@@ -55,7 +64,8 @@ beforedepend:: lexer_ml.ml
 OCAMLYACC=menhir --unused-tokens --explain --fixed-exception
 
 parser_ml.ml parser_ml.mli: parser_ml.mly
-	$(OCAMLYACC) $<
+	  $(OCAMLYACC) $< 2> $(MENHIRLOG); $(SCRIPTDIR)/check_menhir_conflicts.sh $(MENHIRLOG) $(NUM_PERMITTED_CONFLICTS) $(LANG) parser_ml.ml parser_ml.mli
+
 clean::
-	rm -f parser_ml.ml parser_ml.mli parser_ml.output
+	rm -f parser_ml.ml parser_ml.mli parser_ml.output $(MENHIRLOG)
 beforedepend:: parser_ml.ml parser_ml.mli

--- a/lang_ml/parsing/Makefile
+++ b/lang_ml/parsing/Makefile
@@ -64,7 +64,7 @@ beforedepend:: lexer_ml.ml
 OCAMLYACC=menhir --unused-tokens --explain --fixed-exception
 
 parser_ml.ml parser_ml.mli: parser_ml.mly
-	  $(OCAMLYACC) $< 2> $(MENHIRLOG); $(SCRIPTDIR)/check_menhir_conflicts.sh $(MENHIRLOG) $(NUM_PERMITTED_CONFLICTS) $(LANG) parser_ml.ml parser_ml.mli
+	  $(OCAMLYACC) $< 2> $(MENHIRLOG) && $(SCRIPTDIR)/check_menhir_conflicts.sh $(MENHIRLOG) $(NUM_PERMITTED_CONFLICTS) $(LANG) parser_ml.ml parser_ml.mli
 
 clean::
 	rm -f parser_ml.ml parser_ml.mli parser_ml.output $(MENHIRLOG)

--- a/lang_python/parsing/Makefile
+++ b/lang_python/parsing/Makefile
@@ -25,6 +25,14 @@ INCLUDEDIRS= $(TOP)/commons \
   $(TOP)/globals \
   $(TOP)/h_program-lang \
 
+NUM_PERMITTED_CONFLICTS= 2
+
+SCRIPTDIR= $(TOP)/scripts
+
+MENHIRLOG= menhir_out.log
+
+LANG= python
+
 ##############################################################################
 # Generic variables
 ##############################################################################
@@ -57,7 +65,8 @@ beforedepend:: Lexer_python.ml
 OCAMLYACC=menhir --unused-tokens --explain --fixed-exception
 
 Parser_python.ml Parser_python.mli: Parser_python.mly
-	$(OCAMLYACC) $<
+	$(OCAMLYACC) $< 2> $(MENHIRLOG) && $(SCRIPTDIR)/check_menhir_conflicts.sh $(MENHIRLOG) $(NUM_PERMITTED_CONFLICTS) $(LANG) parser_python.ml parser_python.mli
+
 clean::
 	rm -f Parser_python.ml Parser_python.mli Parser_python.output
-beforedepend:: Parser_python.ml Parser_python.mli
+beforedepend:: Parser_python.ml Parser_python.mli $(MENHIRLOG)

--- a/scripts/check_menhir_conflicts.sh
+++ b/scripts/check_menhir_conflicts.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Expected input: first arg is the file with menhir error messages
 #                 second arg is the max allowed conflicts
@@ -11,14 +12,14 @@ generated_mli_file=$5
 INSTR="To bypass this, manually set NUM_PERMITTED_CONFLICTS in pfff/lang_$lang/parsing/Makefile"
 
 # Parse conflicts output
-# Expect "Warning: [num] states have shift/reduce conflicts"
-# and/or "Warning: [num] states have reduce/reduce conflicts"
+# Expect "Warning: [num] shift/reduce conflicts were arbitrarily resolved"
+# and/or "Warning: [num] reduce/reduce conflicts were arbitrarily resolved"
 # Split by space to get [num]
 
-resultsr=`grep -i 'have shift/reduce conflicts' $FILE | cut -d ' ' -f 2` 
-resultrr=`grep -i 'have reduce/reduce conflicts' $FILE | cut -d ' ' -f 2` 
+resultsr=`grep -i 'shift/reduce conflicts were' $FILE | cut -d ' ' -f 2` 
+resultrr=`grep -i 'reduce/reduce conflicts were' $FILE | cut -d ' ' -f 2`
 result=$((resultsr+resultrr))
-MSG="Error: menhir found $result conflicts when $num are permitted. See pfff/lang_$lang/parsing/menhir_out.log for details. ($INSTR)"
+MSG="Error: menhir found $result arbitrarily resolved conflicts when $num are permitted. See pfff/lang_$lang/parsing/menhir_out.log for details. ($INSTR)"
 
 if (( $result > $num )); then
    echo $MSG 1>&2

--- a/scripts/check_menhir_conflicts.sh
+++ b/scripts/check_menhir_conflicts.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Expected input: first arg is the file with menhir error messages
+#                 second arg is the max allowed conflicts
+#                 third arg is the language
+FILE=$1
+num=$2
+lang=$3
+generated_ml_file=$4
+generated_mli_file=$5
+INSTR="To bypass this, manually set NUM_PERMITTED_CONFLICTS in pfff/lang_$lang/parsing/Makefile"
+
+# Parse conflicts output
+# Expect "Warning: [num] states have shift/reduce conflicts"
+# and/or "Warning: [num] states have reduce/reduce conflicts"
+# Split by space to get [num]
+
+resultsr=`grep -i 'have shift/reduce conflicts' $FILE | cut -d ' ' -f 2` 
+resultrr=`grep -i 'have reduce/reduce conflicts' $FILE | cut -d ' ' -f 2` 
+result=$((resultsr+resultrr))
+MSG="Error: menhir found $result conflicts when $num are permitted. See pfff/lang_$lang/parsing/menhir_out.log for details. ($INSTR)"
+
+if (( $result > $num )); then
+   echo $MSG 1>&2
+   rm -f $generated_ml_file $generated_mli_file
+   exit 126
+fi

--- a/scripts/check_menhir_conflicts.sh
+++ b/scripts/check_menhir_conflicts.sh
@@ -16,8 +16,15 @@ INSTR="To bypass this, manually set NUM_PERMITTED_CONFLICTS in pfff/lang_$lang/p
 # and/or "Warning: [num] reduce/reduce conflicts were arbitrarily resolved"
 # Split by space to get [num]
 
-resultsr=`grep -i 'shift/reduce conflicts were' $FILE | cut -d ' ' -f 2` 
-resultrr=`grep -i 'reduce/reduce conflicts were' $FILE | cut -d ' ' -f 2`
+resultsr=`grep -i 'shift/reduce conflict.* arbitrarily' $FILE | cut -d ' ' -f 2` 
+resultrr=`grep -i 'reduce/reduce conflict.* arbitrarily' $FILE | cut -d ' ' -f 2`
+if [[ $resultsr == one ]]; then
+   resultsr=1
+fi
+if [[ "$resultrr" == "one" ]]; then
+   resultrr=1
+fi
+
 result=$((resultsr+resultrr))
 MSG="Error: menhir found $result arbitrarily resolved conflicts when $num are permitted. See pfff/lang_$lang/parsing/menhir_out.log for details. ($INSTR)"
 

--- a/scripts/check_ocamlyacc_conflicts.sh
+++ b/scripts/check_ocamlyacc_conflicts.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+# Expected input: first arg is the file with menhir error messages
+#                 second arg is the max allowed conflicts
+#                 third arg is the language
+FILE=$1
+num=$2
+lang=$3
+generated_ml_file=$4
+generated_mli_file=$5
+INSTR="To bypass this, manually set NUM_PERMITTED_CONFLICTS in pfff/lang_$lang/parsing/Makefile"
+
+# Parse conflicts output
+# Expect "[num] shift/reduce conflicts"
+# and/or "[num] reduce/reduce conflicts"
+# Split by space to get [num]
+
+resultsr=`grep -i 'shift/reduce conflict' $FILE | cut -d ' ' -f 1` 
+resultrr=`grep -i 'reduce/reduce conflict' $FILE | cut -d ' ' -f 1`
+
+result=$((resultsr+resultrr))
+MSG="Error: ocamlyacc found $result conflicts when $num are permitted. See pfff/lang_$lang/parsing/ocamlyacc_out.log for details. ($INSTR)"
+
+if (( $result > $num )); then
+   echo $MSG 1>&2
+   rm -f $generated_ml_file $generated_mli_file
+   exit 126
+fi


### PR DESCRIPTION
Addresses: https://github.com/returntocorp/semgrep/issues/800#event-3356766862

Test plan:
For each language implemented (js, ml, cpp, java, python, go), set the number of permitted conflicts to one below the actual number of conflicts. Run make clean then make twice (either top level or in the test_[lang]/parsing folder). In at least one case when there are no conflicts: introduce a conflict deliberately.

Note: the menhir version has been tested with one conflict, 2 conflicts, >100 conflicts, just shift/reduce, just reduce/reduce, and both shift/reduce and reduce/reduce. The ocamlyacc version has only been tested with the case "1 shift/reduce conflict".