### PR TITLE
Support for template strings used as argument to member expression

### DIFF
--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -416,6 +416,13 @@ and expr =
    (* used for interpolated strings constructs *)
    | ConcatString of concat_string_kind
    | EncodedString of string wrap (* only for Python for now (e.g., b"foo") *)
+   (* TaggedString? for Javascript, for styled.div`bla{xx}`?
+    * We could have this TaggedString where the first arg of Call
+    * will be the tagging function, and the rest will be a Call ConcatString. 
+    * However, it is simpler to just transform those special calls as
+    * regular calls even though they do not have parenthesis
+    * (not all calls have parenthesis anyway, as in OCaml or Ruby).
+    *)
    | Spread (* inline list var, in Container or call context *)
 
    (* used for unary and binary operations *)
@@ -546,7 +553,6 @@ and expr =
     | OE_Define | OE_Arguments 
     | OE_NewTarget
     | OE_Delete | OE_YieldStar
-    | OE_EncapsName (* todo: convert to regular funcall? use Concat? *)
     | OE_Require (* todo: lift to DirectiveStmt? transform in Import? *) 
     | OE_UseStrict (* todo: lift up to program attribute/directive? *)
     (* Python *)

--- a/lang_GENERIC/parsing/Meta_AST.ml
+++ b/lang_GENERIC/parsing/Meta_AST.ml
@@ -365,7 +365,6 @@ and vof_other_expr_operator =
   | OE_NewTarget -> OCaml.VSum (("OE_NewTarget", []))
   | OE_Delete -> OCaml.VSum (("OE_Delete", []))
   | OE_YieldStar -> OCaml.VSum (("OE_YieldStar", []))
-  | OE_EncapsName -> OCaml.VSum (("OE_EncapsName", []))
   | OE_Require -> OCaml.VSum (("OE_Require", []))
   | OE_UseStrict -> OCaml.VSum (("OE_UseStrict", []))
   | OE_In -> OCaml.VSum (("OE_In", []))

--- a/lang_js/analyze/ast_js.ml
+++ b/lang_js/analyze/ast_js.ml
@@ -136,7 +136,7 @@ type special =
   | In | Delete 
   | Spread
   | Yield | YieldStar | Await
-  | Encaps of name option (* less: resolve? *)
+  | Encaps of bool (* if true, first arg of apply is the "tag" *)
   (* CommonJS part2 *)
   | Require
 

--- a/lang_js/analyze/ast_js_build.ml
+++ b/lang_js/analyze/ast_js_build.ml
@@ -576,9 +576,16 @@ and expr env = function
   | C.NewTarget (tok, _, _) ->
     A.Apply (A.IdSpecial (A.NewTarget, tok), [])
 
-  | C.Encaps (name_opt, tok, xs, _) ->
-    let special = A.Encaps name_opt in
+  | C.TemplateString (exp_opt, (tok, xs, _)) ->
+    let special = A.Encaps (exp_opt <> None) in
     let xs = List.map (encaps env) xs in
+    let xs = 
+        match exp_opt with
+        | None -> xs
+        | Some e ->
+            let e = expr env e in
+            e::xs
+    in
     A.Apply (A.IdSpecial (special, tok), xs)
 
   | C.XhpHtml x -> 

--- a/lang_js/analyze/map_ast_js.ml
+++ b/lang_js/analyze/map_ast_js.ml
@@ -115,7 +115,7 @@ and map_special =
   | Yield -> Yield
   | YieldStar -> YieldStar
   | Await -> Await
-  | Encaps v1 -> let v1 = map_of_option map_name v1 in Encaps ((v1))
+  | Encaps v1 -> let v1 = map_of_bool v1 in Encaps ((v1))
   | UseStrict -> UseStrict
   | ArithOp v -> let v = map_of_arith_op v in ArithOp v
   | IncrDecr v -> let v = map_of_inc_dec v in IncrDecr ((v))

--- a/lang_js/analyze/meta_ast_js.ml
+++ b/lang_js/analyze/meta_ast_js.ml
@@ -49,9 +49,7 @@ let vof_special =
   | Yield -> OCaml.VSum (("Yield", []))
   | YieldStar -> OCaml.VSum (("YieldStar", []))
   | Await -> OCaml.VSum (("Await", []))
-  | Encaps v1 ->
-      let v1 = OCaml.vof_option vof_name v1
-      in OCaml.VSum (("Encaps", [ v1 ]))
+  | Encaps v1 -> let v1 = OCaml.vof_bool v1 in OCaml.VSum (("Await", [v1]))
   | ArithOp x -> Meta_ast_generic_common.vof_arithmetic_operator x
   | IncrDecr v1 -> let v1 = Meta_ast_generic_common.vof_inc_dec v1 in 
       OCaml.VSum (("IncrDecr", [ v1 ]))

--- a/lang_js/analyze/visitor_ast_js.ml
+++ b/lang_js/analyze/visitor_ast_js.ml
@@ -100,7 +100,7 @@ and v_special =
   | Yield -> ()
   | YieldStar -> ()
   | Await -> ()
-  | Encaps v1 -> let v1 = v_option v_name v1 in ()
+  | Encaps v1 -> let v1 = v_bool v1 in ()
   | ArithOp v -> let v = v_arith_op v in ()
   | IncrDecr v -> let v = v_inc_dec v in ()
 

--- a/lang_js/parsing/cst_js.ml
+++ b/lang_js/parsing/cst_js.ml
@@ -148,8 +148,8 @@ type expr =
    (* The comma_list can have successive Right because of "elision" *)
    | Array of expr comma_list bracket
 
-   (* Call, see also Encaps that is a sort of call when 'name' is not None.
-    * This covers Eval.
+   (* Call. This covers also Eval.
+    * See also TemplateString when first arg is not None.
     *)
    | Apply of expr * expr comma_list paren
 
@@ -174,8 +174,9 @@ type expr =
    (* es6: template (interpolated) strings 
     * less: you can get multiple EncapsString in encaps below; they
     * are not flatten together, to simplify the lexer/parser.
+    * The first expr option is usually a name or a field (e.g., foo.div).
     *)
-   | Encaps of name option * tok (* ` *) * encaps list * tok (* ` *)
+   | TemplateString of expr option * (tok (* ` *) * encaps list * tok (* ` *))
  
    (* sgrep-ext: *)
    | Ellipsis of tok

--- a/lang_js/parsing/meta_cst_js.ml
+++ b/lang_js/parsing/meta_cst_js.ml
@@ -148,8 +148,8 @@ let rec vof_expr =
       let v1 = vof_paren vof_expr v1 in OCaml.VSum (("Paren", [ v1 ]))
   | XhpHtml v1 ->
       let v1 = vof_xhp_html v1 in OCaml.VSum (("XhpHtml", [ v1 ]))
-  | Encaps ((v1, v2, v3, v4)) ->
-      let v1 = OCaml.vof_option vof_name v1
+  | TemplateString ((v1, (v2, v3, v4))) ->
+      let v1 = OCaml.vof_option vof_expr v1
       and v2 = vof_tok v2
       and v3 = OCaml.vof_list vof_encaps v3
       and v4 = vof_tok v4

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -128,8 +128,8 @@ and v_expr (x: expr) =
   | Arrow v1 -> let v1 = v_arrow_func v1 in ()
   | Paren v1 -> let v1 = v_paren v_expr v1 in ()
   | XhpHtml v1 -> let v1 = v_xhp_html v1 in ()
-  | Encaps ((v1, v2, v3, v4)) ->
-      let v1 = v_option v_name v1
+  | TemplateString ((v1, (v2, v3, v4))) ->
+      let v1 = v_option v_expr v1
       and v2 = v_tok v2
       and v3 = v_list v_encaps v3
       and v4 = v_tok v4

--- a/tests/js/parsing/backquote.js
+++ b/tests/js/parsing/backquote.js
@@ -13,5 +13,3 @@ const getTermLinkMarkdownBlock = termTitle => {
   let anchor = util.getMarkDownAnchor(termTitle);
   return `* [\`${termTitle}\`](#${anchor})` + '\n';
 };
-
-

--- a/tests/js/parsing/template_string.js
+++ b/tests/js/parsing/template_string.js
@@ -1,0 +1,1 @@
+// see backquote.js

--- a/tests/js/parsing/template_string_member.js
+++ b/tests/js/parsing/template_string_member.js
@@ -1,0 +1,4 @@
+
+const AButton = styled.div`
+  float: left;
+`;

--- a/tests/js/parsing/template_string_react.js
+++ b/tests/js/parsing/template_string_react.js
@@ -1,0 +1,68 @@
+import React, { Component } from 'react'
+import styled, { keyframes } from 'styled-components'
+import logo from './logo.svg'
+
+const AppWrapper = styled.div`
+  text-align: center;
+`
+
+const rotate360 = keyframes`
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+`
+
+const AppLogo = styled.img`
+  animation: ${rotate360} infinite 120s linear;
+  height: 80px;
+  &:hover {
+    animation: ${rotate360} infinite 1.5s linear;
+  }
+`
+
+const AppHeader = styled.div`
+  background-color: #222;
+  height: 12rem;
+  padding: 1rem;
+  color: white;
+`
+
+const AppTitle = styled.h1`
+  font-weight: 900;
+`
+
+const AppIntro = styled.p`
+  font-size: large;
+  code {
+    font-size: 1.3rem;
+  }
+`
+
+const EmojiWrapper = styled.span.attrs({
+  role: 'img'
+})``
+
+class App extends Component {
+  render() {
+    return (
+      <AppWrapper>
+        <AppHeader>
+          <AppLogo src={logo} alt="logo" />
+          <AppTitle>Welcome to React</AppTitle>
+        </AppHeader>
+        <AppIntro>
+          Bootstrapped with <code>create-react-app</code>.
+        </AppIntro>
+        <AppIntro>
+          Components styled with <code>styled-components</code>{' '}
+          <EmojiWrapper aria-label="nail polish" />
+        </AppIntro>
+      </AppWrapper>
+    )
+  }
+}
+
+export default App

--- a/tests/js/parsing/template_string_tag.js
+++ b/tests/js/parsing/template_string_tag.js
@@ -1,0 +1,2 @@
+
+var out = sanitize`Hello ${name}, how are you ${time}?`;


### PR DESCRIPTION
This fixes https://github.com/returntocorp/semgrep/issues/823

Test plan:
test files included, they now parse correctly without any parse error
exceptions and their AST dump looks ok.