### PR TITLE
Remove Nop from the Javascript AST to remove some NoTokenLocation exception

### DIFF
--- a/lang_js/analyze/ast_js_build.ml
+++ b/lang_js/analyze/ast_js_build.ml
@@ -652,9 +652,7 @@ and xhp_body env = function
       )
   | C.XhpNested xml -> A.XmlXml (xhp_html env xml)
 
-and expr_opt env = function
-  | None -> None
-  | Some e -> Some (expr env e)
+and expr_opt env = Common.map_opt (expr env)
 
 and literal _env = function
   | C.Bool x -> A.Bool x
@@ -924,8 +922,9 @@ and array_arr env tok xs =
      let e = expr env e in
      e::array_arr env tok xs
   | (Right _)::xs ->
-    (* TODO let e = A.Nop in e::array_arr ... invent a new Hole category
-     * or maybe an array_argument special type like for (call)argument.
+    (* TODO old: let e = A.Nop in e::array_arr ... 
+     * invent a new Hole category or maybe an array_argument special 
+     * type like for the (call)argument type.
      *)
     array_arr env tok xs
   | (Left _)::(Left _)::_ ->

--- a/lang_js/analyze/graph_code_js.mli
+++ b/lang_js/analyze/graph_code_js.mli
@@ -3,8 +3,8 @@ val build:
   Graph_code.graph
 
 (* helpers *)
-val kind_of_expr: 
-  Ast_js.var_kind Ast_js.wrap -> Ast_js.expr -> Entity_code.entity_kind
+val kind_of_expr_opt: 
+  Ast_js.var_kind Ast_js.wrap -> Ast_js.expr option -> Entity_code.entity_kind
 
 val build_for_ai: Common.dirname -> Common.filename list ->
   (Ast_js.qualified_name, Ast_js.var) Hashtbl.t *

--- a/lang_js/analyze/highlight_js.ml
+++ b/lang_js/analyze/highlight_js.ml
@@ -79,7 +79,7 @@ let visit_program ~tag_hook _prefs (cst, toks) =
      Visitor_ast_js.ktop = (fun (k, _) t ->
        (match t with
        | V {v_name = name; v_kind; v_init; v_resolved = _resolved } ->
-           let kind = Graph_code_js.kind_of_expr v_kind v_init in
+           let kind = Graph_code_js.kind_of_expr_opt v_kind v_init in
            tag_name name (Entity (kind, (Def2 fake_no_def2)));
        | _ -> ()
        );
@@ -87,7 +87,7 @@ let visit_program ~tag_hook _prefs (cst, toks) =
      );
      Visitor_ast_js.kprop = (fun (k,_) x ->
       (match x with
-      | Field (PN name, _, Fun _) ->
+      | Field (PN name, _, Some (Fun _)) ->
           tag_name name (Entity (E.Method, (Def2 fake_no_def2)));
       | Field (PN name, _, _) ->
           tag_name name (Entity (E.Field, (Def2 fake_no_def2)));

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -38,7 +38,6 @@ let string = id
 
 let error = AST_generic.error
 
-let fake s = Parse_info.fake_info s
 
 (*****************************************************************************)
 (* Entry point *)
@@ -176,7 +175,6 @@ and expr (x: expr) =
       | SR_Literal l -> G.L l
       | SR_Other (x, tok) -> G.OtherExpr (x, [G.Tk tok])
       )
-  | Nop -> G.L (G.Null (fake "null"))
   | Assign ((v1, tok, v2)) -> let v1 = expr v1 and v2 = expr v2 in 
       let tok = info tok in
       G.Assign (v1, tok, v2)
@@ -245,8 +243,8 @@ and stmt x =
   | Break (t, v1) -> let v1 = option label v1 in
      G.Break (t, G.opt_to_label_ident v1)
   | Return (t, v1) -> 
-      let v1 = expr v1 in 
-      G.Return (t, Some v1)
+      let v1 = option expr v1 in 
+      G.Return (t, v1)
   | Label ((v1, v2)) -> let v1 = label v1 and v2 = stmt v2 in
       G.Label (v1, v2)
   | Throw (t, v1) -> let v1 = expr v1 in G.Throw (t, v1)
@@ -267,8 +265,8 @@ and tok_and_stmt (t, v) =
 and for_header =
   function
   | ForClassic ((v1, v2, v3)) ->
-      let v2 = expr v2 in
-      let v3 = expr v3 in
+      let v2 = option expr v2 in
+      let v3 = option expr v3 in
       (match v1 with
       | Left vars ->
             let vars = vars |> List.map (fun x -> 
@@ -276,10 +274,10 @@ and for_header =
                   G.ForInitVar (a, b)
             )
             in
-            G.ForClassic (vars, Some v2, Some v3)
+            G.ForClassic (vars, v2, v3)
       | Right e ->
          let e = expr e in
-         G.ForClassic ([G.ForInitExpr e], Some v2, Some v3)
+         G.ForClassic ([G.ForInitExpr e], v2, v3)
       )
       
   | ForIn ((v1, t, v2)) ->
@@ -307,17 +305,17 @@ and def_of_var { v_name = x_name; v_kind = x_kind;
   let v2 = var_kind x_kind in 
   let ent = G.basic_entity v1 [v2] in
   (match x_init with
-  | Fun (v3, _nTODO)   -> 
+  | Some (Fun (v3, _nTODO))   -> 
       let def, more_attrs = fun_ v3 in
       { ent with G.attrs = ent.G.attrs @ more_attrs}, G.FuncDef def
-  | Class (v3, _nTODO) -> 
+  | Some (Class (v3, _nTODO)) -> 
       let def, more_attrs = class_ v3 in
       { ent with G.attrs = ent.G.attrs @ more_attrs}, G.ClassDef def
   | _ -> 
-       let v3 = expr x_init in 
+       let v3 = option expr x_init in 
        let v4 = vref resolved_name x_resolved in
        ent.G.info.G.id_resolved := !v4;
-       ent, G.VarDef { G.vinit = Some v3; G.vtype = None }
+       ent, G.VarDef { G.vinit = v3; G.vtype = None }
    )
 
 and var_of_var { v_name = x_name; v_kind = x_kind; 
@@ -325,10 +323,10 @@ and var_of_var { v_name = x_name; v_kind = x_kind;
   let v1 = name x_name in
   let v2 = var_kind x_kind in 
   let ent = G.basic_entity v1 [v2] in
-  let v3 = expr x_init in 
+  let v3 = option expr x_init in 
   let v4 = vref resolved_name x_resolved in
   ent.G.info.G.id_resolved := !v4;
-  ent, { G.vinit = Some v3; G.vtype = None }
+  ent, { G.vinit = v3; G.vtype = None }
 
 
 and var_kind (x, tok) =
@@ -385,16 +383,19 @@ and property x =
   | Field ((v1, v2, v3)) ->
       let v1 = property_name v1
       and v2 = list property_prop v2
-      and v3 = expr v3
+      and v3 = option expr v3
       in 
       (match v1 with
       | Left n ->
         let ent = G.basic_entity n v2 in
        (* todo: could be a Lambda in which case we should return a FuncDef? *)
         G.FieldStmt (G.DefStmt 
-                ((ent, G.VarDef { G.vinit = Some v3; vtype = None })))
-      | Right e ->
-        G.FieldDynamic (e, v2, v3)
+                ((ent, G.VarDef { G.vinit = v3; vtype = None })))
+      | Right e -> 
+        (match v3 with
+         | None -> raise Impossible
+         | Some x -> G.FieldDynamic (e, v2, x)
+        )
       )
   | FieldSpread (t, v1) -> 
       let v1 = expr v1 in 

--- a/lang_js/analyze/map_ast_js.ml
+++ b/lang_js/analyze/map_ast_js.ml
@@ -166,7 +166,6 @@ and map_expr =
       and v2 = map_of_ref map_resolved_name v2
       in Id ((v1, v2))
   | IdSpecial v1 -> let v1 = map_wrap map_special v1 in IdSpecial ((v1))
-  | Nop -> Nop
   | Assign ((v1, v2, v3)) ->
       let v1 = map_expr v1 and v2 = map_tok v2 and v3 = map_expr v3 in
       Assign ((v1, v2, v3))
@@ -231,7 +230,7 @@ and map_stmt =
       let v1 = map_of_option map_label v1 in Break ((t, v1))
   | Return (t, v1) -> 
       let t = map_tok t in
-      let v1 = map_expr v1 in Return ((t, v1))
+      let v1 = map_of_option map_expr v1 in Return ((t, v1))
   | Label ((v1, v2)) ->
       let v1 = map_label v1 and v2 = map_stmt v2 in Label ((v1, v2))
   | Throw (t, v1) -> 
@@ -258,8 +257,8 @@ and map_for_header =
   function
   | ForClassic ((v1, v2, v3)) ->
       let v1 = OCaml.map_of_either (map_of_list map_var) map_expr v1
-      and v2 = map_expr v2
-      and v3 = map_expr v3
+      and v2 = OCaml.map_of_option map_expr v2
+      and v3 = OCaml.map_of_option map_expr v3
       in ForClassic ((v1, v2, v3))
   | ForIn ((v1, t, v2)) ->
       let t = map_tok t in
@@ -282,7 +281,7 @@ and
             v_resolved = v_v_resolved
           } =
   let v_v_resolved = map_of_ref map_resolved_name v_v_resolved in
-  let v_v_init = map_expr v_v_init in
+  let v_v_init = map_of_option map_expr v_v_init in
   let v_v_kind = map_wrap map_var_kind v_v_kind in
   let v_v_name = map_name v_v_name in 
     { v_name = v_v_name; v_kind = v_v_kind; v_init = v_v_init;
@@ -328,7 +327,7 @@ and map_property =
   | Field ((v1, v2, v3)) ->
       let v1 = map_property_name v1
       and v2 = map_of_list (map_wrap map_property_prop) v2
-      and v3 = map_expr v3
+      and v3 = map_of_option map_expr v3
       in Field ((v1, v2, v3))
   | FieldSpread (t, v1) -> 
       let t = map_tok t in let v1 = map_expr v1 in FieldSpread ((t, v1))

--- a/lang_js/analyze/meta_ast_js.ml
+++ b/lang_js/analyze/meta_ast_js.ml
@@ -121,7 +121,6 @@ and vof_expr =
       OCaml.VSum (("Id", [ v1; v2 ]))
   | IdSpecial v1 ->
       let v1 = vof_wrap vof_special v1 in OCaml.VSum (("IdSpecial", [ v1 ]))
-  | Nop -> OCaml.VSum (("Nop", []))
   | Assign ((v1, v2, v3)) ->
       let v1 = vof_expr v1
       and v2 = vof_tok v2
@@ -199,7 +198,8 @@ and vof_stmt =
       in OCaml.VSum (("Break", [ t; v1 ]))
   | Return (t, v1) -> 
       let t = vof_tok t in
-      let v1 = vof_expr v1 in OCaml.VSum (("Return", [ t; v1 ]))
+      let v1 = OCaml.vof_option vof_expr v1 in 
+      OCaml.VSum (("Return", [ t; v1 ]))
   | Label ((v1, v2)) ->
       let v1 = vof_label v1
       and v2 = vof_stmt v2
@@ -228,8 +228,8 @@ and vof_for_header =
   function
   | ForClassic ((v1, v2, v3)) ->
       let v1 = OCaml.vof_either (OCaml.vof_list vof_var) vof_expr v1
-      and v2 = vof_expr v2
-      and v3 = vof_expr v3
+      and v2 = OCaml.vof_option vof_expr v2
+      and v3 = OCaml.vof_option vof_expr v3
       in OCaml.VSum (("ForClassic", [ v1; v2; v3 ]))
   | ForIn ((v1, t, v2)) ->
       let t = vof_tok t in
@@ -255,7 +255,7 @@ and vof_var { v_name = v_v_name;
   let arg = OCaml.vof_ref vof_resolved_name v_v_resolved in
   let bnd = ("v_resolved", arg) in
   let bnds = bnd :: bnds in
-  let arg = vof_expr v_v_init in
+  let arg = OCaml.vof_option vof_expr v_v_init in
   let bnd = ("v_init", arg) in
   let bnds = bnd :: bnds in
   let arg = vof_wrap vof_var_kind v_v_kind in
@@ -322,7 +322,7 @@ and vof_property =
   | Field ((v1, v2, v3)) ->
       let v1 = vof_property_name v1
       and v2 = OCaml.vof_list (vof_wrap vof_property_prop) v2
-      and v3 = vof_expr v3
+      and v3 = OCaml.vof_option vof_expr v3
       in OCaml.VSum (("Field", [ v1; v2; v3 ]))
   | FieldSpread (t, v1) ->
       let t = vof_tok t in

--- a/lang_js/analyze/visitor_ast_js.ml
+++ b/lang_js/analyze/visitor_ast_js.ml
@@ -140,7 +140,6 @@ and v_expr (x: expr) =
   | Regexp v1 -> let v1 = v_wrap v_string v1 in ()
   | Id (v1, _) -> let v1 = v_name v1 in ()
   | IdSpecial v1 -> let v1 = v_wrap v_special v1 in ()
-  | Nop -> ()
   | Assign ((v1, v2, v3)) -> 
         let v1 = v_expr v1 and v2 = v_tok v2 and v3 = v_expr v3 in ()
   | ArrAccess ((v1, v2)) -> let v1 = v_expr v1 and v2 = v_expr v2 in ()
@@ -189,7 +188,7 @@ and v_stmt x =
       let v1 = v_option v_label v1 in ()
   | Return (t, v1) -> 
       let t = v_tok t in
-      let v1 = v_expr v1 in ()
+      let v1 = v_option v_expr v1 in ()
   | Label ((v1, v2)) -> let v1 = v_label v1 and v2 = v_stmt v2 in ()
   | Throw (t, v1) -> 
       let t = v_tok t in
@@ -215,8 +214,8 @@ and v_for_header =
   function
   | ForClassic ((v1, v2, v3)) ->
       let v1 = v_either (v_list v_var) v_expr v1
-      and v2 = v_expr v2
-      and v3 = v_expr v3
+      and v2 = v_option v_expr v2
+      and v3 = v_option v_expr v3
       in ()
   | ForIn ((v1, t, v2)) ->
       let t = v_tok t in
@@ -237,7 +236,7 @@ and v_var { v_name = v_v_name; v_kind = v_v_kind; v_init = v_v_init;
             v_resolved = v_v_resolved } =
   let arg = v_name v_v_name in
   let arg = v_wrap v_var_kind v_v_kind in 
-  let arg = v_expr v_v_init in 
+  let arg = v_option v_expr v_v_init in 
   let arg = v_ref v_resolved_name v_v_resolved in
   ()
 and v_var_kind = function | Var -> () | Let -> () | Const -> ()
@@ -274,7 +273,7 @@ and v_property x =
   | Field ((v1, v2, v3)) ->
       let v1 = v_property_name v1
       and v2 = v_list (v_wrap v_property_prop) v2
-      and v3 = v_expr v3
+      and v3 = v_option v_expr v3
       in ()
   | FieldSpread (t, v1) -> let t = v_tok t in let v1 = v_expr v1 in ()
   | FieldEllipsis v1 -> let v1 = v_tok v1 in ()


### PR DESCRIPTION
As said in ast_js.ml, having Nop in the AST simplified a few things
but hurt us in Semgrep so I've removed it.

This fixes https://github.com/returntocorp/semgrep/issues/824

Test plan:
There is more a vinit = Some Nop below, but instead a None
I'll add a regression test in semgrep-core in another PR.

+ /home/pad/pfff/pfff -dump_ast misc_notoken.js
Pr(
  [DefStmt(
     ({name=("bar", ());
       attrs=[KeywordAttr((Const, ())); KeywordAttr((Async, ()))];
       tparams=[];
       info={id_resolved=Ref(None); id_type=Ref(None);
             id_const_literal=Ref(None); };
       },
      FuncDef(
        {
         fparams=[ParamClassic(
                    {pname=Some(("msg", ())); pdefault=None; ptype=None;
                     pattrs=[];
                     pinfo={id_resolved=Ref(None); id_type=Ref(None);
                            id_const_literal=Ref(None); };
                     })];
         frettype=None;
         fbody=Block(
                 [DefStmt(
                    ({name=("x", ()); attrs=[KeywordAttr((Let, ()))];
                      tparams=[];
                      info={id_resolved=Ref(None); id_type=Ref(None);
                            id_const_literal=Ref(None); };
                      },
                     VarDef({vinit=None; vtype=None; })));