### PR TITLE
Support use of interface{} inside if/for/..., parsing hack

### DIFF
--- a/lang_go/parsing/parsing_hacks_go.ml
+++ b/lang_go/parsing/parsing_hacks_go.ml
@@ -129,6 +129,15 @@ let fix_tokens_lbody toks =
           aux Normal xs3;
           aux Normal ys;
 
+      (* must be after previous case *)
+      (* skipping: if ok := interface{} ... *)
+      | F.Tok (("struct" | "interface"), _)::
+        (F.Braces (_lb1, xs1, _rb1))::
+        ys 
+        when env = InIfHeader ->
+          aux Normal xs1;
+          aux env ys
+
       (* for a := range []int{...} { ... } *)
       | (F.Braces (_lb1, xs1, _rb1))::(F.Braces (lb2, xs2, _rb2))::ys 
         when env = InIfHeader ->
@@ -150,7 +159,7 @@ let fix_tokens_lbody toks =
           aux Normal xs;
           aux env zs
 
-          
+
           
       | (F.Braces (lb, xs, _rb))::ys ->
           (* for ... { ... } *)

--- a/tests/go/parsing/if_header_lbody2.go
+++ b/tests/go/parsing/if_header_lbody2.go
@@ -1,0 +1,7 @@
+package Foo
+
+func test1() {
+  if v, ok := interface{}(x).(interface{ Validate() error }); ok {
+    return 0
+  }
+}


### PR DESCRIPTION
The Go grammar is not LALR(1). To manage some ambiguity we need
to use some parsing hack to find the opening brace of an if/for/switch/select.
This add a new heuristic to not treat the { of interface as the
opening brace.

This fixes https://github.com/returntocorp/semgrep/issues/829

Test plan:
test file included