### PR TITLE
Add support for Python's Walrus (:=) operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -285,3 +285,5 @@ tmp
 /lang_python/parsing/Lexer_python.ml
 /lang_python/parsing/Parser_python.ml
 /lang_python/parsing/Parser_python.mli
+
+menhir_out.log

--- a/lang_python/analyze/Python_to_generic.ml
+++ b/lang_python/analyze/Python_to_generic.ml
@@ -280,6 +280,8 @@ let rec expr (x: expr) =
       G.Await (t, v1)
   | Repr v1 -> let (_, v1, _) = bracket expr v1 in
       G.OtherExpr (G.OE_Repr, [G.E v1])
+  | NamedExpr ((v, t, e)) ->
+      G.Assign(expr v, t, expr e)
 (*e: function [[Python_to_generic.expr]] *)
 
 (*s: function [[Python_to_generic.argument]] *)

--- a/lang_python/analyze/highlight_python.ml
+++ b/lang_python/analyze/highlight_python.ml
@@ -484,6 +484,7 @@ let visit_program ~tag_hook _prefs (program, toks) =
     | T.EQ ii ->
         tag ii Punctuation
 
+    | T.COLONEQ ii
     | T.ADDEQ ii | T.SUBEQ ii | T.MULTEQ ii | T.DIVEQ ii 
     | T.MODEQ ii  | T.POWEQ ii | T.FDIVEQ ii 
     | T.ANDEQ ii | T.OREQ ii | T.XOREQ ii 

--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -175,6 +175,8 @@ type expr =
   (* python3: *)
   | Await of tok * expr
 
+  (* python 3.8+; see https://www.python.org/dev/peps/pep-0572/ *)
+  | NamedExpr of expr * tok * expr
   | Repr of expr bracket (* `` *)
   (* =~ ObjAccess *)
   | Attribute of expr (* value *) * tok (* . *) * name (* attr *) * 

--- a/lang_python/parsing/Lexer_python.mll
+++ b/lang_python/parsing/Lexer_python.mll
@@ -271,6 +271,7 @@ and _token python2 state = parse
   (* symbols *)
   (* ----------------------------------------------------------------------- *)
   (* symbols *)
+  | ":="    { COLONEQ (tokinfo lexbuf) }
   | "+="    { ADDEQ (tokinfo lexbuf) }
   | "-="    { SUBEQ (tokinfo lexbuf) }
   | "*="    { MULTEQ (tokinfo lexbuf) }

--- a/lang_python/parsing/Meta_AST_python.ml
+++ b/lang_python/parsing/Meta_AST_python.ml
@@ -132,6 +132,9 @@ let rec vof_expr =
       and v2 = vof_name v2
       and v3 = vof_expr_context v3
       in OCaml.VSum (("Attribute", [ v1; t; v2; v3 ]))
+  | NamedExpr (v, t, e) ->
+      let v = vof_expr v and t = vof_tok t and e = vof_expr e
+      in OCaml.VSum (("NamedExpr", [ v; t; e ]))
 and vof_number =
   function
   | Int v1 ->

--- a/lang_python/parsing/Token_helpers_python.ml
+++ b/lang_python/parsing/Token_helpers_python.ml
@@ -125,6 +125,7 @@ let visitor_info_of_tok f = function
   | LSHIFT (ii) -> LSHIFT (f ii)
   | RSHIFT (ii) -> RSHIFT (f ii)
   | EQ (ii) -> EQ (f ii)
+  | COLONEQ (ii) -> COLONEQ (f ii)
   | ADDEQ (ii) -> ADDEQ (f ii)
   | SUBEQ (ii) -> SUBEQ (f ii)
   | MULTEQ (ii) -> MULTEQ (f ii)

--- a/lang_python/parsing/Visitor_python.ml
+++ b/lang_python/parsing/Visitor_python.ml
@@ -152,6 +152,8 @@ and v_expr (x: expr) =
   | Attribute ((v1, t, v2, v3)) ->
       let v1 = v_expr v1 and t = v_tok t and v2 = v_name v2 
         and v3 = v_expr_context v3 in ()
+  | NamedExpr ((v, t, e)) ->
+      let v = v_expr v and t = v_tok t and e = v_expr e in ()
   in
   vin.kexpr (k, all_functions) x
 

--- a/tests/python/parsing/python3/walrus-invalid.py
+++ b/tests/python/parsing/python3/walrus-invalid.py
@@ -1,0 +1,8 @@
+# INVALID
+# x := 0
+
+# INVALID
+# x = y := 0
+
+# INVALID
+# foo(cat=category := 'vector')

--- a/tests/python/parsing/python3/walrus.py
+++ b/tests/python/parsing/python3/walrus.py
@@ -18,3 +18,7 @@ foo(cat=(category := 'vector'))
 
 # Valid
 partial_sums = [total := total + v for v in values]
+
+# Valid
+while x := next(f):
+    print(x)

--- a/tests/python/parsing/python3/walrus.py
+++ b/tests/python/parsing/python3/walrus.py
@@ -1,0 +1,20 @@
+f(x := 2)
+y = (x := 3)
+
+# Valid alternative
+(x := 0)
+
+# Valid alternative
+x = (y := 0)
+
+# Valid
+len(lines := f.readlines())
+
+# Valid
+foo(x := 3, cat='vector')
+
+# Valid alternative
+foo(cat=(category := 'vector'))
+
+# Valid
+partial_sums = [total := total + v for v in values]


### PR DESCRIPTION
Python introduced support for expression-level assignment in 3.8 via the
"Walrus" operator, ":=". Add that to Python parsing here.

Note that Python's grammar handles assignment expressions within
arguments separately from "test" expressions; that difference is
included here verbatim from
https://docs.python.org/3/reference/grammar.html.

In both those cases I condense the Python AST to the same "Assign" node
in the generic AST (although arguments are nested within an "Arg" node
as well).

Test cases are taken directly from PEP 572:
https://www.python.org/dev/peps/pep-0572/.

Bonus:

Ignore menhir-out.log files.