### PR TITLE
Properly parse print with dangling comma in python 2

### DIFF
--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -449,7 +449,7 @@ print_stmt:
 
 print_testlist:
   | (* empty *)  { [], true }
-  | "," test "," { [$2], false }
+  | ","          { [], false }
   | "," test print_testlist { $2::(fst $3), snd $3 }
 
 exec_stmt:

--- a/tests/python/parsing/python2/print.py
+++ b/tests/python/parsing/python2/print.py
@@ -1,0 +1,7 @@
+print
+print 1
+print 1,
+print 1, 2
+print 1, 2,
+print 1, 2, 3
+print 1, 2, 3,


### PR DESCRIPTION
Previously, we only parsed:

  print
  print x
  print x, y
  print x, y,

and print statements with longer argument lists. However,

  print x,

is also valid python2. Support that.