### PR TITLE
Support `() => async () => {}` syntax for ECMAScript

### DIFF
--- a/lang_js/parsing/cst_js.ml
+++ b/lang_js/parsing/cst_js.ml
@@ -474,6 +474,7 @@ and func_decl = {
  * is a simple expression, etc. so simpler to have a a different type.
  *)
 and arrow_func = {
+  a_async: tok option;
   a_params: arrow_params;
   (* typing-ext: *)
   a_return_type: type_opt;

--- a/lang_js/parsing/meta_cst_js.ml
+++ b/lang_js/parsing/meta_cst_js.ml
@@ -632,10 +632,14 @@ and vof_default = function
   | DSome (v1,v2) -> let v1 = vof_tok v1 and v2 = vof_expr v2 in OCaml.VSum (("DSome", [v1; v2]))
 
 and
-  vof_arrow_func { a_params = v_a_params; a_return_type = v_a_return_type;
+  vof_arrow_func { a_async = v_a_async;
+                   a_params = v_a_params; a_return_type = v_a_return_type;
                    a_tok = v_a_tok; a_body = v_a_body
                  } =
   let bnds = [] in
+  let arg = vof_async v_a_async in
+  let bnd = ("a_async", arg) in
+  let bnds = bnd :: bnds in
   let arg = vof_arrow_body v_a_body in
   let bnd = ("a_body", arg) in
   let bnds = bnd :: bnds in
@@ -647,6 +651,7 @@ and
   let bnds = bnd :: bnds in
   let arg = vof_arrow_params v_a_params in
   let bnd = ("a_params", arg) in let bnds = bnd :: bnds in OCaml.VDict bnds
+  and vof_async tok = OCaml.VSum(("AAsync", [OCaml.vof_option vof_tok tok]))
 and vof_arrow_params =
   function
   | ASingleParam v1 ->

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -1207,7 +1207,7 @@ encaps:
 
 (* TODO conflict with as then in indent_keyword_bis *)
 arrow_function:
- (* es:7 *)
+ (* es7: *)
  | T_ASYNC id T_ARROW arrow_body
      { { a_async = Some($1); a_params = ASingleParam (ParamClassic (mk_param $2));
          a_return_type = None; a_tok = $3; a_body = $4 } }
@@ -1216,7 +1216,7 @@ arrow_function:
          a_return_type = None; a_tok = $2; a_body = $3 } }
 
  (* can not factorize with TOPAR parameter_list TCPAR, see conflicts.txt *)
- (* es:7 *)
+ (* es7: *)
  | T_ASYNC T_LPAREN_ARROW formal_parameter_list_opt ")" annotation? T_ARROW arrow_body
     { { a_async = Some($1); a_params = AParams ($2, $3, $4); a_return_type = $5;
         a_tok = $6; a_body = $7; } }

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -1209,19 +1209,19 @@ encaps:
 arrow_function:
  (* es:7 *)
  | T_ASYNC id T_ARROW arrow_body
-     { { a_params = ASingleParam (ParamClassic (mk_param $2));
+     { { a_async = Some($1); a_params = ASingleParam (ParamClassic (mk_param $2));
          a_return_type = None; a_tok = $3; a_body = $4 } }
  | id T_ARROW arrow_body
-     { { a_params = ASingleParam (ParamClassic (mk_param $1)); 
+     { { a_async = None; a_params = ASingleParam (ParamClassic (mk_param $1)); 
          a_return_type = None; a_tok = $2; a_body = $3 } }
 
  (* can not factorize with TOPAR parameter_list TCPAR, see conflicts.txt *)
  (* es:7 *)
  | T_ASYNC T_LPAREN_ARROW formal_parameter_list_opt ")" annotation? T_ARROW arrow_body
-    { { a_params = AParams ($2, $3, $4); a_return_type = $5;
+    { { a_async = Some($1); a_params = AParams ($2, $3, $4); a_return_type = $5;
         a_tok = $6; a_body = $7; } }
  | T_LPAREN_ARROW formal_parameter_list_opt ")" annotation? T_ARROW arrow_body
-    { { a_params = AParams ($1, $2, $3); a_return_type = $4;
+    { { a_async = None; a_params = AParams ($1, $2, $3); a_return_type = $4;
         a_tok = $5; a_body = $6; } }
 
 (* was called consise body in spec *)

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -519,9 +519,11 @@ and v_default = function
   | DNone v1 -> let _ = v_tok v1 in ()
   | DSome (v1,v2) -> let _ = v_tok v1 and _ = v_expr v2 in ()
 and
-  v_arrow_func { a_params = v_a_params; a_return_type = v_a_return_type;
+  v_arrow_func { a_async = v_a_async;
+                 a_params = v_a_params; a_return_type = v_a_return_type;
                  a_tok = v_a_tok; a_body = v_a_body }
                =
+  let arg = v_option v_tok v_a_async in
   let arg = v_arrow_params v_a_params in
   let arg = v_type_opt v_a_return_type in
   let arg = v_tok v_a_tok in let arg = v_arrow_body v_a_body in ()

--- a/tests/js/parsing/async.js
+++ b/tests/js/parsing/async.js
@@ -8,3 +8,7 @@ async function doRollup() {
   const min = minify({ comments: false });
 
 }
+
+const foo = (x) => async () => {
+  console.log("yup");
+}


### PR DESCRIPTION
Unfortunately this means manually resolving shift-reduce conflicts by
enumerating grammar possibilities for async arrow functions.

Also added a test case to validate.

Fixes https://github.com/returntocorp/semgrep/issues/562.