### PR TITLE
Add support for optional catch bindings in ECMAScript 2019

### DIFF
--- a/lang_js/analyze/ast_js.ml
+++ b/lang_js/analyze/ast_js.ml
@@ -263,7 +263,10 @@ and stmt =
    | Case of tok * expr * stmt
    | Default of tok * stmt
 
-  and catch = tok * name * stmt
+  and catch =
+   | BoundCatch of tok * name * stmt
+   (* es2019 *)
+   | UnboundCatch of tok * stmt
 
 (*****************************************************************************)
 (* Pattern (destructuring binding) *)

--- a/lang_js/analyze/ast_js_build.ml
+++ b/lang_js/analyze/ast_js_build.ml
@@ -416,11 +416,7 @@ and stmt env = function
     [A.Throw (t, e)]
   | C.Try (t, st, catchopt, finally_opt) ->
     let st = stmt1 env st in
-    let catchopt = opt (fun env (t, arg, st) ->
-       let arg = name env (C.unparen arg) in
-       let st = stmt1 env st in
-       (t, arg, st)
-       ) env catchopt in
+    let catchopt = opt catch_block_handler env catchopt in
     let finally_opt = opt (fun env (t, st) -> t, stmt1 env st) env finally_opt in
     [A.Try (t, st, catchopt, finally_opt)]
 
@@ -463,6 +459,14 @@ and stmt_item_list env items =
 
 and stmt1_item_list env items = 
   stmt_item_list env items |> stmt_of_stmts
+
+and catch_block_handler env = function
+  | C.BoundCatch (t, arg, st) ->
+      let arg = name env (C.unparen arg) in
+      let st = stmt1 env st in
+      A.BoundCatch (t, arg, st)
+  | C.UnboundCatch (t, st) ->
+      A.UnboundCatch (t, stmt1 env st)
   
 (* ------------------------------------------------------------------------- *)
 (* Expression *)

--- a/lang_js/analyze/graph_code_js.ml
+++ b/lang_js/analyze/graph_code_js.ml
@@ -426,14 +426,17 @@ and stmt env = function
    expr env e
  | Try (_, st1, catchopt, finalopt) ->
    stmt env st1;
-   catchopt |> Common.opt (fun (_t, n, st) -> 
+   catchopt |> Common.opt (catch_block env);
+   finalopt |> Common.opt (fun (_t, st) -> stmt env st);
+
+and catch_block env = function
+  | BoundCatch (_t, n, st) ->
      let v = { v_name = n; v_kind = Let, fake "let"; 
                v_init = None; 
                v_resolved = ref Local } in
      let env = add_locals env [v] in
      stmt env st
-   );
-   finalopt |> Common.opt (fun (_t, st) -> stmt env st);
+  | UnboundCatch (_t, st) -> stmt env st
 
 and for_header env = function
  | ForClassic (e1, e2, e3) ->

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -253,13 +253,18 @@ and stmt x =
   | Throw (t, v1) -> let v1 = expr v1 in G.Throw (t, v1)
   | Try ((t, v1, v2, v3)) ->
       let v1 = stmt v1
-      and v2 =
-        option (fun (t, v1, v2) -> 
-           let v1 = name v1 and v2 = stmt v2 in
-           t, G.PatId (v1, G.empty_id_info()), v2
-       ) v2
+      and v2 = option catch_block v2
       and v3 = option tok_and_stmt v3 in
       G.Try (t, v1, Common.opt_to_list v2, v3)
+
+and catch_block = function
+  | BoundCatch (t, v1, v2) ->
+      let v1 = name v1
+      and v2 = stmt v2
+      in t, G.PatId (v1, G.empty_id_info()), v2
+  | UnboundCatch (t, v1) ->
+      let v1 = stmt v1
+      in t, G.PatUnderscore (Parse_info.fake_info "_"), v1
 
 and tok_and_stmt (t, v) = 
   let v = stmt v in

--- a/lang_js/analyze/map_ast_js.ml
+++ b/lang_js/analyze/map_ast_js.ml
@@ -239,14 +239,20 @@ and map_stmt =
   | Try ((t, v1, v2, v3)) ->
       let t = map_tok t in
       let v1 = map_stmt v1
-      and v2 =
-        map_of_option
-          (fun (t, v1, v2) ->
-            let t = map_tok t in
-             let v1 = map_name v1 and v2 = map_stmt v2 in (t, v1, v2))
-          v2
+      and v2 = map_of_option map_catch_block v2
       and v3 = map_of_option map_tok_and_stmt v3
       in Try ((t, v1, v2, v3))
+
+and map_catch_block = function
+  | BoundCatch (t, v1, v2) ->
+      let t = map_tok t
+      and v1 = map_name v1
+      and v2 = map_stmt v2
+      in BoundCatch (t, v1, v2)
+  | UnboundCatch (t, v1) ->
+      let t = map_tok t
+      and v1 = map_stmt v1
+      in UnboundCatch (t, v1)
 
 and map_tok_and_stmt (t, v) = 
   let t = map_tok t in

--- a/lang_js/analyze/meta_ast_js.ml
+++ b/lang_js/analyze/meta_ast_js.ml
@@ -208,16 +208,19 @@ and vof_stmt =
   | Try ((t, v1, v2, v3)) ->
       let t = vof_tok t in
       let v1 = vof_stmt v1
-      and v2 =
-        OCaml.vof_option
-          (fun (t, v1, v2) ->
-             let t = vof_tok t in
-             let v1 = vof_wrap OCaml.vof_string v1
-             and v2 = vof_stmt v2
-             in OCaml.VTuple [ t; v1; v2 ])
-          v2
+      and v2 = OCaml.vof_option vof_catch_block v2
       and v3 = OCaml.vof_option vof_tok_and_stmt v3
       in OCaml.VSum (("Try", [ t; v1; v2; v3 ]))
+and vof_catch_block = function
+  | BoundCatch ((t, v1, v2)) ->
+      let t = vof_tok t in
+      let v1 = vof_wrap OCaml.vof_string v1
+      and v2 = vof_stmt v2
+      in OCaml.VTuple [ t; v1; v2 ]
+  | UnboundCatch ((t, v2)) ->
+      let t = vof_tok t
+      and v2 = vof_stmt v2
+      in OCaml.VTuple [ t; v2 ]
 and vof_tok_and_stmt (t, v) = 
   let t = vof_tok t in
   let v = vof_stmt v in

--- a/lang_js/analyze/visitor_ast_js.ml
+++ b/lang_js/analyze/visitor_ast_js.ml
@@ -196,15 +196,22 @@ and v_stmt x =
   | Try ((t, v1, v2, v3)) ->
       let t = v_tok t in
       let v1 = v_stmt v1
-      and v2 =
-        v_option
-          (fun (t, v1, v2) -> 
-              let t = v_tok t in
-              let v1 = v_name v1 and v2 = v_stmt v2 in ()) v2
+      and v2 = v_option v_catch_block v2
       and v3 = v_option v_tok_and_stmt v3
       in ()
   in
   vin.kstmt (k, all_functions) x
+
+and v_catch_block = function
+  | BoundCatch (t, v1, v2) ->
+      let t = v_tok t
+      and v1 = v_name v1
+      and v2 = v_stmt v2
+      in ()
+  | UnboundCatch (t, v1) ->
+      let t = v_tok t
+      and v1 = v_stmt v1
+      in ()
 
 and v_tok_and_stmt (t, v) = 
   let t = v_tok t in

--- a/lang_js/parsing/cst_js.ml
+++ b/lang_js/parsing/cst_js.ml
@@ -327,7 +327,7 @@ and stmt =
 
   | Throw of tok * expr * sc
   | Try of tok * stmt (* always a block *) *
-      (tok * arg_catch paren * stmt) option * (* catch *)
+      catch_block option * (* catch *)
       (tok * stmt) option (* finally *)
 
   and label = string wrap
@@ -346,6 +346,10 @@ and stmt =
     | Default of tok * tok (*:*) * item list
     | Case of tok * expr * tok (*:*) * item list
 
+  and catch_block =
+    | BoundCatch of tok * (arg_catch paren) * stmt
+    (* es2019 *)
+    | UnboundCatch of tok * stmt
   and arg_catch = string wrap
 
 (*****************************************************************************)

--- a/lang_js/parsing/meta_cst_js.ml
+++ b/lang_js/parsing/meta_cst_js.ml
@@ -414,14 +414,7 @@ and vof_st =
   | Try ((v1, v2, v3, v4)) ->
       let v1 = vof_tok v1
       and v2 = vof_st v2
-      and v3 =
-        OCaml.vof_option
-          (fun (v1, v2, v3) ->
-             let v1 = vof_tok v1
-             and v2 = vof_paren vof_arg v2
-             and v3 = vof_st v3
-             in OCaml.VTuple [ v1; v2; v3 ])
-          v3
+      and v3 = OCaml.vof_option vof_catch_block v3
       and v4 =
         OCaml.vof_option
           (fun (v1, v2) ->
@@ -430,6 +423,16 @@ and vof_st =
              in OCaml.VTuple [ v1; v2 ])
           v4
       in OCaml.VSum (("Try", [ v1; v2; v3; v4 ]))
+and vof_catch_block = function
+  | BoundCatch ((v1, v2, v3)) ->
+     let v1 = vof_tok v1
+     and v2 = vof_paren vof_arg v2
+     and v3 = vof_st v3
+     in OCaml.VTuple [ v1; v2; v3 ]
+  | UnboundCatch ((v1, v2)) ->
+      let v1 = vof_tok v1
+      and v2 = vof_st v2
+      in OCaml.VTuple [ v1; v2 ]
 and vof_label v = vof_wrap OCaml.vof_string v
 and vof_lhs_or_vars =
   function

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -905,7 +905,10 @@ try_stmt:
  | T_TRY block       finally { Try ($1, $2, None, Some $3) }
  | T_TRY block catch finally { Try ($1, $2, Some $3, Some $4) }
 
-catch: T_CATCH "(" id ")" block { $1, ($2, $3, $4), $5 }
+catch:
+ | T_CATCH "(" id ")" block { BoundCatch ($1, ($2, $3, $4), $5) }
+ (* es2019 *)
+ | T_CATCH block { UnboundCatch ($1, $2) }
 
 finally: T_FINALLY block { $1, $2 }
 

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -354,14 +354,7 @@ and v_st x =
   | Try ((v1, v2, v3, v4)) ->
       let v1 = v_tok v1
       and v2 = v_st v2
-      and v3 =
-        v_option
-          (fun (v1, v2, v3) ->
-             let v1 = v_tok v1
-             and v2 = v_paren v_arg v2
-             and v3 = v_st v3
-             in ())
-          v3
+      and v3 = v_option v_catch_block v3
       and v4 =
         v_option (fun (v1, v2) -> let v1 = v_tok v1 and v2 = v_st v2 in ())
           v4
@@ -369,6 +362,16 @@ and v_st x =
   in
   vin.kstmt (k, all_functions) x
 
+and v_catch_block = function
+  | BoundCatch (v1, v2, v3) ->
+      let v1 = v_tok v1
+      and v2 = v_paren v_arg v2
+      and v3 = v_st v3
+      in ()
+  | UnboundCatch (v1, v2) ->
+      let v1 = v_tok v1
+      and v2 = v_st v2
+      in ()
 and v_label v = v_wrap v_string v
 and v_lhs_or_vars =
   function

--- a/tests/js/parsing/try-catch.js
+++ b/tests/js/parsing/try-catch.js
@@ -1,0 +1,13 @@
+try {
+  something();
+} catch (e) {
+  console.log(e);
+}
+
+try {
+    url = new URL(href, window.location.href);
+} catch {
+    elt.removeAttribute("href");
+    elt.removeAttribute("title");
+    continue;
+}


### PR DESCRIPTION
In ES2019+, the value binding after the `catch` keyword is optional.

Support that here, and add a test case.