### PR TITLE
Parse rest param in object destructuring

### DIFF
--- a/lang_js/analyze/transpile_js.ml
+++ b/lang_js/analyze/transpile_js.ml
@@ -153,6 +153,12 @@ let compile_pattern (expr, fname, fpname) varname pat =
         *   var {...a} = b --> var a = <spread>(b)
         *
         * cf. xhp_attribute transpilation
+        *
+        * TODO:
+        *   Apply(
+        *     IdSpecial(Spread, fake "omit"),
+        *     [Id (varname, _), ...<all omitted keys>]
+        *   )
         *)
        let init_builder (_name, _tok) =
          A.Apply (

--- a/lang_js/analyze/transpile_js.ml
+++ b/lang_js/analyze/transpile_js.ml
@@ -146,7 +146,25 @@ let compile_pattern (expr, fname, fpname) varname pat =
                     pname)
        in
        var_of_simple_pattern (expr, fname) init_builder pat
-     | _ -> failwith "TODO: PatObj pattern not handled"
+     | C.PatDots (_ tok, pat) ->
+       (* Need to effectively augment JS semantics here, so transformation target needs to
+        * be impossible in actual JS:
+        *
+        *   var {...a} = b --> var a = <spread>(b)
+        *
+        * cf. xhp_attribute transpilation
+        *)
+       let init_builder (_name, _tok) =
+         A.Apply (
+           A.IdSpecial(A.Spread, fake "spread"),
+           [A.Id (varname, ref A.NotResolved)]
+         )
+       in
+       var_of_simple_pattern (expr, fname) init_builder pat
+     | C.PatNest (_, _) ->
+       failwith "TODO: nesting inside object pattern not handled"
+     | C.PatObj _ | C.PatArr _ ->
+       failwith "Unexpected pattern PatObj or PatArr found inside PatObj"
     ))
   (* 'var [x,y] = varname' -~> 'var x = varname[0]; var y = varname[1] *)
   | C.PatArr x ->

--- a/lang_js/analyze/transpile_js.ml
+++ b/lang_js/analyze/transpile_js.ml
@@ -146,7 +146,7 @@ let compile_pattern (expr, fname, fpname) varname pat =
                     pname)
        in
        var_of_simple_pattern (expr, fname) init_builder pat
-     | C.PatDots (_ tok, pat) ->
+     | C.PatDots (_tok, pat) ->
        (* Need to effectively augment JS semantics here, so transformation target needs to
         * be impossible in actual JS:
         *
@@ -162,7 +162,7 @@ let compile_pattern (expr, fname, fpname) varname pat =
         *)
        let init_builder (_name, _tok) =
          A.Apply (
-           A.IdSpecial(A.Spread, fake "spread"),
+           A.IdSpecial(A.Spread, fake "omit"),
            [A.Id (varname, ref A.NotResolved)]
          )
        in

--- a/tests/js/parsing/spread_params.js
+++ b/tests/js/parsing/spread_params.js
@@ -1,1 +1,10 @@
 const defer = (fn, ...args) => setTimeout(fn, 1, ...args);
+
+const foo = ({ id, ...restStats }) => {};
+
+topLevelComponents.forEach(({ id, ...restStats }) => {
+
+});
+
+function baz({id, ...restStats}) {
+}


### PR DESCRIPTION
Here we transpile:

```js
  var {...a} = b;
```

into

```js
  var a = <spread>(b);
```

This is a bit of a hack, as really the rest param here is equivalent to
ommitting unselected keys. However, there's no built-in within
ECMAScript to perform this omission beyond the object rest param.

Note that this will cause us to confuse the rest parameter in these two
cases:

  var {...a} = b;
  var {x, ...a} = b;

I'm leaving this as an existing wart for now.

The "spread_params.js" test case is updated (although this is a "rest",
rather than a "spread" parameter, with inverse functionality).

Fixes returntocorp/semgrep#581