### PR TITLE
Share build scripts among Dockerfile/CircleCI/GH-Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,14 @@ jobs:
     steps:
       - checkout
       - run:
-          - name: install opam deps
+          - name: Install opam dependencies
           - command: ./scripts/install-opam-deps
       - run:
-          - name: build
+          - name: Build
           - command: ./scripts/build
       - run:
-          - name: test
+          - name: Test
           - command: ./scripts/test
       - run:
-          - name: install
+          - name: Install
           - command: ./scripts/install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,13 @@
 version: 2.1
 jobs:
-  build:
+  build-and-test:
     docker:
       - image: returntocorp/sgrep-build:2.1
     steps:
       - checkout
-      - run: eval $(opam env); opam install grain_dypgen menhir; ./configure -novisual && make depend && make
-
-  test:
-    docker:
-      - image: returntocorp/sgrep-build:2.1
-    environment:
-        PFFF_HOME: /home/opam/project
-    steps:
-      - checkout
-      - run: eval $(opam env); opam install grain_dypgen menhir; ./configure -novisual && make depend && make test
-workflows:
-  version: 2.1
-  build_and_test:
-    jobs:
-      - build
-      - test
+      - run: ./scripts/install-opam-deps
+      - run: ./scripts/build
+      - run: ./scripts/test
+      - run: ./scripts/install
+# The previous config was defining a so-called workflow with two independent
+# jobs, 'build' and 'test', achieving some parallelism.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,5 +9,3 @@ jobs:
       - run: ./scripts/build
       - run: ./scripts/test
       - run: ./scripts/install
-# The previous config was defining a so-called workflow with two independent
-# jobs, 'build' and 'test', achieving some parallelism.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,14 @@ jobs:
     steps:
       - checkout
       - run:
-          - name: Install opam dependencies
-          - command: ./scripts/install-opam-deps
+          name: Install opam dependencies
+          command: ./scripts/install-opam-deps
       - run:
-          - name: Build
-          - command: ./scripts/build
+          name: Build
+          command: ./scripts/build
       - run:
-          - name: Test
-          - command: ./scripts/test
+          name: Test
+          command: ./scripts/test
       - run:
-          - name: Install
-          - command: ./scripts/install
+          name: Install
+          command: ./scripts/install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 jobs:
-  build-and-test:
+  build:
     docker:
       - image: returntocorp/sgrep-build:2.1
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,15 @@ jobs:
       - image: returntocorp/sgrep-build:2.1
     steps:
       - checkout
-      - run: ./scripts/install-opam-deps
-      - run: ./scripts/build
-      - run: ./scripts/test
-      - run: ./scripts/install
+      - run:
+          - name: install opam deps
+          - command: ./scripts/install-opam-deps
+      - run:
+          - name: build
+          - command: ./scripts/build
+      - run:
+          - name: test
+          - command: ./scripts/test
+      - run:
+          - name: install
+          - command: ./scripts/install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+#
+# Build pfff and set it up to run tests.
+#
+# This is meant as a reference on how to build the project. From the project's
+# root, run:
+#
+#   docker build -t pfff .
+#
+# Upon success, you can start bash within the container as follows:
+#
+#   docker run -it pfff
+#
+
+FROM ocaml/opam2:debian-stable
+COPY --chown=opam:opam . /home/opam/pfff
+WORKDIR /home/opam/pfff
+
+RUN ./scripts/setup-debian
+RUN ./scripts/install-opam-deps
+RUN ./scripts/build
+RUN ./scripts/test
+RUN ./scripts/install

--- a/scripts/build
+++ b/scripts/build
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+#
+# Group the few instructions to build pfff into one. This is meant to avoid
+# duplication in the various CI pipelines.
+#
+set -eu
+
+eval $(opam env)
+
+# Remove everything that's git-ignored so as to avoid surprises.
+git clean -dfX
+
+./configure --novisual --nocmt --nobytecode
+make depend
+make
+make opt

--- a/scripts/install
+++ b/scripts/install
@@ -1,0 +1,10 @@
+#! /usr/bin/env bash
+#
+# Install pfff. This is intended for CI.
+#
+set -eu
+
+sudo bash <<EOF
+eval $(opam env)
+make install
+EOF

--- a/scripts/install-opam-deps
+++ b/scripts/install-opam-deps
@@ -1,0 +1,76 @@
+#! /usr/bin/env bash
+#
+# Install external ocaml dependencies in an opam environment.
+#
+set -eu -o pipefail
+
+progname=$(basename "$0")
+
+usage() {
+  cat <<EOF
+Usage: $progname [OPTIONS]
+
+Install the prerequisites to build pfff, assuming opam is already installed.
+
+Options:
+  --help
+      Show this message and exit.
+
+  --ocaml-version VERSION
+      Use this version of ocaml, i.e. change the opam switch to one that
+      supports this specific version of ocaml. This is intended for CI.
+      For manual use, it is recommended to select the desired opam switch
+      manually; see 'opam switch --help'.
+EOF
+}
+
+error() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+# If left blank, use the current opam switch.
+ocaml_version=''
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)
+      usage
+      exit 0
+      ;;
+    --ocaml-version)
+      ocaml_version="$2"
+      shift
+      ;;
+    *)
+      error "Unsupported argument '$1'. Try '$progname --help'."
+  esac
+done
+
+if [[ -n "$ocaml_version" ]]; then
+  opam switch "$ocaml_version"
+fi
+
+eval $(opam env)
+
+packages="
+  conf-perl
+  grain_dypgen
+  json-wheel
+  menhir
+  ocamlgraph
+"
+
+# The docker images from the ocaml community ship with a stale (file://...)
+# opam repository and don't consult the live opam-repository hosted on github.
+# Here we try to detect whether we have at least one remote opam repository,
+# and we add one if needed. This allows us to get the recent versions of
+# packages we might need.
+#
+if ! (opam repo list | grep -q http); then
+  opam repo add --all -k git github \
+       https://github.com/ocaml/opam-repository.git
+fi
+
+opam update
+opam install $packages -y

--- a/scripts/setup-debian
+++ b/scripts/setup-debian
@@ -1,0 +1,51 @@
+#! /usr/bin/env bash
+#
+# Sets up opam and other prerequisites to compile ocaml code.
+# Assumes a Debian-like package manager.
+#
+set -eu
+
+progname=$(basename "$0")
+
+usage() {
+  cat <<EOF
+Usage: $progname [OPTIONS]
+
+Set up opam and other prerequisites to compile ocaml code on a Debian or
+Ubuntu system. If opam is already installed, nothing is done.
+
+Options:
+  --help
+      Show this message and exit.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unsupported argument '$1'. Try '$progname --help'." >&2
+      exit 1
+  esac
+  shift
+done
+
+if opam_version=$(opam --version 2>/dev/null); then
+  echo "Found opam $opam_version."
+else
+  echo "Installing opam."
+  sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh)
+fi
+
+# Install potentially-missing Debian/Ubuntu packages.
+#
+sudo apt-get update
+
+# Needed by some opam package
+sudo apt-get install m4 -y
+
+# Needed for running the pfff tests
+sudo apt-get install swi-prolog -y

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+#
+# Run all the tests. Intended for CI.
+#
+set -eu
+
+eval $(opam env)
+
+# TODO: this is a weird solution. We shouldn't have to install the test cases.
+prefix="/usr/local"
+share="$prefix/share"
+sudo mkdir -p share
+sudo ln -s "$(pwd)" $share/pfff
+
+make test

--- a/scripts/test
+++ b/scripts/test
@@ -5,11 +5,4 @@
 set -eu
 
 eval $(opam env)
-
-# TODO: this is a weird solution. We shouldn't have to install the test cases.
-prefix="/usr/local"
-share="$prefix/share"
-sudo mkdir -p share
-sudo ln -s "$(pwd)" $share/pfff
-
-make test
+PFFF_HOME=$(pwd) make test


### PR DESCRIPTION
* I added a simple Dockerfile to serve as a model on how to build the project (addresses #114). The little quirks are buried in scripts `./scripts/build` etc.
* The CircleCI config now uses the new scripts. It works.
* ~~The GitHub Actions config also uses the new scripts. I don't know if it works.~~

~~It would be good to test the new GH-Actions config before merging into master. I don't know if it's possible. Note that it's also going to be slower than CircleCI because it rebuilds all the opam base each time. Or maybe there's an easy way to specify a custom base docker image like we do with CircleCI? I would like to say that the GitHub Actions documentation pales in comparison to CircleCI.~~

Update: I gave up on fixing things for GitHub Actions. I can't make something clean for this. The current config will do. I recommend not using GitHub Actions at all or find a way to use the base docker image of our choice.
