### PR TITLE
Java parsing: Allow access to new array with an initializer.

### DIFF
--- a/lang_java/parsing/parser_java.mly
+++ b/lang_java/parsing/parser_java.mly
@@ -12,6 +12,10 @@
  * Many modifications by Yoann Padioleau. Attempts to conform to:
  * The Java Language Specification, Third Edition, with some fixes from
  * http://www.cmis.brighton.ac.uk/staff/rnb/bosware/javaSyntax/syntaxV2.html
+ * (broken link)
+ *
+ * Official (but incomplete) specification as of Java 14:
+ * https://docs.oracle.com/javase/specs/jls/se14/html/jls-19.html
  *
  * More modifications by Yoann Padioleau to support more recent versions.
  * Copyright (C) 2011 Facebook
@@ -463,12 +467,22 @@ class_instance_creation_expression:
  | name DOT NEW identifier LP argument_list_opt RP class_body_opt
        { NewQualifiedClass ((Name (name $1)), $3, $4, $6, $8) }
 
+/*
+   A new array that cannot be accessed right away by appending [index]:
+
+    new String[2][1]  // a 2-dimensional array
+*/
 array_creation_expression:
  | NEW primitive_type dim_exprs dims_opt
        { NewArray ($1, $2, List.rev $3, $4, None) }
  | NEW name dim_exprs dims_opt
        { NewArray ($1, TClass (class_type ($2)), List.rev $3, $4, None) }
 
+/*
+   A new array that can be accessed right away by appending [index] as follows:
+
+    new String[] { "abc", "def" }[1]  // a string
+*/
 array_creation_expression_with_initializer:
  | NEW primitive_type dims array_initializer
        { NewArray ($1, $2, [], $3, Some $4) }

--- a/lang_java/parsing/parser_java.mly
+++ b/lang_java/parsing/parser_java.mly
@@ -434,6 +434,8 @@ primary_no_new_array:
  | class_literal       { $1 }
  /*(* javaext: ? *)*/
  | method_reference { $1 }
+ /*(* javaext: ? *) */
+ | array_creation_expression_with_initializer { $1 }
 
 literal:
  | TRUE   { Literal (Bool (true, $1)) }
@@ -466,7 +468,8 @@ array_creation_expression:
        { NewArray ($1, $2, List.rev $3, $4, None) }
  | NEW name dim_exprs dims_opt
        { NewArray ($1, TClass (class_type ($2)), List.rev $3, $4, None) }
- /*(* javaext: ? *)*/
+
+array_creation_expression_with_initializer:
  | NEW primitive_type dims array_initializer
        { NewArray ($1, $2, [], $3, Some $4) }
  | NEW name dims array_initializer

--- a/tests/java/parsing/NewArrayAccess.java
+++ b/tests/java/parsing/NewArrayAccess.java
@@ -1,0 +1,9 @@
+// NewArrayAccess.java
+//
+// Compare to: NewArrayMultidim.java
+//
+public class NewArrayAccess {
+    static String get(int index) {
+        return new String[] { "Courier", "Impact" }[index];
+    }
+}

--- a/tests/java/parsing/NewArrayMultidim.java
+++ b/tests/java/parsing/NewArrayMultidim.java
@@ -1,0 +1,6 @@
+// NewArrayMultidim.java
+public class NewArrayMultidim {
+    static String[][] get(int index) {
+        return new String[3][index];
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/returntocorp/semgrep/issues/906

My understanding is that this construct falls outside of the official grammar specification, but it is implemented in javac and we have to support it.