### PR TITLE
Properly parse python2 "except Exception, ex:" handler

### DIFF
--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -579,6 +579,8 @@ excepthandler:
   | EXCEPT              ":" suite { ExceptHandler ($1, None, None, $3) }
   | EXCEPT test         ":" suite { ExceptHandler ($1, Some $2, None, $4) }
   | EXCEPT test AS NAME ":" suite { ExceptHandler ($1, Some $2, Some $4, $6)}
+  (* python2: *)
+  | EXCEPT test "," NAME ":" suite { ExceptHandler ($1, Some $2, Some $4, $6) }
 
 with_stmt: WITH with_inner { $2 $1 }
 

--- a/tests/python/parsing/python2/raise.py
+++ b/tests/python/parsing/python2/raise.py
@@ -1,0 +1,9 @@
+try:
+    foo()
+except Exception, ex:
+    print ex
+
+try:
+    foo()
+except Exception as ex:
+    print ex


### PR DESCRIPTION
In Python2, exceptions can be named with either a comma or an "as",
whereas in Python3 only "as" is allowed.

This commit extends pfff to recognize the comma Python2 syntax.

For information on the Python 2 grammar, see:
  https://docs.python.org/2/reference/grammar.html

For information on the Python 3 grammar, see:
  https://docs.python.org/3/reference/grammar.html

Fixes https://github.com/returntocorp/semgrep/issues/926