### PR TITLE
Fix infinite loop in AST_generic naming phase

### DIFF
--- a/lang_GENERIC/analyze/Makefile
+++ b/lang_GENERIC/analyze/Makefile
@@ -14,7 +14,7 @@ SRC= \
   IL.ml CFG.ml Meta_IL.ml AST_to_IL.ml CFG_build.ml \
   Dataflow_tainting.ml \
   Test_analyze_generic.ml \
-  Unit_typing_generic.ml
+  Unit_naming_generic.ml Unit_typing_generic.ml
 
 -include $(TOP)/Makefile.config
 

--- a/lang_GENERIC/analyze/Unit_naming_generic.ml
+++ b/lang_GENERIC/analyze/Unit_naming_generic.ml
@@ -1,0 +1,38 @@
+open Common
+open OUnit
+
+(*****************************************************************************)
+(* Unit tests *)
+(*****************************************************************************)
+
+let unittest =
+  "naming generic" >::: [
+
+    "regression files" >:: (fun () ->
+
+      let dir = Filename.concat Config_pfff.path "/tests/python/naming" in
+      let files1 = Common2.glob (spf "%s/*.py" dir) in
+      let dir = Filename.concat Config_pfff.path "/tests/go/naming" in
+      let files2 = Common2.glob (spf "%s/*.go" dir) in
+      let dir = Filename.concat Config_pfff.path "/tests/js/naming" in
+      let files3 = Common2.glob (spf "%s/*.js" dir) in
+      let dir = Filename.concat Config_pfff.path "/tests/java/naming" in
+      let files4 = Common2.glob (spf "%s/*.java" dir) in
+
+      (files1 @ files2 @ files3 @ files4) |> List.iter (fun file ->
+        try
+        (* at least we can assert we don't thrown an exn or go 
+         * into infinite loops *)
+         let ast = Parse_generic.parse_program file in
+         let lang = List.hd (Lang.langs_of_filename file) in
+         Naming_AST.resolve lang ast;
+         (* this used to loop forever if you were not handling correctly
+          * possible cycles with id_type *)
+         let _v = Meta_AST.vof_any (AST_generic.Pr ast) in
+         ()
+        with Parse_info.Parsing_error _ ->
+          assert_failure (spf "it should correctly parse %s" file)
+      )
+    );
+ 
+ ]

--- a/lang_GENERIC/analyze/Unit_naming_generic.mli
+++ b/lang_GENERIC/analyze/Unit_naming_generic.mli
@@ -1,0 +1,5 @@
+(* Returns the testsuite for the current directory. To be concatenated by 
+ * the caller (e.g. in pfff/main_test.ml ) with other testsuites and 
+ * run via OUnit.run_test_tt 
+ *)
+val unittest: OUnit.test

--- a/main_test.ml
+++ b/main_test.ml
@@ -84,7 +84,8 @@ let test regexp =
       Unit_parsing_cpp.unittest;
       Unit_parsing_go.unittest;
 
-      (* typing tests *)
+      (* generic AST tests *)
+      Unit_naming_generic.unittest;
       Unit_typing_generic.unittest;
     ]
   in

--- a/tests/python/naming/shadow_name_type.py
+++ b/tests/python/naming/shadow_name_type.py
@@ -1,0 +1,7 @@
+import email.message as message
+
+def process_message(message: message.Message):
+    if 1:
+        message
+    else:
+        message


### PR DESCRIPTION
This should fix https://github.com/returntocorp/semgrep/issues/923

The issue was that we now annotate certain expression Id with their type,
but in some languages such as Python where there is no clean types,
they use expressions to represent type and those type can then contain
Id that will get associate a type and create cycle in the generic AST,
which then lead certain code (e.g., dumper) to loop forever.

test plan:
regression tests included
make test
~/pfff/pfff -naming_generic shadow_...py does not loop forever anymore