### PR TITLE
Separate var definition from field definition

### DIFF
--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -940,11 +940,23 @@ and definition = entity * definition_kind
      * in a header file (called a prototype in C).
      *)
     | FuncDef   of function_definition
-    (* newvar: can be used also for constants, fields.
+    (* newvar: can be used also for constants.
      * can contain special_multivardef_pattern ident in which case vinit
      * is the pattern assignment.
      *)
     | VarDef    of variable_definition
+    (* FieldDef can only be present inside a record/class (in a FieldStmt).
+     * This used to be merged with VarDef, but in semgrep we don't want
+     * a VarDef to match a field definition.
+     * Note that we could have used a FieldVar in the field type instead
+     * of this FieldDef here, which would be more precise, but 
+     * this complicates things in semgrep where it's convenient to have
+     * a uniform FieldStmt(DefStmt) that covers field and methods
+     * (see m_list__m_field in semgrep).
+     * Note that FieldDef where vinit is a Lambda should really be converted
+     * in a FuncDef instead.
+     *)
+    | FieldDef  of variable_definition
     | ClassDef  of class_definition
     (*s: [[AST_generic.definition_kind]] other cases *)
     | TypeDef   of type_definition
@@ -1109,10 +1121,13 @@ and type_definition = {
   * note: I don't call it field_definition because it's used both to
   * define the shape of a field (a definition), and when creating
   * an actual field (a value).
-  * old: there used to be a FieldVar and FieldMethod similar to
-  * VarDef and FuncDef but they are now instead in FieldStmt(DefStmt).
-  * this simplifies sgrep too so that a function pattern can match
+  * old: there used to be a FieldVar and FieldMethod similar to 
+  * VarDef and FuncDef but they are now converted into a FieldStmt(DefStmt).
+  * This simplifies semgrep so that a function pattern can match
   * toplevel functions, nested functions, and methods.
+  * Note that for FieldVar we ultimately converted it to a FieldDef 
+  * (which is very similar to a VarDef) because some people don't want a VarDef
+  * to match a field definition.
   * Note: the FieldStmt(DefStmt(FuncDef(...))) can have empty body
   * for interface methods.
   *)
@@ -1399,7 +1414,7 @@ let basic_entity id attrs = {
 (*s: function [[AST_generic.basic_field]] *)
 let basic_field id vopt typeopt =
   let entity = basic_entity id [] in
-  FieldStmt(DefStmt(entity, VarDef { vinit = vopt; vtype = typeopt}))
+  FieldStmt(DefStmt (entity, FieldDef { vinit = vopt; vtype = typeopt}))
 (*e: function [[AST_generic.basic_field]] *)
 
 (*s: function [[AST_generic.attr]] *)

--- a/lang_GENERIC/parsing/Map_AST.ml
+++ b/lang_GENERIC/parsing/Map_AST.ml
@@ -582,6 +582,7 @@ and map_definition_kind =
   function
   | FuncDef v1 -> let v1 = map_function_definition v1 in FuncDef ((v1))
   | VarDef v1 -> let v1 = map_variable_definition v1 in VarDef ((v1))
+  | FieldDef v1 -> let v1 = map_variable_definition v1 in FieldDef ((v1))
   | ClassDef v1 -> let v1 = map_class_definition v1 in ClassDef ((v1))
   | TypeDef v1 -> let v1 = map_type_definition v1 in TypeDef ((v1))
   | ModuleDef v1 -> let v1 = map_module_definition v1 in ModuleDef ((v1))

--- a/lang_GENERIC/parsing/Meta_AST.ml
+++ b/lang_GENERIC/parsing/Meta_AST.ml
@@ -757,6 +757,8 @@ and vof_definition_kind =
       let v1 = vof_function_definition v1 in OCaml.VSum (("FuncDef", [ v1 ]))
   | VarDef v1 ->
       let v1 = vof_variable_definition v1 in OCaml.VSum (("VarDef", [ v1 ]))
+  | FieldDef v1 ->
+      let v1 = vof_variable_definition v1 in OCaml.VSum (("FieldDef", [ v1 ]))
   | ClassDef v1 ->
       let v1 = vof_class_definition v1 in OCaml.VSum (("ClassDef", [ v1 ]))
   | TypeDef v1 ->
@@ -887,6 +889,7 @@ and vof_field =
       let v1 = vof_expr v1 in OCaml.VSum (("FieldSpread", [ t; v1 ]))
   | FieldStmt v1 ->
       let v1 = vof_stmt v1 in OCaml.VSum (("FieldStmt", [ v1 ]))
+
 and vof_type_definition { tbody = v_tbody } =
   let bnds = [] in
   let arg = vof_type_definition_kind v_tbody in

--- a/lang_GENERIC/parsing/Visitor_AST.ml
+++ b/lang_GENERIC/parsing/Visitor_AST.ml
@@ -535,6 +535,7 @@ and v_def_kind =
   function
   | FuncDef v1 -> let v1 = v_function_definition v1 in ()
   | VarDef v1 -> let v1 = v_variable_definition v1 in ()
+  | FieldDef v1 -> let v1 = v_variable_definition v1 in ()
   | ClassDef v1 -> let v1 = v_class_definition v1 in ()
   | TypeDef v1 -> let v1 = v_type_definition v1 in ()
   | ModuleDef v1 -> let v1 = v_module_definition v1 in ()

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -410,7 +410,8 @@ and property x =
         let ent = G.basic_entity n v2 in
        (* todo: could be a Lambda in which case we should return a FuncDef? *)
         G.FieldStmt (G.DefStmt 
-                ((ent, G.VarDef { G.vinit = v3; vtype = None })))
+                ((ent, G.FieldDef { G.vinit = v3; vtype = None })))
+
       | Right e -> 
         (match v3 with
          | None -> raise Impossible

--- a/lang_ml/analyze/ml_to_generic.ml
+++ b/lang_ml/analyze/ml_to_generic.ml
@@ -304,7 +304,8 @@ and type_def_kind =
                | Some tok -> [G.attr G.Mutable tok] 
                | None -> []) in
             G.FieldStmt (G.DefStmt
-             (ent, G.VarDef { G.vinit = None; vtype = Some v2 }))))
+             (ent, G.FieldDef { G.vinit = None; vtype = Some v2 }))
+            ))
           v1
       in G.AndType v1
   

--- a/tests/js/parsing/class_field_vs_method.js
+++ b/tests/js/parsing/class_field_vs_method.js
@@ -1,0 +1,8 @@
+class Hello {
+    
+    test() {
+	    console.log(x);
+    }
+    
+}
+


### PR DESCRIPTION
This should help fix https://github.com/returntocorp/semgrep/issues/941

In semgrep we don't want var definition
(or assignment, which are matched against var definition) to match
field definitions.

This slightly reverts 4df9110328bcccd27eaafc72acf0038f1272f691
but use a FieldDef instead of a FieldVar which helps keep
the code in semgrep short.

Test plan:
test file included