### PR TITLE
Remove use of Pervasives

### DIFF
--- a/lang_ruby/analyze/dQueue.ml
+++ b/lang_ruby/analyze/dQueue.ml
@@ -99,7 +99,7 @@ let cmp c ((f1,r1) as l1) ((f2,r2) as l2) = match r1,r2 with
   | [],[] -> compare_list c f1 f2
   | _ -> compare_list c (to_list l1) (to_list l2)
 
-let compare q1 q2 = cmp Pervasives.compare q1 q2
+let compare q1 q2 = cmp Stdlib.compare q1 q2
 
 let list_to_string to_s = function
   | [] -> "[]"

--- a/lang_ruby/parsing/ast_ruby_helpers.ml
+++ b/lang_ruby/parsing/ast_ruby_helpers.ml
@@ -6,7 +6,7 @@ module Utils = Utils_ruby
 (* Comparators *)
 (*****************************************************************************)
 
-let pcompare = Pervasives.compare
+let pcompare = Stdlib.compare
 
 let cmp2 = Utils.cmp2
 let cmp_list = Utils.cmp_list

--- a/lang_ruby/parsing/utils_ruby.ml
+++ b/lang_ruby/parsing/utils_ruby.ml
@@ -10,10 +10,10 @@ let cmp_ctors e1 e2 =
   let o1 = Obj.repr e1 in
   let o2 = Obj.repr e2 in
     match Obj.is_int o1, Obj.is_int o2 with
-      | true,true -> Pervasives.compare e1 e2
+      | true,true -> Stdlib.compare e1 e2
       | true,false -> -1
       | false,true -> 1
-      | false,false -> Pervasives.compare (Obj.tag o1) (Obj.tag o2)
+      | false,false -> Stdlib.compare (Obj.tag o1) (Obj.tag o2)
 
 let cmp2 c1 f a1 a2 = match c1 with
   | 0 -> f a1 a2
@@ -23,7 +23,7 @@ let cmp_list cmp el1 el2 =
   try List.fold_left2 (fun acc e1 e2 -> cmp2 acc cmp e1 e2) 0 el1 el2
   with Invalid_argument _ -> 
     (* different sized lists *)
-    Pervasives.compare (List.length el1) (List.length el2)
+    Stdlib.compare (List.length el1) (List.length el2)
 
 let default_opt def opt = match opt with 
   | None -> def


### PR DESCRIPTION
This does not work anymore in 4.10.0
and we don't care about ocaml < 4.07

test plan:
git grep Pervasives.
but we should really use semgrep for ocaml in CI to prevent those!
especially since the one remaining are in comments :)