### PR TITLE
Fix tokens in Import for JS

### DIFF
--- a/lang_js/analyze/ast_js.ml
+++ b/lang_js/analyze/ast_js.ml
@@ -353,12 +353,12 @@ type module_directive =
    * See Module_path_js to resolve paths.
    *)
   | Import of tok * name * name option (* 'name1 as name2' *) * filename
-  | Export of name
+  | Export of tok * name
 
   (* hard to unsugar in Import because we do not have the list of names *)
   | ModuleAlias of tok * name * filename (* import * as 'name' from 'file' *)
 
-  | ImportCss of filename
+  | ImportCss of tok * filename
   (* those should not exist (except for sgrep where they are useful) *)
   | ImportEffect of tok * filename
 

--- a/lang_js/analyze/ast_js_build.ml
+++ b/lang_js/analyze/ast_js_build.ml
@@ -155,17 +155,15 @@ and module_item env = function
          let tok = first_tok_of_item x in
          A.S (tok, res)
     )
-  | C.Import (_, x, _) -> import env x |> List.map (fun x -> A.M x)
+  | C.Import (tok, x, _) -> import env tok x |> List.map (fun x -> A.M x)
   | C.Export (tok, x) ->  export env tok x
 
-and import env = function
-  | C.ImportEffect ((file, tok)) ->
-     (* TODO: reusing the tok of the file for the import kwd, bad *)
-     let t0 = tok in
+and import env tok = function
+  | C.ImportEffect ((file, tok2)) ->
      if file =~ ".*\\.css$"
-     then [A.ImportCss (file, tok)]
-     else [A.ImportEffect (t0, (file, tok))]
-  | C.ImportFrom ((default_opt, names_opt), (tok, path)) ->
+     then [A.ImportCss (tok, (file, tok2))]
+     else [A.ImportEffect (tok, (file, tok2))]
+  | C.ImportFrom ((default_opt, names_opt), (_tok2, path)) ->
     let file = path_to_file path in
     (match default_opt with
     | Some n -> 
@@ -196,59 +194,59 @@ and import env = function
      )
 
 and export env tok = function
- | C.ExportDefaultExpr (tok, e, _)  -> 
+ | C.ExportDefaultExpr (tok2, e, _)  -> 
    let e = expr env e in
-   let n = A.default_entity, tok in
+   let n = A.default_entity, tok2 in
    let v = {A.v_name = n; v_kind = A.Const, tok; v_init = Some e; 
             v_resolved = not_resolved () } in
-   [A.V v; A.M (A.Export (n))]
+   [A.V v; A.M (A.Export (tok, n))]
  | C.ExportDecl x ->
    let xs = item None env x in
    xs |> List.map (function
     | A.VarDecl v -> 
-         [A.V v; A.M (A.Export (v.A.v_name))]
+         [A.V v; A.M (A.Export (tok, v.A.v_name))]
     | _ -> raise (UnhandledConstruct ("exporting a stmt", tok))
    ) |> List.flatten
- | C.ExportDefaultDecl (tok, x) ->
+ | C.ExportDefaultDecl (tok2, x) ->
    (* this is ok to have anonymous entities here *)
-   let xs = item (Some tok) env x in
+   let xs = item (Some tok2) env x in
    xs |> List.map (function
     | A.VarDecl v -> 
-        [A.V v;  A.M (A.Export (v.A.v_name))]
+        [A.V v;  A.M (A.Export (tok,v.A.v_name))]
     | _ -> raise (UnhandledConstruct ("exporting a stmt", tok))
    ) |> List.flatten
  | C.ExportNames (xs, _) ->
    xs |> C.unparen |> C.uncomma |> List.map (fun (n1, n2opt) ->
      let n1 = name env n1 in
      match n2opt with
-     | None -> [A.M (A.Export (n1))]
+     | None -> [A.M (A.Export (tok, n1))]
      | Some (_, n2) -> 
          let n2 = name env n2 in
          let id = A.Id (n1, not_resolved ()) in
          let v = { A.v_name = n2; v_kind = A.Const, fake "const"; 
                    v_init = Some id;
                    v_resolved = not_resolved () } in
-         [A.V v; A.M (A.Export n2)]
+         [A.V v; A.M (A.Export (tok, n2))]
   ) |> List.flatten
- | C.ReExportNames (xs, (tok, path), _) ->
+ | C.ReExportNames (xs, (tok2, path), _) ->
    xs |> C.unbrace |> C.uncomma |> List.map (fun (n1, n2opt) ->
      let n1 = name env n1 in
      let tmpname = ("!tmp_" ^ fst n1, snd n1) in
      let file = path_to_file path in
-     let import = A.Import (tok, n1, Some tmpname, file) in
+     let import = A.Import (tok2, n1, Some tmpname, file) in
      let id = A.Id (tmpname, not_resolved()) in
      match n2opt with
      | None -> 
        let v = { A.v_name = n1; v_kind = A.Const, fake "const"; 
                   v_init = Some id; 
                   v_resolved = not_resolved () } in
-       [A.M import; A.V v; A.M (A.Export n1)]
+       [A.M import; A.V v; A.M (A.Export (tok, n1))]
      | Some (_, n2) ->
        let n2 = name env n2 in
        let v = { A.v_name = n2; v_kind = A.Const, fake "const"; 
                   v_init = Some id; 
                   v_resolved = not_resolved () } in
-       [A.M import; A.V v; A.M (A.Export n2)]
+       [A.M import; A.V v; A.M (A.Export (tok, n2))]
    ) |> List.flatten
 
  | C.ReExportNamespace (_, _, _) ->

--- a/lang_js/analyze/graph_code_js.ml
+++ b/lang_js/analyze/graph_code_js.ml
@@ -355,7 +355,7 @@ and module_directive env x =
         Hashtbl.replace env.imports str2 (mk_qualified_name readable str1)
       )
     end
-  | Export (name) -> 
+  | Export (_t, name) -> 
      if env.phase = Defs then begin
        let exports =
          try 
@@ -371,7 +371,7 @@ and module_directive env x =
        *)
       let s = s_of_n name in
       Hashtbl.replace env.vars s true;
-  | ImportCss (_file) -> ()
+  | ImportCss (_t, _file) -> ()
   | ImportEffect (_, _file) -> ()
 
 and toplevels env xs = List.iter (toplevel env) xs

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -448,7 +448,7 @@ and module_directive x =
   | ModuleAlias ((t, v1, v2)) ->
       let v1 = name v1 and v2 = filename v2 in
       G.ImportAs (t, G.FileName v2, Some v1)
-  | ImportCss ((v1)) ->
+  | ImportCss ((_t, v1)) ->
       let v1 = name v1 in
       G.OtherDirective (G.OI_ImportCss, [G.I v1])
   (* sgrep: we used to convert this in an OI_ImportEffect, but
@@ -458,7 +458,7 @@ and module_directive x =
       let v1 = name v1 in
       (* old: G.OtherDirective (G.OI_ImportEffect, [G.I v1]) *)
       G.ImportAs (t, G.FileName v1, None)
-  | Export ((v1)) -> let v1 = name v1 in
+  | Export ((_t, v1)) -> let v1 = name v1 in
       G.OtherDirective (G.OI_Export, [G.I v1])
 
 and program v = list toplevel v

--- a/lang_js/analyze/map_ast_js.ml
+++ b/lang_js/analyze/map_ast_js.ml
@@ -362,9 +362,10 @@ and map_module_directive =
       and v2 = map_of_option map_name v2
       and v3 = map_filename v3
       in Import ((t, v1, v2, v3))
-  | ImportCss ((v1)) ->
+  | ImportCss ((t, v1)) ->
+      let t = map_tok t in
       let v1 = map_name v1
-      in ImportCss ((v1))
+      in ImportCss ((t, v1))
   | ImportEffect ((v0, v1)) ->
       let v0 = map_tok v0 in
       let v1 = map_name v1
@@ -374,7 +375,9 @@ and map_module_directive =
       let v1 = map_name v1
       and v2 = map_filename v2
       in ModuleAlias ((t, v1, v2))
-  | Export v1 -> let v1 = map_name v1 in Export ((v1))
+  | Export (t, v1) -> 
+      let t = map_tok t in
+      let v1 = map_name v1 in Export ((t, v1))
   
 and map_program v = map_of_list map_toplevel v
   

--- a/lang_js/analyze/meta_ast_js.ml
+++ b/lang_js/analyze/meta_ast_js.ml
@@ -353,16 +353,18 @@ let vof_module_directive =
       let v1 = vof_name v1
       and v2 = vof_filename v2
       in OCaml.VSum (("ModuleAlias", [ t; v1; v2 ]))
-  | ImportCss ((v1)) ->
+  | ImportCss ((t, v1)) ->
+      let t =  vof_tok t in
       let v1 = vof_filename v1
-      in OCaml.VSum (("ImportCss", [ v1 ]))
+      in OCaml.VSum (("ImportCss", [ t; v1 ]))
   | ImportEffect ((v0, v1)) ->
       let v0 = vof_tok v0 in
       let v1 = vof_filename v1
       in OCaml.VSum (("ImportEffect", [ v0; v1 ]))
-  | Export ((v1)) ->
+  | Export ((t, v1)) ->
+      let t =  vof_tok t in
       let v1 = vof_name v1
-      in OCaml.VSum (("Export", [ v1 ]))
+      in OCaml.VSum (("Export", [ t; v1 ]))
   
 let vof_toplevel =
   function

--- a/lang_js/analyze/visitor_ast_js.ml
+++ b/lang_js/analyze/visitor_ast_js.ml
@@ -305,7 +305,8 @@ and v_module_directive x =
   | Import ((t, v1, v2, v3)) ->
       let t = v_tok t in
       let v1 = v_name v1 and v2 = v_option v_name v2 and v3 = v_filename v3 in ()
-  | ImportCss ((v1)) ->
+  | ImportCss ((t, v1)) ->
+      let t = v_tok t in
       let v1 = v_name v1 in ()
   | ImportEffect ((v0, v1)) ->
       let v0 = v_tok v0 in
@@ -313,7 +314,9 @@ and v_module_directive x =
   | ModuleAlias ((t, v1, v2)) ->
       let t = v_tok t in
       let v1 = v_name v1 and v2 = v_filename v2 in ()
-  | Export ((v1)) -> let v1 = v_name v1 in ()
+  | Export ((t, v1)) -> 
+      let t = v_tok t in
+      let v1 = v_name v1 in ()
 
 and v_any =
   function

--- a/tests/js/parsing/import_tokens.js
+++ b/tests/js/parsing/import_tokens.js
@@ -1,0 +1,1 @@
+import isPromise from 'is-promise';


### PR DESCRIPTION
this closes issue https://github.com/returntocorp/semgrep/issues/820

Test plan:
+ /home/pad/pfff/pfff -dump_ast -full_token_info import_tokens.js
Pr(
  [DirectiveStmt(
     ImportFrom(
       {
        token=OriginTok(
                {str="import"; charpos=0; line=1; column=0;
                 file="import_tokens.js"; });
        transfo=NoTransfo; },
 ...

there is now the "import" token, not the "from" token anymore