### PR TITLE
Start using ppx_deriving and introduce new -show_ml action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
     - name: debugging
       run: opam --version
     - name: Install pfff
-      run: opam init && opam switch create 4.07.1 && opam switch 4.07.1 && eval $(opam env) && opam install -y ocaml-migrate-parsetree ocaml-migrate-parsetree.1.3.1 && opam install -y menhir grain_dypgen && opam install -y pfff
+      run: opam init && opam switch create 4.07.1 && opam switch 4.07.1 && eval $(opam env) && opam install -y ocaml-migrate-parsetree ocaml-migrate-parsetree.1.3.1 && opam install -y menhir grain_dypgen ppx_deriving && opam install -y pfff
     - name: Run Tests
       run: eval $(opam env); export PFFF_HOME=`pwd`; ./configure -novisual && make depend && make test

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ DYPCMA=external/dyp/dyp.cma
 GRAPHCMA=external/ocamlgraph/graph.cma commons_wrappers/graph/lib.cma
 GRAPHDIRS=commons_wrappers/graph 
 
-
+DERIVINGCMA=external/ppx_deriving/ppx_deriving_runtime.cma
 
 #------------------------------------------------------------------------------
 # Main variables
@@ -57,7 +57,7 @@ LIBS= commons/lib.cma \
        $(JSONCMA) \
        $(DYPCMA) \
        $(GRAPHCMA) \
-       $(EXTLIBCMA) $(PTCMA) $(ZIPCMA) $(JAVALIBCMA) \
+       $(EXTLIBCMA) $(PTCMA) $(ZIPCMA) $(JAVALIBCMA) $(DERIVINGCMA) \
     globals/lib.cma \
     h_files-format/lib.cma \
     h_program-lang/lib.cma \
@@ -172,6 +172,7 @@ INCLUDEDIRS=$(MAKESUBDIRS) \
  external/deps-netsys \
  external/json-wheel \
  external/dyp \
+ external/ppx_deriving \
  commons_wrappers/graph \
 
 # cpp causes some 'warning: missing terminating' errors

--- a/external/ppx_deriving
+++ b/external/ppx_deriving
@@ -1,0 +1,1 @@
+OPAM_DIR/lib/ppx_deriving/runtime

--- a/lang_ml/analyze/Makefile
+++ b/lang_ml/analyze/Makefile
@@ -22,6 +22,7 @@ LIBS=$(TOP)/commons/lib.cma \
      ../parsing/lib.cma \
 
 INCLUDEDIRS= $(TOP)/commons \
+   $(TOP)/external/ppx_deriving \
    $(TOP)/commons_ocollection \
    $(TOP)/commons_core \
    $(TOP)/globals \
@@ -53,5 +54,7 @@ $(TARGET).top: $(OBJS) $(LIBS)
 clean::
 	rm -f $(TARGET).top
 
-#ml_to_generic.cmo: ml_to_generic.ml
-#	ocamlc $(INCLUDES) -c $^
+ast_ml.cmo: ast_ml.ml
+	ocamlfind ocamlc -c $(OCAMLCFLAGS) $(INCLUDES) -package ppx_deriving.show ast_ml.ml
+ast_ml.cmx: ast_ml.ml
+	ocamlfind ocamlopt -c $(OCAMLCFLAGS) $(INCLUDES) -package ppx_deriving.show ast_ml.ml

--- a/lang_ml/analyze/ast_ml.ml
+++ b/lang_ml/analyze/ast_ml.ml
@@ -31,25 +31,26 @@
 (* ------------------------------------------------------------------------- *)
 type tok = Parse_info.t
  (* with tarzan *)
+let pp_tok = Cst_ml.pp_tok
 
 (* a shortcut to annotate some information with token/position information *)
 type 'a wrap = 'a * tok
- (* with tarzan *)
+ [@@deriving show] (* with tarzan *)
 
 (* round(), square[], curly{}, angle<> brackets *)
 type 'a bracket = tok * 'a * tok
- (* with tarzan *)
+ [@@deriving show] (* with tarzan *)
 
 (* ------------------------------------------------------------------------- *)
 (* Names  *)
 (* ------------------------------------------------------------------------- *)
 
 type ident = string wrap
- (* with tarzan *)
+ [@@deriving show] (* with tarzan *)
 
 type name = qualifier * ident
  and qualifier = ident list (* TODO: functor? *)
- (* with tarzan *)
+ [@@deriving show] (* with tarzan *)
 
 (* ------------------------------------------------------------------------- *)
 (* Types *)
@@ -66,7 +67,7 @@ type type_ =
 
   | TyTodo of tok
 
- (* with tarzan *)
+ [@@deriving show { with_path = false} ] (* with tarzan *)
 
 (* ------------------------------------------------------------------------- *)
 (* Expressions *)
@@ -182,8 +183,8 @@ and let_binding =
  and parameter = 
    | Param of pattern
    | ParamTodo of tok
-
- (* with tarzan *)
+ 
+ [@@deriving show { with_path = false} ]  (* with tarzan *)
 
 (* ------------------------------------------------------------------------- *)
 (* Type declaration *)
@@ -205,7 +206,7 @@ type type_declaration = {
    (* and type *)
    | RecordType   of (ident * type_ * tok option (* mutable *)) list bracket
 
- (* with tarzan *)
+ [@@deriving show { with_path = false} ] (* with tarzan *)
 
 (* ------------------------------------------------------------------------- *)
 (* Class *)
@@ -251,11 +252,10 @@ and item =
 
   | ItemTodo of tok
 
- (* with tarzan *)
+ [@@deriving show { with_path = false} ] (* with tarzan *)
       
 type program = item list
-
- (* with tarzan *)
+ [@@deriving show ] (* with tarzan *)
 
 (*****************************************************************************)
 (* Any *)
@@ -269,7 +269,7 @@ type any =
   | I of item
   | Pr of program
 
-  (* with tarzan *)
+ [@@deriving show { with_path = false} ] (* with tarzan *)
 
 (*****************************************************************************)
 (* Wrappers *)
@@ -281,3 +281,4 @@ let info_of_ident (_,info) = info
 let ident_of_name (_, ident) = ident
 let qualifier_of_name (qu, _) = 
   qu |> List.map str_of_ident |> Common.join "."
+

--- a/lang_ml/analyze/test_analyze_ml.ml
+++ b/lang_ml/analyze/test_analyze_ml.ml
@@ -1,3 +1,5 @@
+open Common
+
 (*****************************************************************************)
 (* Subsystem testing *)
 (*****************************************************************************)
@@ -24,9 +26,20 @@ let test_parse_ast_ml xs =
       )))
     with exn -> raise exn
   ))
+
+let test_dump_ml file =
+  let cst = Parse_ml.parse_program file in
+  let ast = Ast_ml_build.program cst in
+  let s = Ast_ml.show_program ast in
+  pr2 s
   
+(*****************************************************************************)
+(* Main entry for Arg *)
+(*****************************************************************************)
 
 let actions () = [
   "-parse_ast_ml", "   <files or dirs>",
   Common.mk_action_n_arg test_parse_ast_ml;
+  "-dump_ast_ml", "   <file>",
+  Common.mk_action_1_arg test_dump_ml;
 ]

--- a/lang_ml/parsing/Makefile
+++ b/lang_ml/parsing/Makefile
@@ -22,6 +22,7 @@ LIBS=$(TOP)/commons/lib.cma \
  $(TOP)/h_program-lang/lib.cma \
 
 INCLUDEDIRS= $(TOP)/commons \
+  $(TOP)/external/ppx_deriving \
   $(TOP)/commons_core \
   $(TOP)/globals \
   $(TOP)/h_program-lang \
@@ -51,6 +52,13 @@ $(TARGET).cmxa: $(OPTOBJS) $(LIBS:.cma=.cmxa)
 	$(OCAMLOPT) -a -o $(TARGET).cmxa $(OPTOBJS)
 $(TARGET).top: $(OBJS) $(LIBS)
 	$(OCAMLMKTOP) -o $(TARGET).top $(SYSLIBS) $(LIBS) $(OBJS)
+
+# to see the actual expanded source, use -dsource instead of -c below
+cst_ml.cmo: cst_ml.ml
+	ocamlfind ocamlc -c $(OCAMLCFLAGS) $(INCLUDES) -package ppx_deriving.show cst_ml.ml
+
+cst_ml.cmx: cst_ml.ml
+	ocamlfind ocamlopt -c $(OCAMLCFLAGS) $(INCLUDES) -package ppx_deriving.show cst_ml.ml
 
 clean::
 	rm -f $(TARGET).top

--- a/lang_ml/parsing/cst_ml.ml
+++ b/lang_ml/parsing/cst_ml.ml
@@ -23,6 +23,29 @@ open Common
  *)
 
 (*****************************************************************************)
+(* PPX *)
+(*****************************************************************************)
+
+let pp_tok fmt _ = Format.fprintf fmt "()"
+type ('a, 'b) either = ('a, 'b) Common.either
+
+(* result of ocamlfind ocamlc -dsource ... on this code
+type ('a, 'b) either2 =
+  | Left of 'a
+  | Right of 'b
+[@@deriving show]
+*)
+let pp_either = fun poly_a -> fun poly_b -> fun fmt -> function
+  | Left a0 ->
+    (Ppx_deriving_runtime.Format.fprintf fmt "(@[<2>Left@ ";
+     (poly_a fmt) a0;
+     Ppx_deriving_runtime.Format.fprintf fmt "@])")
+  | Right a0 ->
+    (Ppx_deriving_runtime.Format.fprintf fmt "(@[<2>Right@ ";
+     (poly_b fmt) a0;
+     Ppx_deriving_runtime.Format.fprintf fmt "@])")
+
+(*****************************************************************************)
 (* The AST related types *)
 (*****************************************************************************)
 
@@ -32,20 +55,20 @@ open Common
 type tok = Parse_info.t
 
 (* a shortcut to annotate some information with token/position information *)
-and 'a wrap = 'a * tok
+type 'a wrap = 'a * tok
 
 and 'a paren   = tok * 'a * tok
 and 'a brace   = tok * 'a * tok
 and 'a bracket = tok * 'a * tok 
 
-and 'a comma_list = ('a, tok (* ',' *)) Common.either list
-and 'a and_list = ('a, tok (* 'and' *)) Common.either list
-and 'a star_list = ('a, tok (* '*' *)) Common.either list
+and 'a comma_list = ('a, tok (* ',' *)) either list
+and 'a and_list = ('a, tok (* 'and' *)) either list
+and 'a star_list = ('a, tok (* '*' *)) either list
 (* optional first | *)
-and 'a pipe_list = ('a, tok (* '|' *)) Common.either list
+and 'a pipe_list = ('a, tok (* '|' *)) either list
 (* optional final ; *)
-and 'a semicolon_list = ('a, tok (* ';' *)) Common.either list
-
+and 'a semicolon_list = ('a, tok (* ';' *)) either list
+ [@@deriving show]
  (* with tarzan *)
 
 (* ------------------------------------------------------------------------- *)
@@ -57,13 +80,13 @@ type name = Name of string wrap
   (* lower and uppernames aliases, just for clarity *)
   and lname = name
   and uname = name
-
+ [@@deriving show { with_path = false} ]
  (* with tarzan *)
 
 (* TODO: rename name *)
 type long_name = qualifier * name
  and qualifier = (name * tok (*'.'*)) list
-
+ [@@deriving show]
  (* with tarzan *)
 
 (* ------------------------------------------------------------------------- *)
@@ -85,11 +108,12 @@ type ty =
     | TyArg1 of ty
     | TyArgMulti of ty comma_list paren
     (* todo? | TyNoArg and merge TyName and TyApp ? *)
+ [@@deriving show { with_path = false}]
 
 (* ------------------------------------------------------------------------- *)
 (* Expressions *)
 (* ------------------------------------------------------------------------- *)
-and expr =
+type expr =
   | C of constant
   | L of long_name (* val_longident *)
 
@@ -136,7 +160,7 @@ and expr =
 
   | ExprTodo of tok
 
-and seq_expr = expr semicolon_list
+ and seq_expr = expr semicolon_list
 
  and constant =
    | Int of string wrap
@@ -235,6 +259,8 @@ and let_binding =
    | ParamPat of pattern
    | ParamTodo of tok
 
+ [@@deriving show { with_path = false}]
+
 (* ------------------------------------------------------------------------- *)
 (* Type declaration *)
 (* ------------------------------------------------------------------------- *)
@@ -269,6 +295,7 @@ type type_declaration =
    fld_tok: tok; (* : *)
    fld_type: ty; (* poly_type ?? *)
  }
+ [@@deriving show { with_path = false}]
 
 
 (* ------------------------------------------------------------------------- *)
@@ -284,7 +311,6 @@ type module_expr =
   | ModuleName of long_name
   | ModuleStruct of tok (* struct *) * item list * tok (* end *)
   | ModuleTodo of tok
-
 
 (* ------------------------------------------------------------------------- *)
 (* Signature/Structure items *)
@@ -311,9 +337,12 @@ and item =
   | Module of tok * uname * tok * module_expr
       
   | ItemTodo of tok
+ [@@deriving show { with_path = false}]
 
 type sig_item = item
+ [@@deriving show]
 type struct_item = item
+ [@@deriving show]
 
 (* ------------------------------------------------------------------------- *)
 (* Toplevel phrases *)
@@ -328,9 +357,10 @@ type toplevel =
 
   (* some ml files contain some #! or even #load directives *)
   | TopDirective of tok
+ [@@deriving show { with_path = false}]
 
 type program = toplevel list
-
+ [@@deriving show]
  (* with tarzan *)
 
 (*****************************************************************************)
@@ -360,6 +390,7 @@ type any =
 
   | Info of tok
   | InfoList of tok list
+ [@@deriving show { with_path = false}]
   (* with tarzan *)
 
 (*****************************************************************************)

--- a/lang_ml/parsing/cst_ml.ml
+++ b/lang_ml/parsing/cst_ml.ml
@@ -68,8 +68,7 @@ and 'a star_list = ('a, tok (* '*' *)) either list
 and 'a pipe_list = ('a, tok (* '|' *)) either list
 (* optional final ; *)
 and 'a semicolon_list = ('a, tok (* ';' *)) either list
- [@@deriving show]
- (* with tarzan *)
+ [@@deriving show] (* with tarzan *)
 
 (* ------------------------------------------------------------------------- *)
 (* Names  *)
@@ -80,14 +79,12 @@ type name = Name of string wrap
   (* lower and uppernames aliases, just for clarity *)
   and lname = name
   and uname = name
- [@@deriving show { with_path = false} ]
- (* with tarzan *)
+ [@@deriving show { with_path = false} ] (* with tarzan *)
 
 (* TODO: rename name *)
 type long_name = qualifier * name
  and qualifier = (name * tok (*'.'*)) list
- [@@deriving show]
- (* with tarzan *)
+ [@@deriving show] (* with tarzan *)
 
 (* ------------------------------------------------------------------------- *)
 (* Types *)
@@ -360,8 +357,7 @@ type toplevel =
  [@@deriving show { with_path = false}]
 
 type program = toplevel list
- [@@deriving show]
- (* with tarzan *)
+ [@@deriving show] (* with tarzan *)
 
 (*****************************************************************************)
 (* Any *)
@@ -390,8 +386,7 @@ type any =
 
   | Info of tok
   | InfoList of tok list
- [@@deriving show { with_path = false}]
-  (* with tarzan *)
+ [@@deriving show { with_path = false}] (* with tarzan *)
 
 (*****************************************************************************)
 (* Wrappers *)

--- a/lang_ml/parsing/parser_ml.mly
+++ b/lang_ml/parsing/parser_ml.mly
@@ -1094,5 +1094,4 @@ attr_id: listr_sep(single_attr_id, ".") { $1 }
 
 post_item_attribute: TBracketAtAt attr_id payload "]" { }
 
-(* in theory you can have a full structure here *)
-payload: TString? { }
+payload: structure { }

--- a/lang_ml/parsing/test_parsing_ml.ml
+++ b/lang_ml/parsing/test_parsing_ml.ml
@@ -46,6 +46,11 @@ let test_dump_ml file =
   let s = OCaml.string_of_v v in
   pr s
 
+let test_show_ml file =
+  let ast = Parse_ml.parse_program file in
+  let s = Cst_ml.show_any (Cst_ml.Program ast) in
+  pr s
+
 
 (*****************************************************************************)
 (* One shot *)
@@ -101,6 +106,8 @@ let actions () = [
   Common.mk_action_n_arg test_parse_ml_or_mli;
   "-dump_ml", "   <file>", 
   Common.mk_action_1_arg test_dump_ml;
+  "-show_ml", "   <file>", 
+  Common.mk_action_1_arg test_show_ml;
 
   "-refactor_grammar", "   <subst_file> <file>", 
   Common.mk_action_2_arg refactor_grammar;

--- a/pfff.opam
+++ b/pfff.opam
@@ -40,4 +40,5 @@ depends: [
   "conf-perl"
   "menhir"
   "grain_dypgen"
+  "ppx_deriving"
 ]

--- a/scripts/install-opam-deps
+++ b/scripts/install-opam-deps
@@ -59,6 +59,7 @@ packages="
   json-wheel
   menhir
   ocamlgraph
+  ppx_deriving
 "
 
 # The docker images from the ocaml community ship with a stale (file://...)

--- a/tests/ml/parsing/attributes.ml
+++ b/tests/ml/parsing/attributes.ml
@@ -3,3 +3,5 @@ let foo x =
 [@@interactive]
 
 [@@@warning "-3"]
+
+[@@deriving show]


### PR DESCRIPTION
Ppx_deriving is a better option than my ocamltarzan for
the different AST dumpers in Pfff. They are automatically generated
and up-to-date as opposed to ocamltarzan meta_ast_xxx.ml which
are first auto-generated but then need to be modified manually
for each modification on the original AST

test plan:
make

the output of -dump_ml (ocamltarzan based) and -show_ml is mostly
the same.

~/pfff/pfff -show_ml foo.ml
(Program
   [(TopItem
       (Let ((), None,
          [(Left
              (LetClassic
                 { l_name = (Name ("x", ()));
                   l_params =
                   [(ParamPat (PatVar (Name ("a", ()))));
                     (ParamPat (PatVar (Name ("b", ()))))];
                   l_tok = ();
                   l_body =
                   [(Left
                       (FunCallSimple (
                          ([((Name ("Pervasives", ())), ())],
                           (Name ("compare", ()))),
                          [(ArgExpr (L ([], (Name ("a", ())))));
                            (ArgExpr (L ([], (Name ("b", ())))))]
                          )))
                     ]
                   }))
            ]
          )))
     ])
develop/home/pad/semgrep/tests/ocaml $ ~/pfff/pfff -dump_ml foo.ml
Program(
  [TopItem(
     Let((), None,
       [Left(
          LetClassic(
            {l_name=Name(("x", ()));
             l_args=[ParamPat(PatVar(Name(("a", ()))));
                     ParamPat(PatVar(Name(("b", ()))))];
             l_tok=();
             l_body=[Left(
                       FunCallSimple(
                         ([(Name(("Pervasives", ())), ())],
                          Name(("compare", ()))),
                         [ArgExpr(L(([], Name(("a", ())))));
                          ArgExpr(L(([], Name(("b", ())))))]))];
             }))]))])