### PR TITLE
Replace non-ascii UTF-8 characters by Zs or spaces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,6 @@ jobs:
     - name: debugging
       run: opam --version
     - name: Install pfff
-      run: opam init && opam switch create 4.07.1 && opam switch 4.07.1 && eval $(opam env) && opam install -y ocaml-migrate-parsetree ocaml-migrate-parsetree.1.3.1 && opam install -y menhir grain_dypgen ppx_deriving && opam install -y pfff
+      run: opam init && opam switch create 4.07.1 && opam switch 4.07.1 && eval $(opam env) && opam install -y ocaml-migrate-parsetree ocaml-migrate-parsetree.1.3.1 && opam install -y menhir grain_dypgen ppx_deriving uucp uutf && opam install -y pfff
     - name: Run Tests
       run: eval $(opam env); export PFFF_HOME=`pwd`; ./configure -novisual && make depend && make test

--- a/Makefile
+++ b/Makefile
@@ -32,14 +32,9 @@ JSONCMA=external/deps-netsys/netsys_oothr.cma external/deps-netsys/netsys.cma\
         external/deps-netstring/netstring.cma\
         external/json-wheel/jsonwheel.cma 
 
-# for ruby
-DYPCMA=external/dyp/dyp.cma
-
 # could be FEATURE_OCAMLGRAPH, or should give dependencies between features
 GRAPHCMA=external/ocamlgraph/graph.cma commons_wrappers/graph/lib.cma
 GRAPHDIRS=commons_wrappers/graph 
-
-DERIVINGCMA=external/ppx_deriving/ppx_deriving_runtime.cma
 
 #------------------------------------------------------------------------------
 # Main variables
@@ -55,9 +50,12 @@ LIBS= commons/lib.cma \
     commons_core/lib.cma \
     commons_ocollection/lib.cma \
        $(JSONCMA) \
-       $(DYPCMA) \
        $(GRAPHCMA) \
-       $(EXTLIBCMA) $(PTCMA) $(ZIPCMA) $(JAVALIBCMA) $(DERIVINGCMA) \
+       $(EXTLIBCMA) $(PTCMA) $(ZIPCMA) $(JAVALIBCMA)\
+    external/dyp/dyp.cma \
+    external/ppx_deriving/ppx_deriving_runtime.cma \
+    external/uucp/uucp.cma \
+    external/uutf/uutf.cma \
     globals/lib.cma \
     h_files-format/lib.cma \
     h_program-lang/lib.cma \

--- a/demos/Makefile
+++ b/demos/Makefile
@@ -14,6 +14,7 @@ all::
 include ../Makefile.config
 
 LIBS= ../commons/lib.cma ../commons_core/lib.cma \
+      ../external/uucp/uucp.cma ../external/uutf/uutf.cma \
       ../h_program-lang/lib.cma \
       ../lang_php/parsing/lib.cma
 

--- a/external/uucp
+++ b/external/uucp
@@ -1,0 +1,1 @@
+OPAM_DIR/lib/uucp

--- a/external/uutf
+++ b/external/uutf
@@ -1,0 +1,1 @@
+OPAM_DIR/lib/uutf

--- a/h_program-lang/Makefile
+++ b/h_program-lang/Makefile
@@ -7,6 +7,7 @@ OPAMPKG=pfff-h_program-lang
 
 SRC= entity_code.ml scope_code.ml \
      flag_parsing.ml \
+     Unicode.mli Unicode.ml \
      Parse_info.ml meta_parse_info.ml \
      comment_code.ml \
      ast_fuzzy.ml meta_ast_fuzzy.ml lib_ast_fuzzy.ml \

--- a/h_program-lang/Makefile
+++ b/h_program-lang/Makefile
@@ -7,7 +7,7 @@ OPAMPKG=pfff-h_program-lang
 
 SRC= entity_code.ml scope_code.ml \
      flag_parsing.ml \
-     Unicode.mli Unicode.ml \
+     Unicode.ml \
      Parse_info.ml meta_parse_info.ml \
      comment_code.ml \
      ast_fuzzy.ml meta_ast_fuzzy.ml lib_ast_fuzzy.ml \
@@ -32,6 +32,8 @@ SRC= entity_code.ml scope_code.ml \
 SYSLIBS= str.cma unix.cma
 LIBS=../commons/lib.cma
 INCLUDEDIRS= $(TOP)/commons \
+ $(TOP)/external/uutf \
+ $(TOP)/external/uucp \
  $(TOP)/external/json-wheel \
  $(TOP)/h_files-format
 

--- a/h_program-lang/Parse_info.ml
+++ b/h_program-lang/Parse_info.ml
@@ -534,8 +534,9 @@ let complete_token_location_large filename table x =
  *    skip them easily with one Common.exclude
  *)
 let tokenize_all_and_adjust_pos file tokenizer visitor_tok is_eof =
- Common.with_open_infile file (fun chan -> 
-  let lexbuf = Lexing.from_channel chan in
+ Common.with_open_infile file (fun chan ->
+  let string = Unicode.UTF8.asciify chan in
+  let lexbuf = Lexing.from_string string in
   let table     = full_charpos_to_pos_large file in
   let adjust_info ii = 
     { ii with token =

--- a/h_program-lang/Parse_info.ml
+++ b/h_program-lang/Parse_info.ml
@@ -537,8 +537,7 @@ let tokenize_all_and_adjust_pos ?(unicode_hack=false)
  file tokenizer visitor_tok is_eof =
  Common.with_open_infile file (fun chan ->
   let lexbuf = 
-     (* todo: opti: check if char > 128 in file *)
-     if unicode_hack
+     if unicode_hack && Unicode.file_contains_non_ascii file
      then
        let string = 
             Common.profile_code "Unicode.asciify" (fun () ->

--- a/h_program-lang/Parse_info.mli
+++ b/h_program-lang/Parse_info.mli
@@ -218,6 +218,7 @@ val tok_add_s: string -> t -> t
 (*s: signature [[Parse_info.tokenize_all_and_adjust_pos]] *)
 (* to be used by the lexer *)
 val tokenize_all_and_adjust_pos: 
+  ?unicode_hack:bool ->
   Common.filename -> 
   (Lexing.lexbuf -> 'tok) (* tokenizer *) -> 
   ((t -> t) -> 'tok -> 'tok) (* token visitor *) -> 

--- a/h_program-lang/Unicode.ml
+++ b/h_program-lang/Unicode.ml
@@ -1,0 +1,53 @@
+(*
+   Utilities for dealing with Unicode issues.
+*)
+
+module UTF8 = struct
+  (* Guess the length of the original UTF-8 sequence by re-encoding the
+     character. This is quite inefficient. *)
+  let get_length uchar =
+    let buf = Buffer.create 8 in
+    let enc = Uutf.encoder `UTF_8 (`Buffer buf) in
+    ignore (Uutf.encode enc uchar);
+    ignore (Uutf.encode enc `End);
+    Buffer.length buf
+
+  let asciify ic =
+    let src = `Channel ic in
+    let buf = Buffer.create 4096 in
+    let dec =
+      Uutf.decoder
+        ~nln:(`ASCII (Uchar.of_char '\n'))
+        ~encoding:`UTF_8 src
+    in
+    let rec translate () =
+      match Uutf.decode dec with
+      | `Uchar x as uchar ->
+          let code = Uchar.to_int x in
+          if code < 128 then
+            (* Waste as little time as possible here since most characters
+               are ascii and need no translation. *)
+            Buffer.add_char buf (Char.chr code)
+          else (
+            let len = get_length uchar in
+            let replacement_string =
+              if Uucp.White.is_white_space x then
+                String.make len ' '
+              else
+                String.make len 'Z'
+            in
+            Buffer.add_string buf replacement_string
+          );
+          translate ()
+      | `End ->
+          ()
+      | `Malformed s ->
+          (* Keep it and hope for the best. *)
+          Buffer.add_string buf s;
+          translate ()
+      | `Await ->
+          assert false
+    in
+    translate ();
+    Buffer.contents buf
+end

--- a/h_program-lang/Unicode.ml
+++ b/h_program-lang/Unicode.ml
@@ -2,6 +2,24 @@
    Utilities for dealing with Unicode issues.
 *)
 
+exception Found
+
+(* could probably be faster, but seems "good enough" *)
+let file_contains_non_ascii file =
+  (* copy-paste of Common.read_file without Bytes.to_string *)
+  let ic = open_in file  in
+  let size = in_channel_length ic in
+  let buf = Bytes.create size in
+  really_input ic buf 0 size;
+  close_in ic;
+  try
+    buf |> Bytes.iter (fun char ->
+        if Char.code char > 128
+        then raise Found
+    );
+    false
+  with Found -> true
+
 module UTF8 = struct
   (* Guess the length of the original UTF-8 sequence by re-encoding the
      character. This is quite inefficient. *)

--- a/h_program-lang/Unicode.mli
+++ b/h_program-lang/Unicode.mli
@@ -2,6 +2,8 @@
    Utilities for dealing with Unicode issues.
 *)
 
+val file_contains_non_ascii: Common.filename -> bool
+
 module UTF8 : sig
   (*
      Convert non-ascii whitespace to space characters and

--- a/h_program-lang/Unicode.mli
+++ b/h_program-lang/Unicode.mli
@@ -1,0 +1,16 @@
+(*
+   Utilities for dealing with Unicode issues.
+*)
+
+module UTF8 : sig
+  (*
+     Convert non-ascii whitespace to space characters and
+     other characters to 'Z' characters. The number of replacement
+     characters is adjusted to as to match the number of bytes of the original
+     character.
+
+     This is meant to be used as a hack to tolerate non-ascii input in
+     lexers that only support ascii.
+  *)
+  val asciify : in_channel -> string
+end

--- a/lang_go/parsing/parse_go.ml
+++ b/lang_go/parsing/parse_go.ml
@@ -49,7 +49,7 @@ let tokens2 file =
   let token lexbuf = 
       Lexer.token lexbuf
   in
-  Parse_info.tokenize_all_and_adjust_pos 
+  Parse_info.tokenize_all_and_adjust_pos ~unicode_hack:true
     file token TH.visitor_info_of_tok TH.is_eof
 
 let tokens a = 

--- a/lang_java/parsing/lexer_java.mll
+++ b/lang_java/parsing/lexer_java.mll
@@ -216,8 +216,8 @@ let EscapeSequence_semgrep =
   '\\' _
 
 
-(* ugly: hardcoded stuff for fbandroid, error in SoundexTest.java *)
-let UnicodeX = "�"
+(* ugly: see unicode_hack in Parse_info.ml *)
+let UnicodeX = "Z"+
 
 let SingleCharacter = [^ '\'' '\\' '\n' '\r']
 let CharacterLiteral = '\'' (SingleCharacter | EscapeSequence | UnicodeX ) '\''

--- a/lang_java/parsing/parse_java.ml
+++ b/lang_java/parsing/parse_java.ml
@@ -45,7 +45,7 @@ let error_msg_tok tok =
 
 let tokens2 file =
   let token = Lexer_java.token in
-  Parse_info.tokenize_all_and_adjust_pos 
+  Parse_info.tokenize_all_and_adjust_pos ~unicode_hack:true
     file token TH.visitor_info_of_tok TH.is_eof
 
 let tokens a =

--- a/lang_js/parsing/lexer_js.mll
+++ b/lang_js/parsing/lexer_js.mll
@@ -271,6 +271,8 @@ rule initial = parse
    * The right solution would be to switch to a unicode-aware lexer generator,
    * like ulex or sedlex.
    * todo: https://en.wikipedia.org/wiki/Whitespace_character#Unicode
+   * update: with Parse_info.tokenize_all_and_adjust_pos ~unicode_hack:true
+   * the hack below is redundant.
    *)
   | "\xc2\xa0" (* non-breaking-space \u{00A0} *) 
   | "\xef\xbb\xbf" (* byte-order-mark \u{FEFF} *)

--- a/lang_js/parsing/parse_js.ml
+++ b/lang_js/parsing/parse_js.ml
@@ -184,7 +184,7 @@ let tokens2 file =
      then Lexer_js._last_non_whitespace_like_token := Some tok;
      tok
   in
-  Parse_info.tokenize_all_and_adjust_pos
+  Parse_info.tokenize_all_and_adjust_pos ~unicode_hack:true
     file token TH.visitor_info_of_tok TH.is_eof
 
 let tokens a = 

--- a/lang_php/pretty/Makefile
+++ b/lang_php/pretty/Makefile
@@ -3,7 +3,8 @@ TOP=../..
 # Variables
 ##############################################################################
 TARGET=lib
-BIN=prettyphp
+#BIN=prettyphp
+
 OPAMPKG=pfff-lang_php-pretty
 
 SRC= \
@@ -35,13 +36,15 @@ INCLUDEDIRS= \
 ##############################################################################
 # Top rules
 ##############################################################################
-all:: $(TARGET).cma $(BIN)
-all.opt:: $(TARGET).cmxa $(BIN).opt
+all:: $(TARGET).cma
+# $(BIN)
+all.opt:: $(TARGET).cmxa 
+#$(BIN).opt
 
-$(BIN): $(OBJS) $(LIBS) main.ml
-	$(OCAMLC) -o $@ -custom $(SYSLIBS) $(LIBS) $(OBJS) main.ml
-$(BIN).opt: $(OBJS) $(LIBS) main.ml
-	$(OCAMLOPT) -o $@ $(SYSLIBSOPT) $(LIBS:.cma=.cmxa) $(OPTOBJS) main.ml
+#$(BIN): $(OBJS) $(LIBS) main.ml
+#	$(OCAMLC) -o $@ -custom $(SYSLIBS) $(LIBS) $(OBJS) main.ml
+#$(BIN).opt: $(OBJS) $(LIBS) main.ml
+#	$(OCAMLOPT) -o $@ $(SYSLIBSOPT) $(LIBS:.cma=.cmxa) $(OPTOBJS) main.ml
 $(TARGET).cma: $(OBJS) $(LIBS)
 	$(OCAMLC) -a -o $@ $(OBJS)
 $(TARGET).cmxa: $(OPTOBJS) $(LIBS:.cma=.cmxa)

--- a/lang_python/parsing/Parse_python.ml
+++ b/lang_python/parsing/Parse_python.ml
@@ -91,7 +91,7 @@ let tokens2 parsing_mode file =
     | Lexer.STATE_IN_FSTRING_TRIPLE_DOUBLE ->
        Lexer.fstring_triple_double state lexbuf
   in
-  Parse_info.tokenize_all_and_adjust_pos 
+  Parse_info.tokenize_all_and_adjust_pos ~unicode_hack:true
     file token TH.visitor_info_of_tok TH.is_eof
 (*e: function [[Parse_python.tokens2]] *)
 

--- a/lang_python/parsing/Test_parsing_python.ml
+++ b/lang_python/parsing/Test_parsing_python.ml
@@ -33,6 +33,8 @@ let test_parse_python_common parsing_mode xs =
   in
 
   let stat_list = ref [] in
+  let newscore  = Common2.empty_score () in
+  let ext = "python" in
 
   fullxs |> Console.progress (fun k -> List.iter (fun file ->
     k();
@@ -43,8 +45,28 @@ let test_parse_python_common parsing_mode xs =
        Parse_python.parse ~parsing_mode file
     )) in
     Common.push stat stat_list;
+    let s = spf "bad = %d" stat.Parse_info.bad in
+    if stat.Parse_info.bad = 0
+    then Hashtbl.add newscore file (Common2.Ok)
+    else Hashtbl.add newscore file (Common2.Pb s)
   ));
   Parse_info.print_parsing_stat_list !stat_list;
+  let dirname_opt = 
+    match xs with
+    | [x] when Common2.is_directory x -> Some (Common.fullpath x)
+    | _ -> None
+  in
+    let score_path = Filename.concat Config_pfff.path "tmp" in
+    dirname_opt |> Common.do_option (fun dirname -> 
+      let dirname = Common.fullpath dirname in
+      pr2 "--------------------------------";
+      pr2 "regression testing  information";
+      pr2 "--------------------------------";
+      let str = Str.global_replace (Str.regexp "/") "__" dirname in
+      Common2.regression_testing newscore 
+        (Filename.concat score_path
+         (spf "score_parsing__%s%s.marshalled" str ext))
+    );
   ()
 (*e: function [[Test_parsing_python.test_parse_python_common]] *)
 

--- a/pfff.opam
+++ b/pfff.opam
@@ -41,4 +41,6 @@ depends: [
   "menhir"
   "grain_dypgen"
   "ppx_deriving"
+  "uutf"
+  "uucp"
 ]

--- a/scripts/install-opam-deps
+++ b/scripts/install-opam-deps
@@ -60,6 +60,7 @@ packages="
   menhir
   ocamlgraph
   ppx_deriving
+  uucp uutf
 "
 
 # The docker images from the ocaml community ship with a stale (file://...)

--- a/tests/java/parsing/Unicode.java
+++ b/tests/java/parsing/Unicode.java
@@ -1,0 +1,5 @@
+class Foo {
+
+   private static final char A = '傳';
+
+}

--- a/tests/python/parsing/unicode.py
+++ b/tests/python/parsing/unicode.py
@@ -1,0 +1,64 @@
+# from https://raw.githubusercontent.com/uber-archive/pyflame/v1.6.7/tests/sleeper_%E3%83%A6%E3%83%8B%E3%82%B3%E3%83%BC%E3%83%89.py
+# Copyright 2017 Uber Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import time
+
+
+def _sleep(sleep_time):
+    time.sleep(sleep_time)
+    target = time.time() + sleep_time
+    while time.time() < target:
+        pass
+
+
+def låtìÑ1(sleep_time):
+    _sleep(sleep_time)
+
+
+# Arabic
+def وظيفة(sleep_time):
+    _sleep(sleep_time)
+
+
+# Japanese
+def 日本語はどうですか(sleep_time):
+    _sleep(sleep_time)
+
+
+# Khmer
+def មុខងារ(sleep_time):
+    _sleep(sleep_time)
+
+
+# Thai
+def ฟังก์ชัน(sleep_time):
+    _sleep(sleep_time)
+
+
+def main():
+    sys.stdout.write('%d\n' % (os.getpid(), ))
+    sys.stdout.flush()
+    while True:
+        låtìÑ1(0.1)
+        وظيفة(0.1)
+        日本語はどうですか(0.1)
+        មុខងារ(0.1)
+        ฟังก์ชัน(0.1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
As a preprocessing step before parsing, this attempts to replace characters outside the ascii range by ascii characters. If the unicode character "whitespace", it gets replaced by spaces, otherwise it gets replaced by Zs. The length of the replacement string should be equal to the original UTF-8 sequence being replaced in most cases (but it's not guaranteed due to Unicode having multiple ways of encoding the same character. See https://www.wikiwand.com/en/Unicode_equivalence#/Normalization).