### PR TITLE
* lang_json/parsing/parse_json.ml: correctly parse JSON semgrep pattern

### DIFF
--- a/lang_json/parsing/parse_json.ml
+++ b/lang_json/parsing/parse_json.ml
@@ -38,7 +38,15 @@ let parse_program filename =
       raise (PI.Parsing_error (TH.info_of_tok cur))
 
 let any_of_string str =
-  match Parse_js.any_of_string str with
-  | Cst_js.Expr e_cst ->
-      Ast_json.E (Ast_js_build.expr e_cst)
-  | _ -> failwith (spf "not a valid JSON expression: %s" str)
+  Common2.with_tmp_file ~str ~ext:"json" (fun file ->
+    let toks = tokens file in
+    let _tr, lexer, lexbuf_fake = PI.mk_lexer_for_yacc toks TH.is_comment in
+    (* bugfix: currently Parser_js.sgrep_spatch_pattern does not
+     * recognize full expression as a start, it uses 
+     * assignment_expr_no_stmt because of possible ambiguities
+     * when seeing { } which can be a block or an object,
+     * so let's call directly Parser_js.json
+     *)
+    let e = Parser_js.json lexer lexbuf_fake in
+    Ast_json.E (Ast_js_build.expr e)
+  )


### PR DESCRIPTION
test plan:
~/pfff/pfff -lang json -dump_pattern metavar_array.json
now works