### PR TITLE
Support {} semgrep pattern in JS directly

### DIFF
--- a/lang_js/analyze/highlight_js.ml
+++ b/lang_js/analyze/highlight_js.ml
@@ -238,7 +238,7 @@ let visit_program ~tag_hook _prefs (cst, toks) =
 
     (* Punctuation *)
 
-    | T.T_LCURLY (ii) | T.T_RCURLY (ii)
+    | T.T_LCURLY (ii) | T.T_RCURLY (ii) | T.T_LCURLY_SEMGREP ii
     | T.T_LPAREN (ii) | T.T_LPAREN_ARROW (ii) | T.T_RPAREN (ii)
     | T.T_LBRACKET (ii) | T.T_RBRACKET (ii)
     | T.T_SEMICOLON (ii)

--- a/lang_js/analyze/highlight_js.ml
+++ b/lang_js/analyze/highlight_js.ml
@@ -234,7 +234,8 @@ let visit_program ~tag_hook _prefs (cst, toks) =
     | T.T_XHP_CLOSE_TAG (_, ii) -> tag ii EmbededHtml
     | T.T_XHP_SLASH_GT ii -> tag ii EmbededHtml
     | T.T_XHP_GT ii -> tag ii EmbededHtml
-    | T.T_XHP_OPEN_TAG (_, ii) -> tag ii EmbededHtml
+    | T.T_XHP_OPEN_TAG (_, ii) | T.T_XHP_SHORT_FRAGMENT ii
+      -> tag ii EmbededHtml
 
     (* Punctuation *)
 

--- a/lang_js/parsing/cst_js.ml
+++ b/lang_js/parsing/cst_js.ml
@@ -265,7 +265,8 @@ type expr =
 
  (* facebook-ext: JSX extension, similar to XHP for PHP (hence the name) *)
  and xhp_html =
-   | Xhp of xhp_tag wrap * xhp_attribute list * tok (* > *) *
+   | Xhp of xhp_tag wrap (* this can be "" for React '<>' short fragment *) * 
+       xhp_attribute list * tok (* > *) *
        xhp_body list * xhp_tag option wrap
    | XhpSingleton of xhp_tag wrap * xhp_attribute list * tok (* /> *)
 

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -184,6 +184,8 @@ let (^@) sc xs =
 %token <Cst_js.tok> T_VIRTUAL_SEMICOLON
 (* fresh_token: the opening '(' of the parameters preceding an '->' *)
 %token <Cst_js.tok> T_LPAREN_ARROW
+(* fresh_token: the first '{' in a semgrep pattern for objects *)
+%token <Cst_js.tok> T_LCURLY_SEMGREP
 
 (*************************************************************************)
 (* Priorities *)
@@ -290,7 +292,12 @@ json: expr EOF { $1 }
 (*************************************************************************)
 
 sgrep_spatch_pattern:
- | assignment_expr_no_stmt EOF           { Expr $1 }
+ (* copy-paste of object_literal rule but with T_LCURLY_SEMGREP *)
+ | T_LCURLY_SEMGREP "}"    { Expr (Object ($1, [], $2)) }
+ | T_LCURLY_SEMGREP listc2(property_name_and_value) ","? "}" 
+     { Expr (Object ($1, $2 @@ $3, $4)) }
+
+ | assignment_expr_no_stmt EOF   { Expr $1 }
  | module_item EOF               { fix_sgrep_module_item $1}
  | module_item module_item+ EOF  { ModuleItems ($1::$2) }
 

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -175,6 +175,8 @@ let (^@) sc xs =
 %token <Parse_info.t> T_XHP_GT T_XHP_SLASH_GT
 
 %token <string * Parse_info.t> T_XHP_ATTR T_XHP_TEXT
+(* '<>', see https://reactjs.org/docs/fragments.html#short-syntax *)
+%token <Parse_info.t> T_XHP_SHORT_FRAGMENT
 
 (*-----------------------------------------*)
 (* Extra tokens: *)
@@ -1205,6 +1207,9 @@ xhp_html:
      { Xhp ($1, $2, $3, $4, $5)  }
  | T_XHP_OPEN_TAG xhp_attribute* T_XHP_SLASH_GT
      { XhpSingleton ($1, $2, $3) }
+ (* reactext: https://reactjs.org/docs/fragments.html#short-syntax *)
+ | T_XHP_SHORT_FRAGMENT xhp_child* T_XHP_CLOSE_TAG 
+     { Xhp (("", $1), [], $1, $2, $3) }
 
 xhp_child:
  | T_XHP_TEXT        { XhpText $1 }

--- a/lang_js/parsing/token_helpers_js.ml
+++ b/lang_js/parsing/token_helpers_js.ml
@@ -158,6 +158,7 @@ let visitor_info_of_tok f = function
   | T_XHP_ATTR (s,ii) -> T_XHP_ATTR (s, f ii)
   | T_XHP_TEXT (s,ii) -> T_XHP_TEXT (s, f ii)
   | T_ARROW ii -> T_ARROW (f ii)
+  | T_XHP_SHORT_FRAGMENT ii -> T_XHP_SHORT_FRAGMENT (f ii)
 
   | T_DOTS ii -> T_DOTS (f ii)
   | LDots (ii) -> LDots (f ii)

--- a/lang_js/parsing/token_helpers_js.ml
+++ b/lang_js/parsing/token_helpers_js.ml
@@ -96,6 +96,7 @@ let visitor_info_of_tok f = function
   | T_RCURLY ii -> T_RCURLY (f ii)
   | T_LPAREN ii -> T_LPAREN (f ii)
   | T_LPAREN_ARROW ii -> T_LPAREN_ARROW (f ii)
+  | T_LCURLY_SEMGREP ii -> T_LCURLY_SEMGREP (f ii)
   | T_RPAREN ii -> T_RPAREN (f ii)
   | T_LBRACKET ii -> T_LBRACKET (f ii)
   | T_RBRACKET ii -> T_RBRACKET (f ii)

--- a/tests/js/parsing/react_fragment.js
+++ b/tests/js/parsing/react_fragment.js
@@ -1,0 +1,10 @@
+class Columns extends React.Component {
+  render() {
+    return (
+      <React.Fragment>
+        <td>Hello</td>
+        <td>World</td>
+      </React.Fragment>
+    );
+  }
+}

--- a/tests/js/parsing/react_short_fragment.js
+++ b/tests/js/parsing/react_short_fragment.js
@@ -1,0 +1,10 @@
+class Columns extends React.Component {
+  render() {
+    return (
+      <>
+        <td>Hello</td>
+        <td>World</td>
+      </>
+    );
+  }
+}


### PR DESCRIPTION
This fixes https://github.com/returntocorp/semgrep/issues/435
and https://github.com/returntocorp/semgrep/issues/782

Test plan:
~/pfff/pfff -sgrep_mode -lang js -dump_pattern misc_object_directly.sgrep
(E
   (Record
      ((),
       [(FieldStmt
           (DefStmt
              ({ name = ("fld1", ()); attrs = [];
                 info =
                 { id_resolved = ref (None); id_type = ref (None);
                   id_const_literal = ref (None) };
                 tparams = [] },
               (FieldDef
                  { vinit =
                    (Some (Id (("$X", ()),
                             { id_resolved = ref (None);
                               id_type = ref (None);
                               id_const_literal = ref (None) }
                             )));
                    vtype = None }))))
         ],
       ())))