### PR TITLE
Test file showing we now support <> and complex JS

### DIFF
--- a/lang_js/parsing/lexer_js.mll
+++ b/lang_js/parsing/lexer_js.mll
@@ -367,6 +367,11 @@ rule initial = parse
       | None -> T_ID (s, info)
     }
 
+  (* very incomplete hack to support https://tc39.es/proposal-decorators/ *)
+  | "@" ['a'-'z''A'-'Z' '$' '_']['a'-'z''A'-'Z''$''_''0'-'9']* as s {
+      T_ID (s, tokinfo lexbuf)
+   }
+
   (* ----------------------------------------------------------------------- *)
   (* Constant *)
   (* ----------------------------------------------------------------------- *)

--- a/tests/js/parsing/arrow.js
+++ b/tests/js/parsing/arrow.js
@@ -1,0 +1,10 @@
+const X = (x) => { return 2; };
+
+const Val = (x) => {
+    return (
+      <>
+       xxx
+      </>
+    )
+};
+

--- a/tests/js/parsing/ext_decorators_at.js
+++ b/tests/js/parsing/ext_decorators_at.js
@@ -1,0 +1,5 @@
+@connect(state => ({
+  counter: state.counter
+}))
+
+@foo 

--- a/tests/js/parsing/react_short_fragment2.js
+++ b/tests/js/parsing/react_short_fragment2.js
@@ -1,0 +1,13 @@
+const Val = (x) => {
+  return (
+      <div>
+        {toExpand && (
+          <Button>
+            {baz ? 'test' : <a href={parentTag}>test2</a>} // added > before test2
+          </Button>
+        )} 
+      </div>
+  );
+};
+
+export default Val;

--- a/tests/js/parsing/react_short_fragment3.js
+++ b/tests/js/parsing/react_short_fragment3.js
@@ -1,0 +1,27 @@
+const Val = ({ x = []}) => {
+  return (
+    <>
+      <div>
+        {x.map((a, b) => {
+          return 3;
+        })}
+      </div>
+      <div>
+        {toExpand && (
+          <Button
+            key="a"
+            size="small"
+            type="link"
+            onClick={() => {
+              foo(!bar);
+            }}
+          >
+            {baz ? 'test' : <a href={parentTag}>test2</a>} // real error there before
+          </Button>
+        )} 
+      </div>
+    </>
+  );
+};
+
+export default Val;


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/1009
There is actually a real error in this file.

Test plan:
Test file included
~/pfff/pfff -dump_ast react_short_fragment3.js
shows a good dump, not anymore a parse error