### PR TITLE
* lang_GENERIC/analyze/Naming_AST.ml: Fix lookup semantic of Python

### DIFF
--- a/tests/java/parsing/AnnotVar.java
+++ b/tests/java/parsing/AnnotVar.java
@@ -1,0 +1,6 @@
+public class HelloWorld {
+	public static void main(String[] args) {
+        
+        @Language("SQL") String sql = String.format("SELECT field FROM untrusted WHERE nkey='%s'", (String) args[0]);
+	}
+}

--- a/tests/php/semantic/global.php
+++ b/tests/php/semantic/global.php
@@ -1,0 +1,9 @@
+<?php
+
+$global = 1;
+
+function foo() {
+  // new one actually
+  print($global);
+}
+

--- a/tests/python/semantic/global.py
+++ b/tests/python/semantic/global.py
@@ -1,0 +1,20 @@
+GLOBAL = 1
+
+def foo():
+  # the global one
+  print(GLOBAL)
+
+
+def foo2():
+  # actually a new local
+  GLOBAL=2
+  print(GLOBAL)
+
+def foo3():
+  # actually a new local
+  global GLOBAL
+  GLOBAL=3
+  # back to the global one
+  print(GLOBAL)
+
+print(GLOBAL)


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/1101

Test plan:
The dump below now show Global, 1 also for reference.

~/pfff/pfff -naming_generic global.py
(Pr
   [(ExprStmt (
       (Assign (
          (Id (("GLOBAL", ()),
             { id_resolved = ref ((Some (Global, 1))); id_type = ref (None);
               id_const_literal = ref (None) }
             )),
          (), (L (Int ("1", ()))))),
       ()));
     (DefStmt
        ({ name = ("foo", ()); attrs = [];
           info =
           { id_resolved = ref (None); id_type = ref (None);
             id_const_literal = ref (None) };
           tparams = [] },
         (FuncDef
            { fparams = []; frettype = None;
              fbody =
              (Block
                 ((),
                  [(ExprStmt (
                      (Call (
                         (Id (("print", ()),
                            { id_resolved = ref (None); id_type = ref (None);
                              id_const_literal = ref (None) }
                            )),
                         ((),
                          [(Arg
                              (Id (("GLOBAL", ()),
                                 { id_resolved = ref ((Some (Global, 1)));
                                   id_type = ref (None);
                                   id_const_literal = ref (None) }
                                 )))
                            ],
                          ())
                         )),
                      ()))
                    ],
                  ()))
              })));
...