### PR TITLE
Support 'final' for const propagation

### DIFF
--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -962,7 +962,9 @@ and definition = entity * definition_kind
     | VarDef    of variable_definition
     (* FieldDef can only be present inside a record/class (in a FieldStmt).
      * This used to be merged with VarDef, but in semgrep we don't want
-     * a VarDef to match a field definition.
+     * a VarDef to match a field definition for certain languages (e.g., JS).
+     * TODO? maybe merge back with VarDef but add a field in 
+     *  variable_definition saying whether it's using a field syntax?
      * Note that we could have used a FieldVar in the field type instead
      * of this FieldDef here, which would be more precise, but 
      * this complicates things in semgrep where it's convenient to have
@@ -1138,7 +1140,7 @@ and type_definition = {
        | OOTEO_EnumWithMethods | OOTEO_EnumWithArguments
 (*e: type [[AST_generic.other_or_type_element_operator]] *)
 
- (* Field definition and use, for classes and records.
+ (* Field definition and use, for classes, objects, and records.
   * note: I don't call it field_definition because it's used both to
   * define the shape of a field (a definition), and when creating
   * an actual field (a value).
@@ -1146,9 +1148,10 @@ and type_definition = {
   * VarDef and FuncDef but they are now converted into a FieldStmt(DefStmt).
   * This simplifies semgrep so that a function pattern can match
   * toplevel functions, nested functions, and methods.
-  * Note that for FieldVar we ultimately converted it to a FieldDef 
+  * Note that for FieldVar we sometimes converts it to a FieldDef 
   * (which is very similar to a VarDef) because some people don't want a VarDef
-  * to match a field definition.
+  * to match a field definition in certain languages (e.g., Javascript) where
+  * de variable declaration and field definition have a different syntax.
   * Note: the FieldStmt(DefStmt(FuncDef(...))) can have empty body
   * for interface methods.
   *)

--- a/lang_GENERIC/analyze/Constant_propagation.ml
+++ b/lang_GENERIC/analyze/Constant_propagation.ml
@@ -28,7 +28,7 @@ module V = Visitor_AST
  * Right now we just propagate constants when we're sure it's a constant
  * because:
  *  - the variable declaration use the 'const' keyword in Javascript/Go/...
- *  - TODO the field declaration use the 'final' keyword in Java
+ *  - the field declaration use the 'final' keyword in Java
  *  - TODO we do a very basic const analysis where we check the variable
  *    is used only in an rvalue context (never assigned).
  *
@@ -77,7 +77,8 @@ let propagate _lang prog =
         (* note that some languages such as Python do not have VarDef.
          * todo? should add those somewhere instead of in_lvalue detection? *)
         VarDef ({ vinit = Some (L literal); _ }) ->
-          if Ast.has_keyword_attr Const attrs
+          if Ast.has_keyword_attr Const attrs ||
+             Ast.has_keyword_attr Final attrs
           then begin
               id_info.id_const_literal := Some literal;
               add_constant_env id (sid, literal) env;

--- a/lang_GENERIC/analyze/Test_analyze_generic.ml
+++ b/lang_GENERIC/analyze/Test_analyze_generic.ml
@@ -74,6 +74,14 @@ let test_naming_generic file =
   pr2 s
 (*e: function [[Test_analyze_generic.test_naming_generic]] *)
 
+let test_constant_propagation file =
+  let ast = Parse_generic.parse_program file in
+  let lang = List.hd (Lang.langs_of_filename file) in
+  Naming_AST.resolve lang ast;
+  Constant_propagation.propagate lang ast;
+  let s = AST_generic.show_any (AST_generic.Pr ast) in
+  pr2 s
+
 (*s: function [[Test_analyze_generic.test_il_generic]] *)
 let test_il_generic file =
   let ast = Parse_generic.parse_program file in
@@ -154,6 +162,8 @@ let actions () = [
   Common.mk_action_1_arg test_dfg_generic;
   "-naming_generic", " <file>",
   Common.mk_action_1_arg test_naming_generic;
+  "-constant_propagation", " <file>",
+  Common.mk_action_1_arg test_constant_propagation;
   "-il_generic", " <file>",
   Common.mk_action_1_arg test_il_generic;
   "-cfg_il", " <file>",

--- a/tests/java/naming/unknown_var.java
+++ b/tests/java/naming/unknown_var.java
@@ -1,0 +1,7 @@
+public class tableConcatStatements {
+    public void tableConcat() {
+        // ok
+        stmt.execute("DROP TABLE " + tableName);
+        stmt.execute(String.format("CREATE TABLE %s", tableName));
+    }
+}


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/1088

Test plan:
see id_const_literal below

~/pfff/pfff -constant_propagation equivalence_constant_propagation.java
(Pr
   [(DefStmt
       ({ name = ("SemgrepTest", ()); attrs = [(KeywordAttr (Public, ()))];
          info =
          { id_resolved = ref (None); id_type = ref (None);
            id_const_literal = ref (None) };
          tparams = [] },
        (ClassDef
           { ckind = Class; cextends = []; cimplements = []; cmixins = [];
             cbody =
             ((),
              [(FieldStmt
                  (DefStmt
                     ({ name = ("MD5_1", ());
                        attrs =
                        [(KeywordAttr (Public, ()));
                          (KeywordAttr (Static, ()));
                          (KeywordAttr (Final, ()))];
                        info =
                        { id_resolved = ref ((Some (EnclosedVar, 1)));
                          id_type =
                          ref ((Some (TyName
                                        (("String", ()),
                                         { name_qualifier = (Some []);
                                           name_typeargs = None }))));
                          id_const_literal =
                          ref ((Some (String ("MD5", ())))) };