### PR TITLE
Basic const analysis for Python for basic const propagation for semgrep

### DIFF
--- a/lang_GENERIC/analyze/Constant_propagation.mli
+++ b/lang_GENERIC/analyze/Constant_propagation.mli
@@ -2,4 +2,5 @@
  * We pass the lang because some constant propagation algorithm may be
  * specific to a language.
  *)
+(* !Note that this assumes Naming_AST.resolve has been called before! *)
 val propagate: Lang.t -> AST.program -> unit


### PR DESCRIPTION
This partially solves https://github.com/returntocorp/semgrep/issues/349

Test plan:
test file in semgrep_core.
See id_const_literal for CONST_GLOBAL below!

~/pfff/pfff -constant_propagation equivalence_constant_propagation.py
(Pr
   [(ExprStmt (
       (Assign (
          (Id (("CONST_GLOBAL", ()),
             { id_resolved = ref ((Some (Global, 1))); id_type = ref (None);
               id_const_literal = ref ((Some (String ("secret", ())))) }
             )),
          (), (L (String ("secret", ()))))),
       ()));
     (ExprStmt (
        (Assign (
           (Id (("GLOBAL", ()),
              { id_resolved = ref ((Some (Global, 2))); id_type = ref (None);
                id_const_literal = ref (None) }
              )),
           (), (L (String ("secret", ()))))),
        ()));
     (DefStmt