### PR TITLE
Add 'make reinstall-libs' to install script used by Dockerfile and CircleCI.

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -7,4 +7,5 @@ set -eu
 sudo bash <<EOF
 eval $(opam env)
 make install
+make reinstall-libs
 EOF


### PR DESCRIPTION
I'm assuming that just `make install` installs the `pfff` executable but not libraries. Please correct me as needed.