### PR TITLE
Parse python2 "raise expr, expr, expr"

### DIFF
--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -718,7 +718,8 @@ and stmt =
     | OS_Delete 
     (* todo: reduce? transpile? *)
     | OS_ForOrElse | OS_WhileOrElse | OS_TryOrElse
-    | OS_ThrowFrom | OS_ThrowNothing 
+    | OS_ThrowFrom | OS_ThrowNothing
+    | OS_ThrowArgsLocation (* Python2: `raise expr, expr` and `raise expr, expr, exr` *)
     | OS_Pass
     | OS_Async
     (* Java *)

--- a/lang_GENERIC/parsing/Meta_AST.ml
+++ b/lang_GENERIC/parsing/Meta_AST.ml
@@ -657,6 +657,7 @@ and vof_other_stmt_operator =
   | OS_TryOrElse -> OCaml.VSum (("OS_TryOrElse", []))
   | OS_ThrowFrom -> OCaml.VSum (("OS_ThrowFrom", []))
   | OS_ThrowNothing -> OCaml.VSum (("OS_ThrowNothing", []))
+  | OS_ThrowArgsLocation -> OCaml.VSum (("OS_ThrowArgsLocation", []))
   | OS_GlobalComplex -> OCaml.VSum (("OS_GlobalComplex", []))
   | OS_Pass -> OCaml.VSum (("OS_Pass", []))
   | OS_Sync -> OCaml.VSum (("OS_Sync", []))

--- a/lang_python/analyze/Python_to_generic.ml
+++ b/lang_python/analyze/Python_to_generic.ml
@@ -578,23 +578,11 @@ and stmt_aux x =
       in
       [G.OtherStmtWithStmt (G.OSWS_With, e, v3)]
 
-  | Raise (t, v1, v2, v3) ->
+  | Raise (t, v1) ->
       (match v1 with
       | Some (e, None) ->
         let e = expr e in
-        let st = G.Throw (t, e) in
-        (match (v2, v3) with
-        | (Some args, Some loc) ->
-          let args = expr args
-          and loc = expr loc
-          in
-          [G.OtherStmt (G.OS_ThrowArgsLocation, [G.E loc; G.E args; G.S st])]
-        | (Some args, None) ->
-          let args = expr args in
-          [G.OtherStmt (G.OS_ThrowArgsLocation, [G.E args; G.S st])]
-        | (None, _) ->
-          [st]
-        )
+        [G.Throw (t, e)]
       | Some (e, Some from) ->
         let e = expr e in
         let from = expr from in
@@ -603,6 +591,21 @@ and stmt_aux x =
       | None ->
         [G.OtherStmt (G.OS_ThrowNothing, [G.Tk t])]
       )
+  | RaisePython2 (t, e, v2, v3) ->
+    let e = expr e in
+    let st = G.Throw (t, e) in
+    (match (v2, v3) with
+    | (Some args, Some loc) ->
+      let args = expr args
+      and loc = expr loc
+      in
+      [G.OtherStmt (G.OS_ThrowArgsLocation, [G.E loc; G.E args; G.S st])]
+    | (Some args, None) ->
+      let args = expr args in
+      [G.OtherStmt (G.OS_ThrowArgsLocation, [G.E args; G.S st])]
+    | (None, _) ->
+      [st]
+    )
                   
   | TryExcept ((t, v1, v2, v3)) ->
       let v1 = list_stmt1 v1

--- a/lang_python/analyze/Python_to_generic.ml
+++ b/lang_python/analyze/Python_to_generic.ml
@@ -578,12 +578,24 @@ and stmt_aux x =
       in
       [G.OtherStmtWithStmt (G.OSWS_With, e, v3)]
 
-  | Raise (t, v1) ->
+  | Raise (t, v1, v2, v3) ->
       (match v1 with
-      | Some (e, None) -> 
-        let e = expr e in 
-        [G.Throw (t, e)]
-      | Some (e, Some from) -> 
+      | Some (e, None) ->
+        let e = expr e in
+        let st = G.Throw (t, e) in
+        (match (v2, v3) with
+        | (Some args, Some loc) ->
+          let args = expr args
+          and loc = expr loc
+          in
+          [G.OtherStmt (G.OS_ThrowArgsLocation, [G.E loc; G.E args; G.S st])]
+        | (Some args, None) ->
+          let args = expr args in
+          [G.OtherStmt (G.OS_ThrowArgsLocation, [G.E args; G.S st])]
+        | (None, _) ->
+          [st]
+        )
+      | Some (e, Some from) ->
         let e = expr e in
         let from = expr from in
         let st = G.Throw (t, e) in

--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -352,7 +352,7 @@ type stmt =
   | Break of tok | Continue of tok
   | Pass of tok
 
-  | Raise of tok * (expr * expr option (* from *)) option * expr option (* class *) * expr option (* location *)
+  | Raise of tok * (expr * expr option (* from *)) option * expr option (* arguments *) * expr option (* location *)
   | TryExcept of tok * stmt list (* body *) * excepthandler list (* handlers *)
            * stmt list (* orelse *)
   | TryFinally of tok * stmt list (* body *) * tok * stmt list (* finalbody *)

--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -352,7 +352,7 @@ type stmt =
   | Break of tok | Continue of tok
   | Pass of tok
 
-  | Raise of tok * (expr * expr option (* from *)) option
+  | Raise of tok * (expr * expr option (* from *)) option * expr option (* class *) * expr option (* location *)
   | TryExcept of tok * stmt list (* body *) * excepthandler list (* handlers *)
            * stmt list (* orelse *)
   | TryFinally of tok * stmt list (* body *) * tok * stmt list (* finalbody *)

--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -352,7 +352,8 @@ type stmt =
   | Break of tok | Continue of tok
   | Pass of tok
 
-  | Raise of tok * (expr * expr option (* from *)) option * expr option (* arguments *) * expr option (* location *)
+  | Raise of tok * (expr * expr option (* from *)) option
+  | RaisePython2 of tok * expr * expr option (* arguments *) * expr option (* location *)
   | TryExcept of tok * stmt list (* body *) * excepthandler list (* handlers *)
            * stmt list (* orelse *)
   | TryFinally of tok * stmt list (* body *) * tok * stmt list (* finalbody *)

--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -496,10 +496,13 @@ return_stmt:
 yield_stmt: yield_expr { ExprStmt ($1) }
 
 raise_stmt:
-  | RAISE                           { Raise ($1, None) }
-  | RAISE test                      { Raise ($1, Some ($2, None)) }
+  | RAISE                           { Raise ($1, None, None, None) }
+  | RAISE test                      { Raise ($1, Some ($2, None), None, None) }
   (* python3-ext: *)
-  | RAISE test FROM test            { Raise ($1, Some ($2, Some $4)) }
+  | RAISE test FROM test            { Raise ($1, Some ($2, Some $4), None, None) }
+  (* python2-ext: *)
+  | RAISE test "," test             { Raise ($1, Some ($2, None), Some $4, None) }
+  | RAISE test "," test "," test    { Raise ($1, Some ($2, None), Some $4, Some $6) }
 
 
 global_stmt: GLOBAL list_sep(NAME, ",") { Global ($1, $2) }

--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -496,13 +496,13 @@ return_stmt:
 yield_stmt: yield_expr { ExprStmt ($1) }
 
 raise_stmt:
-  | RAISE                           { Raise ($1, None, None, None) }
-  | RAISE test                      { Raise ($1, Some ($2, None), None, None) }
+  | RAISE                           { Raise ($1, None) }
+  | RAISE test                      { Raise ($1, Some ($2, None)) }
   (* python3-ext: *)
-  | RAISE test FROM test            { Raise ($1, Some ($2, Some $4), None, None) }
+  | RAISE test FROM test            { Raise ($1, Some ($2, Some $4)) }
   (* python2-ext: *)
-  | RAISE test "," test             { Raise ($1, Some ($2, None), Some $4, None) }
-  | RAISE test "," test "," test    { Raise ($1, Some ($2, None), Some $4, Some $6) }
+  | RAISE test "," test             { RaisePython2 ($1, $2, Some $4, None) }
+  | RAISE test "," test "," test    { RaisePython2 ($1, $2, Some $4, Some $6) }
 
 
 global_stmt: GLOBAL list_sep(NAME, ",") { Global ($1, $2) }

--- a/lang_python/parsing/Visitor_python.ml
+++ b/lang_python/parsing/Visitor_python.ml
@@ -335,13 +335,15 @@ and v_stmt x =
       and v2 = v_option v_expr v2
       and v3 = v_list v_stmt v3
       in ()
-  | Raise (t, v1) ->
+  | Raise (t, v1, v2, v3) ->
         let t = v_info t in
       let v1 =
         v_option
           (fun (v1, v2) ->
              let v1 = v_expr v1 and v2 = v_option v_expr v2 in ())
           v1
+      and v2 = v_option v_expr v2
+      and v3 = v_option v_expr v3
       in ()
   | TryExcept ((t, v1, v2, v3)) ->
         let t = v_info t in

--- a/lang_python/parsing/Visitor_python.ml
+++ b/lang_python/parsing/Visitor_python.ml
@@ -335,13 +335,17 @@ and v_stmt x =
       and v2 = v_option v_expr v2
       and v3 = v_list v_stmt v3
       in ()
-  | Raise (t, v1, v2, v3) ->
+  | Raise (t, v1) ->
         let t = v_info t in
       let v1 =
         v_option
           (fun (v1, v2) ->
              let v1 = v_expr v1 and v2 = v_option v_expr v2 in ())
           v1
+      in ()
+  | RaisePython2 (t, v1, v2, v3) ->
+      let t = v_info t
+      and v1 = v_expr v1
       and v2 = v_option v_expr v2
       and v3 = v_option v_expr v3
       in ()

--- a/tests/python/parsing/python2/raise.py
+++ b/tests/python/parsing/python2/raise.py
@@ -1,3 +1,6 @@
+def foo():
+    pass
+
 try:
     foo()
 except Exception, ex:
@@ -7,3 +10,8 @@ try:
     foo()
 except Exception as ex:
     print ex
+
+try:
+    foo()
+except:
+    raise Exception, "message", sys.exc_info()[2]

--- a/tests/python/parsing/python2/raise.sgrep
+++ b/tests/python/parsing/python2/raise.sgrep
@@ -1,0 +1,1 @@
+raise $CLASS, $ARGS, $LOC


### PR DESCRIPTION
This is a one-off construct in python2, so I add a one-off node in the
generic AST: OS_ThrowArgsLocation to handle it. Doing so will allow us
to match all these expressions.

Fixes returntocorp/semgrep#1162.