### PR TITLE
Parse Python2 tuple patterns

### DIFF
--- a/lang_python/analyze/Python_to_generic.ml
+++ b/lang_python/analyze/Python_to_generic.ml
@@ -416,14 +416,20 @@ and slice e =
       G.SliceAccess (e, v1, v2, v3)
 (*e: function [[Python_to_generic.slice]] *)
 
+and param_pattern = function
+  | PatternName n -> G.PatId (name n, G.empty_id_info())
+  | PatternTuple t -> G.PatTuple (list param_pattern t)
+
 (*s: function [[Python_to_generic.parameters]] *)
 and parameters xs =
   xs |> List.map (function
-  | ParamClassic ((n, topt), eopt) ->
+  | ParamClassic ((PatternName n, topt), eopt) ->
      let n = name n in
      let topt = option type_ topt in
      let eopt = option expr eopt in
      G.ParamClassic { (G.param_of_id n) with G.ptype = topt; pdefault = eopt; }
+  | ParamClassic ((PatternTuple pat, _), _) ->
+     G.ParamPattern (G.PatTuple (list param_pattern pat))
   | ParamStar (n, topt) ->
      let n = name n in
      let topt = option type_ topt in

--- a/lang_python/analyze/Python_to_generic.ml
+++ b/lang_python/analyze/Python_to_generic.ml
@@ -423,12 +423,16 @@ and param_pattern = function
 (*s: function [[Python_to_generic.parameters]] *)
 and parameters xs =
   xs |> List.map (function
-  | ParamClassic ((PatternName n, topt), eopt) ->
+  | ParamDefault ((n, topt), e) ->
      let n = name n in
      let topt = option type_ topt in
-     let eopt = option expr eopt in
-     G.ParamClassic { (G.param_of_id n) with G.ptype = topt; pdefault = eopt; }
-  | ParamClassic ((PatternTuple pat, _), _) ->
+     let e = expr e in
+     G.ParamClassic { (G.param_of_id n) with G.ptype = topt; pdefault = Some e; }
+  | ParamPattern ((PatternName n, topt)) ->
+     let n = name n
+     and topt = option type_ topt in
+     G.ParamClassic { (G.param_of_id n) with G.ptype = topt }
+  | ParamPattern ((PatternTuple pat, _)) ->
      G.ParamPattern (G.PatTuple (list param_pattern pat))
   | ParamStar (n, topt) ->
      let n = name n in

--- a/lang_python/analyze/highlight_python.ml
+++ b/lang_python/analyze/highlight_python.ml
@@ -258,11 +258,12 @@ let visit_program ~tag_hook _prefs (program, toks) =
     );
     V.kparameter = (fun (k, _) x ->
       (match x with
-      | ParamClassic ((PatternName name, _), _)
+      | ParamPattern ((PatternName name, _))
+      | ParamDefault ((name, _), _)
       | ParamStar (name, _) | ParamPow (name, _) ->
         tag_name name (Parameter Def);
       | ParamSingleStar _ | ParamEllipsis _
-      | ParamClassic ((PatternTuple _, _), _) ->
+      | ParamPattern ((PatternTuple _, _)) ->
         ()
       );
       k x

--- a/lang_python/analyze/highlight_python.ml
+++ b/lang_python/analyze/highlight_python.ml
@@ -258,10 +258,12 @@ let visit_program ~tag_hook _prefs (program, toks) =
     );
     V.kparameter = (fun (k, _) x ->
       (match x with
-      | ParamClassic ((name, _), _)
+      | ParamClassic ((PatternName name, _), _)
       | ParamStar (name, _) | ParamPow (name, _) ->
         tag_name name (Parameter Def);
-      | ParamSingleStar _ | ParamEllipsis _ -> ()
+      | ParamSingleStar _ | ParamEllipsis _
+      | ParamClassic ((PatternTuple _, _), _) ->
+        ()
       );
       k x
     );

--- a/lang_python/analyze/resolve_python.ml
+++ b/lang_python/analyze/resolve_python.ml
@@ -74,9 +74,9 @@ let params_of_parameters params =
       (spf "!arg%d!" ix, Parse_info.fake_info "tuple")
   in
   let collect_param_names (ix, out) = function
-    | ParamClassic ((pat, _), _) ->
+    | ParamPattern ((pat, _)) ->
       (ix + 1, (param_pattern_name ix pat)::out)
-    | ParamStar (name, _) | ParamPow (name, _) ->
+    | ParamDefault ((name, _), _) | ParamStar (name, _) | ParamPow (name, _) ->
       (ix + 1, name::out)
     | ParamSingleStar _ | ParamEllipsis _ ->
       (ix + 1, out)

--- a/lang_python/analyze/resolve_python.ml
+++ b/lang_python/analyze/resolve_python.ml
@@ -13,6 +13,7 @@
  * license.txt for more details.
  *)
 open AST_python
+open Common
 module Ast = AST_python
 module V = Visitor_python
 
@@ -62,14 +63,28 @@ let add_name_env name kind env =
 let with_new_context ctx env f = 
   Common.save_excursion env.ctx ctx f
 
-
 let params_of_parameters params =
-  params |> Common.map_filter (function
-    | ParamClassic ((name, _), _)
-    | ParamStar (name, _) | ParamPow (name, _) 
-    -> Some name
-    | ParamSingleStar _ | ParamEllipsis _ -> None
-   )
+  let param_pattern_name ix = function
+    | PatternName name -> name
+    | PatternTuple _names ->
+      (* We factor all tuple patterns into a common generic name, so these are useless for further analysis.
+       * They will, however, parse.
+       * TODO: Add factoring similar to lang_js/analyze/transpile_js patterns
+       *)
+      (spf "!arg%d!" ix, Parse_info.fake_info "tuple")
+  in
+  let collect_param_names (ix, out) = function
+    | ParamClassic ((pat, _), _) ->
+      (ix + 1, (param_pattern_name ix pat)::out)
+    | ParamStar (name, _) | ParamPow (name, _) ->
+      (ix + 1, name::out)
+    | ParamSingleStar _ | ParamEllipsis _ ->
+      (ix + 1, out)
+  in
+  let zipped = List.fold_left collect_param_names (0, []) params
+  in
+  (match zipped with | (_, names) -> names)
+
 
 (*****************************************************************************)
 (* Entry point *)

--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -273,7 +273,9 @@ type expr =
       (* the first expr can be only a Name or a Tuple (pattern?),
        * and the Name can have a type associated with it
        *)
-     | ParamClassic of (param_pattern * type_ option) * expr option (* default value *)
+     | ParamDefault of (name * type_ option) * expr (* default value *)
+     (* pattern can be either a name or a tuple pattern *)
+     | ParamPattern of param_pattern * type_ option
      | ParamStar of (name * type_ option)
      (* python3: single star delimiter to force keyword-only arguments after.
       * reference: https://www.python.org/dev/peps/pep-3102/ *)

--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -273,7 +273,7 @@ type expr =
       (* the first expr can be only a Name or a Tuple (pattern?),
        * and the Name can have a type associated with it
        *)
-     | ParamClassic of (name * type_ option) * expr option (* default value *)
+     | ParamClassic of (param_pattern * type_ option) * expr option (* default value *)
      | ParamStar of (name * type_ option)
      (* python3: single star delimiter to force keyword-only arguments after.
       * reference: https://www.python.org/dev/peps/pep-3102/ *)
@@ -317,9 +317,13 @@ and type_parent = argument
 (*****************************************************************************)
 (*s: type [[AST_python.pattern]] *)
 (* Name, or Tuple? or more? *)
-type pattern = expr
+and pattern = expr
 (*e: type [[AST_python.pattern]] *)
  [@@deriving show]  (* with tarzan *)
+
+and param_pattern =
+  | PatternName of name
+  | PatternTuple of param_pattern list
 
 (*****************************************************************************)
 (* Statement *)

--- a/lang_python/parsing/Visitor_python.ml
+++ b/lang_python/parsing/Visitor_python.ml
@@ -245,8 +245,12 @@ and v_parameter x =
   match x with
   | ParamSingleStar v1 -> v_tok v1; ()
   | ParamEllipsis v1 -> v_tok v1; ()
-  | ParamClassic ((v1, v2)) ->
-      let v1 = v_param_pattern_and_type v1 and v2 = v_option v_expr v2 in ()
+  | ParamDefault ((v1, v2)) ->
+      let v1 = v_name_and_type v1 and v2 = v_expr v2 in ()
+  | ParamPattern ((v1, v2)) ->
+      let v1 = v_param_pattern v1
+      and v2 = v_option v_type_ v2
+      in ()
   | ParamStar ((v1, v2)) ->
       let v1 = v_name v1 and v2 = v_option v_type_ v2 in ()
   | ParamPow ((v1, v2)) ->
@@ -254,8 +258,8 @@ and v_parameter x =
   in
   vin.kparameter (k, all_functions) x
 
-and v_param_pattern_and_type (v1, v2) =
-  let v1 = v_param_pattern v1
+and v_name_and_type (v1, v2) =
+  let v1 = v_name v1
   and v2 = v_option v_type_ v2
   in ()
 

--- a/lang_python/parsing/Visitor_python.ml
+++ b/lang_python/parsing/Visitor_python.ml
@@ -246,7 +246,7 @@ and v_parameter x =
   | ParamSingleStar v1 -> v_tok v1; ()
   | ParamEllipsis v1 -> v_tok v1; ()
   | ParamClassic ((v1, v2)) ->
-      let v1 = v_name_and_type v1 and v2 = v_option v_expr v2 in ()
+      let v1 = v_param_pattern_and_type v1 and v2 = v_option v_expr v2 in ()
   | ParamStar ((v1, v2)) ->
       let v1 = v_name v1 and v2 = v_option v_type_ v2 in ()
   | ParamPow ((v1, v2)) ->
@@ -254,8 +254,14 @@ and v_parameter x =
   in
   vin.kparameter (k, all_functions) x
 
-and v_name_and_type (v1, v2) =
-  let v1 = v_name v1 and v2 = v_option v_type_ v2 in ()
+and v_param_pattern_and_type (v1, v2) =
+  let v1 = v_param_pattern v1
+  and v2 = v_option v_type_ v2
+  in ()
+
+and v_param_pattern = function
+  | PatternName v1 -> v_name v1; ()
+  | PatternTuple v1 -> v_list v_param_pattern v1; ()
 
 and v_expr_and_opt_expr (v1, opt) = 
   let v1 = v_expr v1 in

--- a/tests/python/parsing/python2/pattern.py
+++ b/tests/python/parsing/python2/pattern.py
@@ -1,0 +1,4 @@
+def foo(x, (y, z)):
+    pass
+
+z = lambda (x, y): x + y

--- a/tests/python/parsing_errors/python2/pattern.py
+++ b/tests/python/parsing_errors/python2/pattern.py
@@ -1,0 +1,2 @@
+def foo(**(x, y)):
+    pass


### PR DESCRIPTION
Adds the ability to parse

```
  def foo((x, y)):
      ...
```

and

```
  lambda (x, y): ...
```

Note that the solution here would allow funky mixed Python2/3 syntax:

```
  def foo(x: int, (y, z)):
      ...
```

But this should be ok for code search.

Fixes returntocorp/semgrep#994.

Fixes returntocorp/semgrep#1164.