### PR TITLE
Parse trailing whitespace in Python files

### DIFF
--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -216,7 +216,14 @@ tuple(X):
 (* Toplevel *)
 (*************************************************************************)
 
-main: file_input EOF { $1 }
+main:
+ | file_input EOF { $1 }
+ (* Handles trailing indentation.
+  * Note that I couldn't figure out why the lexer spits this out,
+  * but I didn't want to mess with its state machine too much,
+  * so I just match against the relavent output here.
+  *)
+ | file_input INDENT NEWLINE DEDENT NEWLINE EOF { $1 }
 
 file_input: nl_or_stmt* { List.flatten $1 }
 

--- a/tests/python/parsing/trailing.py
+++ b/tests/python/parsing/trailing.py
@@ -1,0 +1,2 @@
+json_error(_("foobar"))
+	


### PR DESCRIPTION
For whatever reason, the Python interpreter allows you to leave dangling
whitespace after the last statement in a Python file, and this does not
actually get interpreted as indentation.

I couldn't figure out exactly what the lexer was doing here, but it
parses trailing whitespace (all on one line) as:

  INDENT NEWLINE DEDENT NEWLINE EOF

Here I just match against this magic code and drop it at the end of
a file.

Fixes returntocorp/semgrep#312.