### PR TITLE
Parse Python 3.8 positional-only demarcator

### DIFF
--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -1069,7 +1069,7 @@ and function_definition = {
 (*s: type [[AST_generic.other_parameter_operator]] *)
   and other_parameter_operator =
      (* Python *)
-     | OPO_KwdParam | OPO_SingleStarParam
+     | OPO_KwdParam | OPO_SingleStarParam | OPO_SlashParam
      (* Go *)
      | OPO_Receiver (* of parameter_classic, used to tag the "self" parameter*)
      (* PHP *) 

--- a/lang_GENERIC/parsing/Meta_AST.ml
+++ b/lang_GENERIC/parsing/Meta_AST.ml
@@ -890,6 +890,7 @@ and vof_other_parameter_operator =
   | OPO_Ref -> OCaml.VSum (("OPO_Ref", []))
   | OPO_Receiver -> OCaml.VSum (("OPO_Receiver", []))
   | OPO_SingleStarParam -> OCaml.VSum ("OPO_SingleStarParam", [])
+  | OPO_SlashParam -> OCaml.VSum ("OPO_SlashParam", [])
 and vof_variable_definition { vinit = v_vinit; vtype = v_vtype } =
   let bnds = [] in
   let arg = OCaml.vof_option vof_type_ v_vtype in

--- a/lang_python/analyze/Python_to_generic.ml
+++ b/lang_python/analyze/Python_to_generic.ml
@@ -447,6 +447,8 @@ and parameters xs =
    | ParamEllipsis tok -> G.ParamEllipsis tok
    | ParamSingleStar tok ->
      G.OtherParam (G.OPO_SingleStarParam, [G.Tk tok])
+   | ParamSlash tok ->
+     G.OtherParam (G.OPO_SlashParam, [G.Tk tok])
   )
 (*e: function [[Python_to_generic.parameters]] *)
 

--- a/lang_python/analyze/highlight_python.ml
+++ b/lang_python/analyze/highlight_python.ml
@@ -262,7 +262,7 @@ let visit_program ~tag_hook _prefs (program, toks) =
       | ParamDefault ((name, _), _)
       | ParamStar (name, _) | ParamPow (name, _) ->
         tag_name name (Parameter Def);
-      | ParamSingleStar _ | ParamEllipsis _
+      | ParamSingleStar _ | ParamSlash _ | ParamEllipsis _
       | ParamPattern ((PatternTuple _, _)) ->
         ()
       );

--- a/lang_python/analyze/resolve_python.ml
+++ b/lang_python/analyze/resolve_python.ml
@@ -78,7 +78,7 @@ let params_of_parameters params =
       (ix + 1, (param_pattern_name ix pat)::out)
     | ParamDefault ((name, _), _) | ParamStar (name, _) | ParamPow (name, _) ->
       (ix + 1, name::out)
-    | ParamSingleStar _ | ParamEllipsis _ ->
+    | ParamSingleStar _ | ParamSlash _ | ParamEllipsis _ ->
       (ix + 1, out)
   in
   let zipped = List.fold_left collect_param_names (0, []) params

--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -280,6 +280,8 @@ type expr =
      (* python3: single star delimiter to force keyword-only arguments after.
       * reference: https://www.python.org/dev/peps/pep-3102/ *)
      | ParamSingleStar of tok
+     (* python3: single slash delimiter to force positional-only arguments prior. *)
+     | ParamSlash of tok
      | ParamPow  of (name * type_ option)
      (* sgrep-ext: *)
      | ParamEllipsis of tok

--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -149,7 +149,7 @@ let mk_str ii =
 (* operators *)
 %token <AST_python.tok> 
   ADD            (* + *)  SUB            (* - *)
-  MULT "*"       (* * *)  DIV            (* / *)
+  MULT "*"       (* * *)  DIV "/"        (* / *)
   MOD            (* % *)
   POW  "**"      (* ** *)  FDIV           (* // *)
   BITOR          (* | *)  BITAND         (* & *)  BITXOR         (* ^ *)
@@ -380,6 +380,8 @@ typed_parameter:
   | tfpdef "=" test { ParamDefault (mk_name_param $1, $3) }
   | "*" tfpdef      { ParamStar (fst $2, snd $2) }
   | "*"             { ParamSingleStar $1 }
+  (* python3-ext: https://www.python.org/dev/peps/pep-0570/ *)
+  | "/"             { ParamSlash $1 }
   | "**" tfpdef     { ParamPow (fst $2, snd $2) }
   (* sgrep-ext: *)
   | "..."           { Flag_parsing.sgrep_guard (ParamEllipsis $1) }
@@ -409,6 +411,8 @@ parameter:
   | fpdef           { ParamPattern ($1, None) }
   | NAME "=" test   { ParamDefault (($1, None), $3) }
   | "*" NAME        { ParamStar ($2, None) }
+  (* python3-ext: https://www.python.org/dev/peps/pep-0570/ *)
+  | "/"             { ParamSlash $1 }
   | "**" NAME       { ParamPow ($2, None) }
 
 fpdef:

--- a/lang_python/parsing/Visitor_python.ml
+++ b/lang_python/parsing/Visitor_python.ml
@@ -243,7 +243,7 @@ and v_parameters v = v_list v_parameter v
 and v_parameter x =
   let k x = 
   match x with
-  | ParamSingleStar v1 -> v_tok v1; ()
+  | ParamSingleStar v1 | ParamSlash v1 -> v_tok v1; ()
   | ParamEllipsis v1 -> v_tok v1; ()
   | ParamDefault ((v1, v2)) ->
       let v1 = v_name_and_type v1 and v2 = v_expr v2 in ()

--- a/tests/python/parsing/params-positional-only.py
+++ b/tests/python/parsing/params-positional-only.py
@@ -1,0 +1,3 @@
+# Python 3.8 -- PEP 570
+def f(a, /, b, *, c=1):
+    return a + b + c


### PR DESCRIPTION
PEP 570 adds a single slash as a demarcation between positional-only and
classic Python 3 parameters. This commit adds parsing support.

Fixes returntocorp/semgrep#1165.