### PR TITLE
opam install with 'reinstall-libs'

### DIFF
--- a/pfff.opam
+++ b/pfff.opam
@@ -30,7 +30,7 @@ build: [
   [make "opt"]
 ]
 install: [
-  [make "install-libs"]
+  [make "reinstall-libs"]
 ]
 depends: [
   "ocaml" {>= "4.07.0"}


### PR DESCRIPTION
This avoids a problem in my environment, where an error tells me that the libs are already installed when running in docker. Something must be unclean, but regardless I also think the `reinstall-libs` is a reasonable default, so here we go.