### PR TITLE
Return python Expr for sgrep expressions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
   semgrep:
     docker:
       - image: returntocorp/semgrep:develop
-    working_directory: /home/repo
+    working_directory: /src
     steps:
       - checkout
       - run: semgrep --config semgrep.yml --error .

--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -232,8 +232,12 @@ nl_or_stmt:
  | stmt    { $1 }
 
 sgrep_spatch_pattern:
- | small_stmt EOF            { match $1 with [x] -> Stmt x | xs -> Stmts xs }
- | small_stmt NEWLINE EOF    { match $1 with [x] -> Stmt x | xs -> Stmts xs }
+ | small_stmt NEWLINE? EOF   {
+   match $1 with
+   | [ExprStmt x] -> Expr x
+   | [x] -> Stmt x
+   | xs -> Stmts xs
+ }
  | compound_stmt EOF         { Stmt $1 }
  | compound_stmt NEWLINE EOF { Stmt $1 }
 


### PR DESCRIPTION
In bc9cdad83, we resolved a S/R conflict by choosing to represent
"expression" type Python sgrep patterns as ExprStmt nodes. This appears
to have caused regressions within semgrep. Let's instead resolve by
choosing to represent these patterns as Expr nodes.

I validated that this works in semgrep/semgrep-core by:

  opam uninstall pfff
  opam install ../pfff
  make clean
  make
  make install
  make test