### PR TITLE
Parse Python 2 "True" and "False" as names

### DIFF
--- a/lang_python/parsing/Lexer_python.mll
+++ b/lang_python/parsing/Lexer_python.mll
@@ -406,8 +406,8 @@ and _token python2 state = parse
          * in case of a parse error.
          *)
         | "None"    -> NONE (tokinfo lexbuf)
-        | "True"    -> TRUE (tokinfo lexbuf)
-        | "False"    -> FALSE (tokinfo lexbuf)
+        | "True"   when not python2 -> TRUE (tokinfo lexbuf)
+        | "False"  when not python2 -> FALSE (tokinfo lexbuf)
 
         | "async"    when not python2 -> ASYNC (tokinfo lexbuf)
         | "await"    when not python2 -> AWAIT (tokinfo lexbuf)

--- a/lang_python/parsing/Parse_python.ml
+++ b/lang_python/parsing/Parse_python.ml
@@ -144,7 +144,7 @@ let rec parse_basic ?(parsing_mode=Python) filename =
     if parsing_mode = Python &&
        (tr.PI.passed |> Common.take_safe 10 |> List.exists (function
          | T.NAME (("print" | "exec"), _) 
-         | T.ASYNC _ | T.AWAIT _ | T.NONLOCAL _
+         | T.ASYNC _ | T.AWAIT _ | T.NONLOCAL _ | T.TRUE _ | T.FALSE _
               -> true
          | _ -> false))
     then 

--- a/tests/python/parsing/python2/reassign-true.py
+++ b/tests/python/parsing/python2/reassign-true.py
@@ -1,0 +1,8 @@
+True = False
+
+class Test():
+    def __init__(self):
+        self.True = False
+        
+t = Test()
+print t.True


### PR DESCRIPTION
In Python 2 they are names, not keywords.

Fixes returntocorp/semgrep#1168.