### PR TITLE
Create generic AST from nested JS patterns

### DIFF
--- a/tests/js/parsing/pattern_nested.js
+++ b/tests/js/parsing/pattern_nested.js
@@ -6,6 +6,10 @@
 // PatNested
 const { RSVP: { resolve } } = Ember;
 
+const [ x, { a, b } ] = y;
+
+const [ m, [ n, o ] ] = p;
+
 //export default function(name, options = {}) {
 //    module(name, {
 //        beforeEach() {

--- a/tests/js/parsing/pattern_param.js
+++ b/tests/js/parsing/pattern_param.js
@@ -17,3 +17,7 @@ const x: Y = ({
    findings,
    filePath
 }) => repoSlug;
+
+foo.every(([a, {b, c}]) => a + b + c);
+
+foo.every(([m, [n, {o, p}]]) => null);


### PR DESCRIPTION
Previously, our transpilation step (necessary for creating a generic
AST) for JavaScript could not handle nested array patterns.

Note that JavaScript does not support nested object patterns (instead,
one would assign to the right-hand-side of a property pattern), so we
fail hard in this case.

After this commit, patterns like:

```javascript
  function foo([a, [b, {c}]]) { ... }
```

Will be transpiled to:

```javascript
  function foo(arg0) {
    let a = arg0[0];
    let b = arg0[1][0];
    let c = arg0[1][1].c;
  }
```

Fixes returntocorp/semgrep#582