### PR TITLE
Support binding patterns in JS catch-expressions

### DIFF
--- a/lang_js/analyze/ast_js.ml
+++ b/lang_js/analyze/ast_js.ml
@@ -267,7 +267,7 @@ and stmt =
    | Default of tok * stmt
 
   and catch =
-   | BoundCatch of tok * name * stmt
+   | BoundCatch of tok * pattern * stmt
    (* es2019 *)
    | UnboundCatch of tok * stmt
 

--- a/lang_js/analyze/ast_js_build.ml
+++ b/lang_js/analyze/ast_js_build.ml
@@ -462,10 +462,10 @@ and stmt1_item_list env items =
   stmt_item_list env items |> stmt_of_stmts
 
 and catch_block_handler env = function
-  | C.BoundCatch (t, arg, st) ->
-      let arg = name env (C.unparen arg) in
+  | C.BoundCatch (t, pat, st) ->
+      let pat = pattern env (C.unparen pat) in
       let st = stmt1 env st in
-      A.BoundCatch (t, arg, st)
+      A.BoundCatch (t, pat, st)
   | C.UnboundCatch (t, st) ->
       A.UnboundCatch (t, stmt1 env st)
   

--- a/lang_js/analyze/graph_code_js.ml
+++ b/lang_js/analyze/graph_code_js.ml
@@ -430,11 +430,8 @@ and stmt env = function
    finalopt |> Common.opt (fun (_t, st) -> stmt env st);
 
 and catch_block env = function
-  | BoundCatch (_t, n, st) ->
-     let v = { v_name = n; v_kind = Let, fake "let"; 
-               v_init = None; 
-               v_resolved = ref Local } in
-     let env = add_locals env [v] in
+  | BoundCatch (_t, pat, st) ->
+     expr env pat;
      stmt env st
   | UnboundCatch (_t, st) -> stmt env st
 

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -272,9 +272,9 @@ and stmt x =
 
 and catch_block = function
   | BoundCatch (t, v1, v2) ->
-      let v1 = name v1
+      let v1 = G.expr_to_pattern (expr v1)
       and v2 = stmt v2
-      in t, G.PatId (v1, G.empty_id_info()), v2
+      in t, v1, v2
   | UnboundCatch (t, v1) ->
       let v1 = stmt v1
       in t, G.PatUnderscore (Parse_info.fake_info "_"), v1

--- a/lang_js/analyze/map_ast_js.ml
+++ b/lang_js/analyze/map_ast_js.ml
@@ -247,7 +247,7 @@ and map_stmt =
 and map_catch_block = function
   | BoundCatch (t, v1, v2) ->
       let t = map_tok t
-      and v1 = map_name v1
+      and v1 = map_expr v1
       and v2 = map_stmt v2
       in BoundCatch (t, v1, v2)
   | UnboundCatch (t, v1) ->

--- a/lang_js/analyze/visitor_ast_js.ml
+++ b/lang_js/analyze/visitor_ast_js.ml
@@ -205,7 +205,7 @@ and v_stmt x =
 and v_catch_block = function
   | BoundCatch (t, v1, v2) ->
       let t = v_tok t
-      and v1 = v_name v1
+      and v1 = v_expr v1
       and v2 = v_stmt v2
       in ()
   | UnboundCatch (t, v1) ->

--- a/lang_js/parsing/cst_js.ml
+++ b/lang_js/parsing/cst_js.ml
@@ -350,10 +350,9 @@ and stmt =
     | Case of tok * expr * tok (*:*) * item list
 
   and catch_block =
-    | BoundCatch of tok * (arg_catch paren) * stmt
+    | BoundCatch of tok * pattern paren * stmt
     (* es2019 *)
     | UnboundCatch of tok * stmt
-  and arg_catch = string wrap
 
 (*****************************************************************************)
 (* Type *)

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -936,9 +936,10 @@ try_stmt:
  | T_TRY block catch finally { Try ($1, $2, Some $3, Some $4) }
 
 catch:
- | T_CATCH "(" id ")" block { BoundCatch ($1, ($2, $3, $4), $5) }
+ | T_CATCH "(" id ")" block { BoundCatch ($1, ($2, PatId ($3, None), $4), $5) }
  (* es2019 *)
  | T_CATCH block { UnboundCatch ($1, $2) }
+ | T_CATCH "(" binding_pattern ")" block { BoundCatch ($1, ($2, $3, $4), $5) }
 
 finally: T_FINALLY block { $1, $2 }
 

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -363,7 +363,7 @@ and v_st x =
 and v_catch_block = function
   | BoundCatch (v1, v2, v3) ->
       let v1 = v_tok v1
-      and v2 = v_paren v_arg v2
+      and v2 = v_paren v_pattern v2
       and v3 = v_st v3
       in ()
   | UnboundCatch (v1, v2) ->

--- a/tests/js/parsing/pattern_catch.js
+++ b/tests/js/parsing/pattern_catch.js
@@ -1,0 +1,11 @@
+try {
+  throw foo;
+} catch ({ message }) {
+  console.log(message);
+}
+
+try {
+  throw foo;
+} catch (message) {
+  console.log(message);
+}


### PR DESCRIPTION
ECMA 2021 allows for binding parameters in the argument to catch
expressions. See https://tc39.es/ecma262/#prod-CatchParameter.

This commit adds support for them.

Fixes returntocorp/semgrep#1040.