### PR TITLE
Go Metavariable Parsing Bug Fix

### DIFF
--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -1334,6 +1334,7 @@ and any =
   | Pr of program
   (*s: [[AST_generic.any]] other cases *)
   | N of name
+  | Modn of module_name
   | En of entity
   | Pa of parameter
   | Ar of argument

--- a/lang_GENERIC/parsing/Map_AST.ml
+++ b/lang_GENERIC/parsing/Map_AST.ml
@@ -807,6 +807,7 @@ and map_any =
   | Tk v1 -> let v1 = map_tok v1 in Tk v1
   | I v1 -> let v1 = map_ident v1 in I ((v1))
   | N v1 -> let v1 = map_name v1 in N ((v1))
+  | Modn v1 -> let v1 = map_module_name v1 in Modn ((v1))
   | En v1 -> let v1 = map_entity v1 in En ((v1))
   | E v1 -> let v1 = map_expr v1 in E ((v1))
   | S v1 -> let v1 = map_stmt v1 in S ((v1))

--- a/lang_GENERIC/parsing/Meta_AST.ml
+++ b/lang_GENERIC/parsing/Meta_AST.ml
@@ -1061,6 +1061,7 @@ and vof_any =
   function
   | Tk v1 -> let v1 = vof_tok v1 in OCaml.VSum (("Tk", [ v1 ]))
   | N v1 -> let v1 = vof_name v1 in OCaml.VSum (("N", [ v1 ]))
+  | Modn v1 -> let v1 = vof_module_name v1 in OCaml.VSum (("Modn", [ v1 ]))
   | En v1 -> let v1 = vof_entity v1 in OCaml.VSum (("En", [ v1 ]))
   | E v1 -> let v1 = vof_expr v1 in OCaml.VSum (("E", [ v1 ]))
   | S v1 -> let v1 = vof_stmt v1 in OCaml.VSum (("S", [ v1 ]))

--- a/lang_GENERIC/parsing/Visitor_AST.ml
+++ b/lang_GENERIC/parsing/Visitor_AST.ml
@@ -706,6 +706,7 @@ and v_program v = v_stmts v
 and v_any =
   function
   | N v1 -> let v1 = v_name v1 in ()
+  | Modn v1 -> let v1 = v_module_name v1 in ()
   | En v1 -> let v1 = v_entity v1 in ()
   | E v1 -> let v1 = v_expr v1 in ()
   | S v1 -> let v1 = v_stmt v1 in ()


### PR DESCRIPTION
Added node Modn to AST in order to correctly call envf. DId this in order to fix the go metavariable parsing error issue 638.