### PR TITLE
Refactor Go toplevel declaration

### DIFF
--- a/lang_go/analyze/go_to_generic.ml
+++ b/lang_go/analyze/go_to_generic.ml
@@ -547,8 +547,14 @@ and top_decl =
       let receiver = G.OtherParam (G.OPO_Receiver, [G.Pa (G.ParamClassic v2)])
       in
       G.DefStmt (ent, G.FuncDef { def with G.fparams=receiver::def.G.fparams})
-  | D v1 -> let v1 = decl v1 in
-      v1
+  | DTop v1 -> let v1 = decl v1 in v1
+  | STop v1 -> stmt v1
+  | Package (t1, id) -> 
+      let id = ident id in
+      G.DirectiveStmt (G.Package (t1, [id]))
+  | Import x ->
+      let x = import x in
+      G.DirectiveStmt x
 
 and import { i_path = i_path; i_kind = i_kind; i_tok } =
   let module_name = G.FileName (wrap string i_path) in
@@ -568,14 +574,12 @@ and import_kind itok kind module_name _id_no_more_used =
   | ImportDot v1 -> let v1 = tok v1 in 
       G.ImportAll (itok, module_name, v1)
 
-and program { package = pack; imports = imports; decls = decls } =
+and program xs =
   anon_types := [];
-  let (t1, id) = pack in
-  let arg1 = ident id |> (fun x -> G.DirectiveStmt (G.Package (t1, [x]))) in
-  let arg2 = list import imports |> List.map (fun x -> G.DirectiveStmt x) in
-  let arg3 = list top_decl decls in
+  let xs = list top_decl xs in
   let arg_types = !anon_types |> List.map (fun x -> G.DefStmt x) in
-  arg1 :: arg2 @ arg_types @ arg3
+  (* TODO? put after program and imports? *)
+  arg_types @ xs
 
 and item_aux = function
  | ITop x -> [top_decl x]

--- a/lang_go/analyze/highlight_go.ml
+++ b/lang_go/analyze/highlight_go.ml
@@ -126,8 +126,10 @@ let visit_program ~tag_hook _prefs (program, toks) =
 
     (* defs *)
     V.kprogram = (fun (k, _) x ->
-      tag_ident (snd x.package) (Entity (E.Module, def2));
-      x.imports |> List.iter (fun import ->
+      let (package, imports) = package_and_imports_of_program x in
+
+      tag_ident (snd package) (Entity (E.Module, def2));
+      imports |> List.iter (fun import ->
         tag_ident import.i_path (Entity (E.Module, use2));
         match import.i_kind with
         | ImportNamed id -> tag_ident id (Entity (E.Module, def2))
@@ -139,7 +141,8 @@ let visit_program ~tag_hook _prefs (program, toks) =
       (match x with
       | DFunc   (id,     (_t, _st)) -> tag_ident id (Entity (E.Function, def2))
       | DMethod (id, _o, (_t, _st)) -> tag_ident id (Entity (E.Method, def2))
-      | D _ -> ()
+      | DTop _ | STop _ -> ()
+      | Package _ | Import _ -> ()
       );
      Common.save_excursion in_toplevel false (fun () -> 
        k x

--- a/lang_go/parsing/parser_go.mly
+++ b/lang_go/parsing/parser_go.mly
@@ -278,9 +278,11 @@ let rev_and_fix_items xs =
 /*(*************************************************************************)*/
 
 file: package imports xdcl_list EOF 
-  { { package = $1; imports = List.rev $2; decls = List.rev $3 } }
+  { ($1)::
+    (List.rev $2 |> List.map (fun x -> Import x)) @
+    (List.rev $3) }
 
-package: LPACKAGE sym LSEMICOLON { $1, $2 }
+package: LPACKAGE sym LSEMICOLON { Package ($1, $2) }
 
 /*(* Go does some ASI so we do not need like in Java to use stmt_no_dots
    * to allow '...' without trailing semicolon and avoid ambiguities.
@@ -304,8 +306,6 @@ item:
 item_list:
 |   item { $1 }
 |   item_list LSEMICOLON item { $3 @ $1 }
-
- 
 
 /*(*************************************************************************)*/
 /*(*1 Import *)*/
@@ -334,7 +334,7 @@ import_stmt:
 /*(*************************************************************************)*/
 
 xdcl:
-|   common_dcl { $1 |> List.map (fun decl -> D decl) }
+|   common_dcl { $1 |> List.map (fun decl -> DTop decl) }
 |   xfndcl     { [$1] }
 
 common_dcl:

--- a/lang_go/parsing/visitor_go.ml
+++ b/lang_go/parsing/visitor_go.ml
@@ -358,7 +358,10 @@ and v_top_decl x =
       and v2 = v_parameter v2
       and v3 = v_function_ v3
       in ()
-  | D v1 -> let v1 = v_decl v1 in ()
+  | DTop v1 -> let v1 = v_decl v1 in ()
+  | STop v1 -> let v1 = v_stmt v1 in ()
+  | Package (v1, v2) -> v_package (v1, v2)
+  | Import x -> v_import x
   in
   vin.ktop_decl (k, all_functions) x
 
@@ -378,11 +381,7 @@ and v_package (v1, v2) =
   let v2 = v_ident v2 in
   ()
 and v_program x = 
-  let k { package = pack; imports = v_imports; decls = v_decls } =
-  let arg = v_package pack in
-  let arg = v_list v_import v_imports in
-  let arg = v_list v_top_decl v_decls in ()
-  in
+  let k x = v_list v_top_decl x in
   vin.kprogram (k, all_functions) x
 
 and v_item = function


### PR DESCRIPTION
The goal is to make it easier to have package pattern in semgrep and
to use ast_go.ml for tree-sitter-go

This should help https://github.com/returntocorp/semgrep/issues/1315

Test plan:
make test