### PR TITLE
Generate different generic AST for x = a, and x := a in Go

### DIFF
--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -317,7 +317,8 @@ and expr =
    * todo: see IL.ml where we normalize this AST with expr/instr/stmt
    * update: should even be in a separate simple_stmt, as in Go
    *)
-  | Assign of expr * tok (* =, or sometimes := in Go, <- in OCaml *) * expr
+  | Assign of expr * tok (* '=', '<-' in OCaml. ':=' Go is AssignOp (Eq) *) * 
+              expr
   (*s: [[AST_generic.expr]] other assign cases *)
   (* less: could desugar in Assign, should be only binary_operator *)
   | AssignOp of expr * operator wrap * expr

--- a/lang_go/analyze/go_to_generic.ml
+++ b/lang_go/analyze/go_to_generic.ml
@@ -338,10 +338,12 @@ and simple = function
       and v2 = tok v2
       and v3 = list expr v3
       in
-      (* use OtherExpr? at least v2 contains a different token :=, not = so
-       * the information is there
+      (* people don't want '=' assign pattern to match ':=' short var decls,
+       * so better to not generate an Assign there too.
+       * less: could define a ColonEq operator in AST_generic.ml
        *)
-      (G.Assign (list_to_tuple_or_expr v1, v2, list_to_tuple_or_expr v3))
+      (G.AssignOp (list_to_tuple_or_expr v1, (G.Eq, v2), 
+                   list_to_tuple_or_expr v3))
   | AssignOp ((v1, v2, v3)) ->
       let v1 = expr v1
       and v2 = wrap arithmetic_operator v2

--- a/tests/go/parsing/assign_vs_shortvar.go
+++ b/tests/go/parsing/assign_vs_shortvar.go
@@ -1,0 +1,6 @@
+package foo
+
+func main() {
+  a = 2
+  b := 2
+}


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/1300

Test plan:
You can see below Assign vs AssignOp now
```
+ /home/pad/pfff/pfff -dump_ast assign_vs_shortvar.go
[(DirectiveStmt (Package ((), [("foo", ())])));
  (DefStmt
     ({ name = ("main", ()); attrs = [];
        info =
        { id_resolved = ref (None); id_type = ref (None);
          id_const_literal = ref (None) };
        tparams = [] },
      (FuncDef
         { fparams = []; frettype = None;
           fbody =
           (Block
              ((),
               [(ExprStmt (
                   (Assign (
                      (Id (("a", ()),
                         { id_resolved = ref (None); id_type = ref (None);
                           id_const_literal = ref (None) }
                         )),
                      (), (L (Int ("2", ()))))),
                   ()));
                 (ExprStmt (
                    (AssignOp (
                       (Id (("b", ()),
                          { id_resolved = ref (None); id_type = ref (None);
                            id_const_literal = ref (None) }
                          )),
                       (Eq, ()), (L (Int ("2", ()))))),
                    ()))
                 ],
               ()))
           })))
  ]
```