### PR TITLE
Add more information in Error_code.Timeout and add Error_code.OutOfMemory

### DIFF
--- a/h_program-lang/Error_code.mli
+++ b/h_program-lang/Error_code.mli
@@ -41,13 +41,16 @@ type error = {
 
   (* other *)
   | FatalError of string
-  | Timeout
+  | Timeout of string option
+  | OutOfMemory of string option
 (*e: type [[Error_code.error_kind]] *)
 
 (*s: type [[Error_code.entity]] *)
  and entity = (string * Entity_code.entity_kind)
 (*e: type [[Error_code.entity]] *)
 
+(* internal: you should prefer to use the error function below *)
+val mk_error_loc: Parse_info.token_location -> error_kind -> error
 
 (*s: type [[Error_code.annotation]] *)
 (* @xxx to acknowledge or explain false positives *)


### PR DESCRIPTION
This should help https://github.com/returntocorp/semgrep/issues/1361
by giving better diagnoistic when something takes too long in semgrep

Test plan:
make test