### PR TITLE
Add support for self-documenting python 3.8 fstrings

### DIFF
--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -760,11 +760,19 @@ string:
 
 interpolated:
   | FSTRING_STRING { Str $1 }
-  | FSTRING_LBRACE interpolant "}" { $2 }
-  | FSTRING_LBRACE interpolant ":" format_specifier "}"
-     { InterpolatedString ($2::mk_str $3::$4) }
-  | FSTRING_LBRACE interpolant BANG format_specifier "}"
-     { InterpolatedString ($2::mk_str $3::$4) }
+  | FSTRING_LBRACE interpolant fstring_print_spec "}" { InterpolatedString ($2::$3) }
+
+fstring_print_spec:
+  | fstring_format_clause { $1 }
+  | "=" fstring_format_clause { mk_str $1::$2 }
+
+fstring_format_clause:
+  | { [] }
+  | fstring_format_delimeter format_specifier { mk_str $1::$2 }
+
+fstring_format_delimeter:
+  | ":" { $1 }
+  | BANG { $1 }
 
 interpolant:
   (* Note that the f-string mini-language at

--- a/tests/python/parsing/fstrings_self_documenting.py
+++ b/tests/python/parsing/fstrings_self_documenting.py
@@ -1,0 +1,4 @@
+# Introduced in 3.8
+
+msg="HI"
+print(f"Message is {msg=}")


### PR DESCRIPTION
Adds ability to support f"{foo=}".

Note that this adds a wrapping of all f-string interpolants, even
without formatters. So previously:

  f"{foo}"

would result in

  InterpolatedString([E(Id("foo"))])

and now one gets

  InterpolatedString([InterpolatedString([E(Id("foo"))])])

However, as an advantage, wrapping is the same whether or not
a formatter is added.

Fixes returntocorp/semgrep#1339.