### PR TITLE
Allow Java package declarations as semgrep patterns

### DIFF
--- a/lang_java/parsing/parser_java.mly
+++ b/lang_java/parsing/parser_java.mly
@@ -264,6 +264,7 @@ sgrep_spatch_pattern:
  | import_declaration EOF           { AStmt (DirectiveStmt $1) }
  | import_declaration import_declarations EOF  
     { AStmts (($1::$2) |> List.map (fun x -> DirectiveStmt x)) }
+ | package_declaration EOF          { AStmt (DirectiveStmt $1) }
  | expression EOF                   { AExpr $1 }
  | item_no_dots EOF                 { mk_stmt_or_stmts $1 }
  | item_no_dots item_sgrep_list EOF { mk_stmt_or_stmts ($1 @ (List.flatten $2)) }

--- a/tests/java/semgrep/package.sgrep
+++ b/tests/java/semgrep/package.sgrep
@@ -1,0 +1,1 @@
+package $X;


### PR DESCRIPTION
Fixes returntocorp/semgrep#1381