### PR TITLE
Convert stmt pattern in expr pattern when ExprStmt

### DIFF
--- a/lang_go/parsing/Makefile
+++ b/lang_go/parsing/Makefile
@@ -27,11 +27,11 @@ INCLUDEDIRS= $(TOP)/commons \
   $(TOP)/globals \
   $(TOP)/h_program-lang \
 
-NUM_PERMITTED_CONFLICTS= 1
+NUM_PERMITTED_CONFLICTS=0
 
 SCRIPTDIR= $(TOP)/scripts
 
-OCAMLYLOG= ocamlyacc_out.log
+MENHIRLOG= menhir_out.log
 
 LANG= go
 
@@ -67,9 +67,10 @@ clean::
 	rm -f lexer_go.ml
 beforedepend:: lexer_go.ml
 
+OCAMLYACC=menhir --unused-tokens --explain --fixed-exception
 
 parser_go.ml parser_go.mli: parser_go.mly
-	$(OCAMLYACC) $< 2>&1 | tee $(OCAMLYLOG) && $(SCRIPTDIR)/check_ocamlyacc_conflicts.sh $(OCAMLYLOG) $(NUM_PERMITTED_CONFLICTS) $(LANG) parser_go.ml parser_go.mli
+	$(OCAMLYACC) $< 2>&1 | tee $(MENHIRLOG) && $(SCRIPTDIR)/check_menhir_conflicts.sh $(MENHIRLOG) $(NUM_PERMITTED_CONFLICTS) $(LANG) parser_go.ml parser_go.mli
 clean::
 	rm -f parser_go.ml parser_go.mli parser_go.output
 beforedepend:: parser_go.ml parser_go.mli

--- a/lang_go/parsing/parser_go.mly
+++ b/lang_go/parsing/parser_go.mly
@@ -263,13 +263,14 @@ package: LPACKAGE sym LSEMICOLON { Package ($1, $2) }
    * to allow '...' without trailing semicolon and avoid ambiguities.
    *)*/
 sgrep_spatch_pattern: 
- | expr         EOF       { E $1 }
- /*(* should be item_no_simple_stmt to remove 1 s/r conflict *)*/
- | item LSEMICOLON EOF       { item1 $1 }
  /*(* make version with and without LSEMICOLON which is inserted
     * if the item as a newline before the EOF (which leads to ASI)
     *)*/
- | item            EOF       { item1 $1 }
+ | item LSEMICOLON? EOF  { 
+    match $1 with
+    | [IStmt (SimpleStmt (ExprStmt x))] -> E x
+    | _ -> item1 $1 
+    }
  | item LSEMICOLON item LSEMICOLON item_list EOF 
     { Items ($1 @ $3 @ rev_and_fix_items $5) }
 

--- a/scripts/check_menhir_conflicts.sh
+++ b/scripts/check_menhir_conflicts.sh
@@ -28,7 +28,7 @@ fi
 result=$((resultsr+resultrr))
 MSG="Error: menhir found $result arbitrarily resolved conflicts when $num are permitted. See pfff/lang_$lang/parsing/menhir_out.log for details. ($INSTR)"
 
-if (( $result > $num )); then
+if (( $result != $num )); then
    echo $MSG 1>&2
    rm -f $generated_ml_file $generated_mli_file
    exit 126

--- a/scripts/check_ocamlyacc_conflicts.sh
+++ b/scripts/check_ocamlyacc_conflicts.sh
@@ -21,8 +21,7 @@ resultrr=`grep -i 'reduce/reduce conflict' $FILE | cut -d ' ' -f 1`
 
 result=$((resultsr+resultrr))
 MSG="Error: ocamlyacc found $result conflicts when $num are permitted. See pfff/lang_$lang/parsing/ocamlyacc_out.log for details. ($INSTR)"
-
-if (( $result > $num )); then
+if (( $result != $num )); then
    echo $MSG 1>&2
    rm -f $generated_ml_file $generated_mli_file
    exit 126


### PR DESCRIPTION
This will help fix https://github.com/returntocorp/semgrep/issues/1370

test plan:
in semgrep-core test repo:

~/pfff/pfff -lang go -dump_pattern misc_exprstmt_vs_expr.sgrep
(E
   (Call ((IdSpecial ((Op Eq), ())),
      ((),
       [(Arg
 ...

we now have an E (for expr) instead of an S (for stmt)