### PR TITLE
Parse correctly JSX patterns in semgrep mode

### DIFF
--- a/lang_js/parsing/parse_js.ml
+++ b/lang_js/parsing/parse_js.ml
@@ -334,9 +334,14 @@ let any_of_string s =
   Common2.with_tmp_file ~str:s ~ext:"js" (fun file ->
     let toks = tokens file in
     let toks = Parsing_hacks_js.fix_tokens toks in
-    (* TODO? run the parsing hack ASI fix?  
-     * introduce lots of regressions in sgrep make test?
+    (* note that this does not trigger the ASI done during
+     * error recovery, so there is still a different behavior regarding
+     * ASI between parsing code and semgrep patterns. This is why
+     * we still need to assignment_expr_no_stmt sgrep_spatch_pattern rule
+     * and at few places allow the 'sc' to be optional because in semgrep
+     * patterns they are not always inserted.
      *)
+    let toks = Parsing_hacks_js.fix_tokens_ASI toks in
     let _tr, lexer, lexbuf_fake = PI.mk_lexer_for_yacc toks TH.is_comment in
     Parser_js.sgrep_spatch_pattern lexer lexbuf_fake
   )

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -74,6 +74,8 @@ let fix_sgrep_module_item x =
   match x with
   | It (FunDecl ({ f_kind = F_func (_, None); _ } as decl)) ->
       Expr (Function decl)
+  (* less: could check that sc is an ASI *)
+  | It (St (ExprStmt (e, _sc))) -> Expr e
   | _ -> ModuleItem x
 
 let (@@) xs sc =
@@ -1215,7 +1217,7 @@ xhp_html:
 xhp_child:
  | T_XHP_TEXT        { XhpText $1 }
  | xhp_html          { XhpNested $1 }
- | "{" expr sc "}"   { XhpExpr ($1, Some $2, $4) (*TODO$3*) }
+ | "{" expr sc? "}"   { XhpExpr ($1, Some $2, $4) (*TODO$3*) }
  | "{" "}"           { XhpExpr ($1, None , $2) (*TODO$3*) }
 
 xhp_attribute:
@@ -1226,7 +1228,7 @@ xhp_attribute:
 
 xhp_attribute_value:
  | T_STRING           { XhpAttrString ($1) }
- | "{" expr sc "}"    { XhpAttrExpr ($1, $2, $4)(*TODO$3*)}
+ | "{" expr sc? "}"    { XhpAttrExpr ($1, $2, $4)(*TODO$3*)}
 
 (*----------------------------*)
 (* interpolated strings *)


### PR DESCRIPTION
this will help https://github.com/returntocorp/semgrep/issues/1441

Test plan:
test file in semgrep but:

~/pfff/pfff -lang js -dump_pattern misc_jsx.sgrep
(E
   (Xml
      { xml_tag = ("div", ());
        xml_attrs =
        [(("a", ()),
          (Call (
             (Id (("foo", ()),
                { id_resolved = ref (None); id_type = ref (None);
                  id_const_literal = ref (None) }
                )),
             ((), [], ()))))
          ];
        xml_body = [] }))