### PR TITLE
More precise type for Python decorator

### DIFF
--- a/lang_python/analyze/Python_to_generic.ml
+++ b/lang_python/analyze/Python_to_generic.ml
@@ -720,18 +720,16 @@ and excepthandler =
       ), v3
 (*e: function [[Python_to_generic.excepthandler]] *)
 
-(*s: function [[Python_to_generic.expr_to_attribute]] *)
-and expr_to_attribute t v = 
-  match v with
-  | G.Call (G.Id (id, _), args) -> 
-      G.NamedAttr (t, [id], G.empty_id_info (), args)
-  | _ -> G.OtherAttribute (G.OA_Expr, [G.Tk t; G.E v])
-(*e: function [[Python_to_generic.expr_to_attribute]] *)
-
 (*s: function [[Python_to_generic.decorator]] *)
-and decorator (t, v) = 
-  let v = expr v in
-  expr_to_attribute t v
+and decorator (t, v1, v2) = 
+  let v1 = dotted_name v1 in
+  let v2 = option (bracket (list argument)) v2 in
+  let args = 
+    match v2 with
+    | Some (t1, x, t2) -> (t1, x, t2)
+    | None -> G.fake_bracket []
+  in
+  G.NamedAttr (t, v1, G.empty_id_info(), args)
 (*e: function [[Python_to_generic.decorator]] *)
 
 (*s: function [[Python_to_generic.alias]] *)

--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -314,7 +314,6 @@ and type_ = expr
 (*s: type [[AST_python.type_parent]] *)
 and type_parent = argument
 (*e: type [[AST_python.type_parent]] *)
- [@@deriving show { with_path = false }]  (* with tarzan *)
 
 (*****************************************************************************)
 (* Pattern *)
@@ -323,11 +322,11 @@ and type_parent = argument
 (* Name, or Tuple? or more? *)
 and pattern = expr
 (*e: type [[AST_python.pattern]] *)
- [@@deriving show]  (* with tarzan *)
 
 and param_pattern =
   | PatternName of name
   | PatternTuple of param_pattern list
+ [@@deriving show { with_path = false }]  (* with tarzan *)
 
 (*****************************************************************************)
 (* Statement *)
@@ -417,7 +416,7 @@ and excepthandler =
 (* Decorators (a.k.a annotations) *)
 (* ------------------------------------------------------------------------- *)
 (*s: type [[AST_python.decorator]] *)
-and decorator = tok (* @ *) * expr (* usually an Id or Call *)
+and decorator = tok (* @ *) * dotted_name * argument list bracket option
 (*e: type [[AST_python.decorator]] *)
 
 (* ------------------------------------------------------------------------- *)

--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -30,7 +30,6 @@
  *)
 open Common
 open AST_python
-module G = AST_generic
 
 (* intermediate helper type *)
 type single_or_tuple =
@@ -438,22 +437,22 @@ arglist_paren_opt:
  (* python3-ext: was expr_list before *)
  | "(" list_comma(argument) ")" { $2 }
 
-arglist_paren2_opt: 
- | (* empty *) { G.fake_bracket [] }
- | "(" ")"     { $1, [], $2 }
- (* python3-ext: was expr_list before *)
- | "(" list_comma(argument) ")" { $1, $2, $3 }
-
 (*************************************************************************)
 (* Annotations *)
 (*************************************************************************)
 
 decorator: "@" decorator_name arglist_paren2_opt NEWLINE 
-    { $1, Call ($2, $3) }
+    { $1, $2, $3 }
 
 decorator_name:
-  | NAME                    { Name ($1, Load, ref NotResolved) }
-  | decorator_name "." NAME { Attribute ($1, $2, $3, Load) }
+  | NAME                    { [$1] }
+  | decorator_name "." NAME { $1 @ [$3] }
+
+arglist_paren2_opt: 
+ | (* empty *) { None }
+ | "(" ")"     { Some ($1, [], $2) }
+ (* python3-ext: was expr_list before *)
+ | "(" list_comma(argument) ")" { Some ($1, $2, $3) }
 
 (*************************************************************************)
 (* Statement *)

--- a/lang_python/parsing/Visitor_python.ml
+++ b/lang_python/parsing/Visitor_python.ml
@@ -414,9 +414,10 @@ and v_excepthandler =
       and v3 = v_list v_stmt v3
       in ()
 and v_decorator v = 
-  let k (t, x) =
+  let k (t, x1, x2) =
     v_tok t;
-    v_expr x
+    v_dotted_name x1;
+    v_option (v_bracket (v_list v_argument)) x2
   in
   vin.kdecorator (k, all_functions) v
 


### PR DESCRIPTION
This gets closer to the annotation type in AST generic.
This is necessary for https://github.com/returntocorp/semgrep/issues/1508
otherwise we get regressions on python semgrep tests.

test plan:
make