### PR TITLE
Visit assignment expression in vardef

### DIFF
--- a/tests/GENERIC/typing/EqVarCmp.java
+++ b/tests/GENERIC/typing/EqVarCmp.java
@@ -1,7 +1,7 @@
 class A {
   void foo() {
     String var1 = 5;
-    int var2 = 6;
+    int var2;
     if (var1 == var2) var1 = 0;
   }
 }


### PR DESCRIPTION
A VarDef with an initializer can be expanded as a simple variable
declaration followed by an assignment.

In order to match properly, we must therefore traverse the assignment
_as an expression_. Currently, we visit statements and expressions
separately. To match on this assignment expression then, we must visit
it using Visitor_AST.

I've tested this in semgrep-core (separate commit to follow).

It makes the following match work:

Pattern:

```
foo = "a"
```

Code:

```js
const foo = "a";
```

which previously failed.

This commit also fixes a number of TODO items in the semgrep test
corpus.