### PR TITLE
Do not transpile ParamPattern for Javascript

### DIFF
--- a/lang_js/analyze/ast_js.ml
+++ b/lang_js/analyze/ast_js.ml
@@ -422,6 +422,7 @@ type program = toplevel list
 type any = 
   | Expr of expr
   | Stmt of stmt
+  | Pattern of pattern
   | Item of toplevel
   | Items of toplevel list
   | Program of program

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -494,7 +494,6 @@ and module_directive x =
 
 and program v = list toplevel v
 
-
 let any =
   function
   | Expr v1 -> let v1 = expr v1 in G.E v1
@@ -502,4 +501,4 @@ let any =
   | Item v1 -> let v1 = toplevel v1 in G.S v1
   | Items v1 -> let v1 = List.map toplevel v1 in G.Ss v1
   | Program v1 -> let v1 = program v1 in G.Pr v1
-
+  | Pattern v1 -> let v1 = pattern v1 in G.P v1

--- a/lang_js/analyze/map_ast_js.ml
+++ b/lang_js/analyze/map_ast_js.ml
@@ -408,6 +408,7 @@ and map_any =
   function
   | Expr v1 -> let v1 = map_expr v1 in Expr ((v1))
   | Stmt v1 -> let v1 = map_stmt v1 in Stmt ((v1))
+  | Pattern v1 -> let v1 = map_pattern v1 in Pattern v1
   | Items v1 -> let v1 = map_of_list map_toplevel v1 in Items ((v1))
   | Item v1 -> let v1 = map_toplevel v1 in Item ((v1))
   | Program v1 -> let v1 = map_program v1 in Program ((v1))

--- a/lang_js/analyze/visitor_ast_js.ml
+++ b/lang_js/analyze/visitor_ast_js.ml
@@ -337,6 +337,7 @@ and v_any =
   function
   | Expr v1 -> let v1 = v_expr v1 in ()
   | Stmt v1 -> let v1 = v_stmt v1 in ()
+  | Pattern v1 -> v_pattern v1
   | Item v1 -> let v1 = v_toplevel v1 in ()
   | Items v1 -> let v1 = v_list v_toplevel v1 in ()
   | Program v1 -> let v1 = v_program v1 in ()


### PR DESCRIPTION
It is better to stay close to the original code and not do too much
magic. I was transpiling for the abstract interpreter to simplify
things but for semgrep better not too. We can still reuse the
transpiling code for the IL (and it can be generic!)

Test plan:
make
also make reinstall-libs and doing make test in semgrep seems to still work!