### PR TITLE
Use --strict for semgrep CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
     working_directory: /src
     steps:
       - checkout
-      - run: semgrep --config semgrep.yml --error .
+      - run: semgrep --config semgrep.yml --error --strict --exclude parsing_errors .
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -415,7 +415,7 @@ website:
 .PHONY:: check tags graph prolog  db layers visual   tests test .merlin
 
 check:
-	docker run --rm -v "${PWD}:/src" returntocorp/semgrep:develop --config semgrep.yml
+	docker run --rm -v "${PWD}:/src" returntocorp/semgrep:develop --config semgrep.yml --exclude parsing_errors --strict
 
 .merlin:
 	@echo '# -*- sh -*-' > .merlin

--- a/lang_ruby/analyze/il_ruby_build.ml
+++ b/lang_ruby/analyze/il_ruby_build.ml
@@ -581,7 +581,7 @@ let rec refactor_expr (acc:stmt acc) (e : Ast.expr) : stmt acc * Il_ruby.expr =
 
 
     | Ast.Unary((Ast.U Ast.Op_UMinus, _pos), Ast.Literal(Ast.Float(s,_))) -> 
-        assert(s.[0] != '-');
+        assert(s.[0] <> '-');
         acc, ELit (Float("-" ^ s))
 
     | Ast.Unary(((Ast.U Ast.Op_UBang | Ast.Op_UNot),pos),e) ->

--- a/semgrep.yml
+++ b/semgrep.yml
@@ -14,9 +14,6 @@ rules:
     message: Pervasives is deprecated and not available after 4.10. Use Stdlib.
     languages: [ocaml]
     severity: ERROR
-    paths:
-      exclude:
-       - web/
 
   - id: physical-inequality
     pattern: $X != $Y
@@ -45,6 +42,7 @@ rules:
     #TODO: fix at some point
     paths:
       exclude:
+       - commons/common2.ml
        - commons_core/regexp.ml
        - commons_wrappers/graph/graphe.ml
        - h_visualization/plot_jgraph.ml


### PR DESCRIPTION
Now that semgrep and pfff can correctly parse 100% of pfff codebase,
we can switch to --strict

test plan:
make check