### PR TITLE
* lang_js/analyze/ast_js_build.ml: do not transpile pattern anymore

### DIFF
--- a/lang_js/analyze/ast_js_build.ml
+++ b/lang_js/analyze/ast_js_build.ml
@@ -835,7 +835,7 @@ and parameter_binding env idx = function
  | C.ParamClassic p -> A.ParamClassic (parameter env p), []
  | C.ParamEllipsis t -> A.ParamEllipsis t, []
  | C.ParamPattern x -> 
-    if !transpile_pattern || true (* TODO *)
+    if !transpile_pattern
     then begin
      let tok = (C.Pattern x.C.ppat) |> Lib_parsing_js.ii_of_any |> List.hd in
      let intermediate = spf "!arg%d!" idx, tok in


### PR DESCRIPTION
We do not transpile patter in JS in Parse_javascript_tree_sitter.ml
so we should not do it either in pfff otherwise the semgrep
pattern AST has one shape and the code AST has anohter one

test plan:
make test