### PR TITLE
java: Allow `...' in the body of an interface

### DIFF
--- a/lang_java/parsing/parser_java.mly
+++ b/lang_java/parsing/parser_java.mly
@@ -1229,6 +1229,8 @@ interface_member_declaration:
  | annotation_type_declaration { [Class $1] }
 
  | ";"  { [] }
+ (* sgrep-ext: allows ... inside interface body *)
+ | "..." { [DeclEllipsis $1] }
 
 
 (* note: semicolon is missing in 2nd edition java language specification.*)

--- a/tests/java/semgrep/ellipsis-interface.sgrep
+++ b/tests/java/semgrep/ellipsis-interface.sgrep
@@ -1,0 +1,5 @@
+// https://github.com/returntocorp/semgrep/issues/877
+interface $INTERFACE extends Remote {
+  ...
+  $RETURNTYPE $METHOD(Object $PARAM) throws RemoteException;
+}


### PR DESCRIPTION
This should fix https://github.com/returntocorp/semgrep/issues/877. I have tested it locally (seems to work) and I'll add a test to semgrep in a separate pull request.