### PR TITLE
Start of changes to ast_ruby.ml to better represent atoms and strings

### DIFF
--- a/lang_ruby/parsing/lexer_ruby.mll
+++ b/lang_ruby/parsing/lexer_ruby.mll
@@ -159,7 +159,8 @@ let mk_char (charcode, t) =
 let fail_eof _f _state _lexbuf = 
   failwith "parse error: premature end of file"
     
-let contents_of_str s = [Ast_ruby.StrChars s]
+let contents_of_str s = s
+  (* old: [Ast_ruby.StrChars s] *)
 
 (* returns true if string following the modifier m (e.g., %m{...})
    should be parsed as a single quoted or double quoted (interpreted)
@@ -724,6 +725,7 @@ and atom t state = parse
         end_state_unless_afterdef state; 
         T_ATOM(contents_of_str (":" ^ str), (add_to_tok lexbuf t)) }
 
+  (* regular atom (e.g., :foo), possibly prefixed with @ and suffixed with = *)
   | ('@'* id) '='?
       { end_state_unless_afterdef state; 
         T_ATOM((contents_of_str (":" ^ str lexbuf)), (add_to_tok lexbuf t)) }

--- a/lang_ruby/parsing/parser_ruby.dyp
+++ b/lang_ruby/parsing/parser_ruby.dyp
@@ -188,7 +188,7 @@ and params_to_pattern xs =
 %token <string * Parse_info.t>  T_NUM
 %token <string * Parse_info.t>  T_FLOAT
 
-%token <Ast_ruby.string_contents list * Parse_info.t> T_ATOM
+%token <string * Parse_info.t> T_ATOM
 %token <Parse_info.t> T_ATOM_BEG
 
 %token <string * Parse_info.t> T_SINGLE_STRING
@@ -199,7 +199,7 @@ and params_to_pattern xs =
 %token <Parse_info.t> T_TICK_BEG
 %token <string * Parse_info.t> T_USER_BEG
 
-%token <Ast_ruby.string_contents list * string * Parse_info.t> T_REGEXP
+%token <Ast_ruby.interp list * string * Parse_info.t> T_REGEXP
 %token <Parse_info.t> T_REGEXP_BEG
 %token <string * Parse_info.t>  T_REGEXP_MOD
 
@@ -564,8 +564,8 @@ constant:
 
   | string<s>        { s }
 
-  | T_ATOM    { Literal (Atom $1) }
-  | T_ATOM_BEG<pos> interp_str<istr> { Literal (Atom (istr,pos)) }
+  | T_ATOM    { Atom (AtomSimple $1) }
+  | T_ATOM_BEG<pos> interp_str<istr> { Atom (AtomFromString (istr,pos)) }
 
   | T_REGEXP<s,m,pos> { Literal(Regexp ((s,m),pos)) }
   | T_REGEXP_BEG<pos> interp_str<istr> T_REGEXP_MOD<mods, _posTODO>
@@ -1069,7 +1069,7 @@ method_kind:
 
 meth_or_atom:
     | method_name  { $1 }
-    | T_ATOM       { MethodAtom $1 }
+    | T_ATOM       { MethodAtom (AtomSimple $1) }
 
 /*(* TODO: split in scoped_id *)*/
 var_or_scoped_id:

--- a/lang_ruby/parsing/parser_ruby.mli
+++ b/lang_ruby/parsing/parser_ruby.mli
@@ -87,7 +87,7 @@ type token =
   | K_CLASS of Parse_info.t
   | T_REGEXP_MOD of (string * Parse_info.t)
   | T_REGEXP_BEG of Parse_info.t
-  | T_REGEXP of (Ast_ruby.string_contents list * string * Parse_info.t)
+  | T_REGEXP of (Ast_ruby.interp list * string * Parse_info.t)
   | T_USER_BEG of (string * Parse_info.t)
   | T_TICK_BEG of Parse_info.t
   | T_INTERP_END of (string * Parse_info.t)
@@ -95,7 +95,7 @@ type token =
   | T_DOUBLE_BEG of Parse_info.t
   | T_SINGLE_STRING of (string * Parse_info.t)
   | T_ATOM_BEG of Parse_info.t
-  | T_ATOM of (Ast_ruby.string_contents list * Parse_info.t)
+  | T_ATOM of (string * Parse_info.t)
   | T_FLOAT of (string * Parse_info.t)
   | T_NUM of (string * Parse_info.t)
   | T_CLASS_VAR of (string * Parse_info.t)
@@ -152,7 +152,7 @@ val pp :
     | `Obj_T_ANDOP of Parse_info.t
     | `Obj_T_ASSIGN of Parse_info.t
     | `Obj_T_ASSOC of Parse_info.t
-    | `Obj_T_ATOM of Ast_ruby.atom
+    | `Obj_T_ATOM of string * Parse_info.t
     | `Obj_T_ATOM_BEG of Parse_info.t
     | `Obj_T_BANG of Parse_info.t
     | `Obj_T_CARROT of Parse_info.t
@@ -199,7 +199,7 @@ val pp :
     | `Obj_T_QUESTION of Parse_info.t
     | `Obj_T_RBRACE of Parse_info.t
     | `Obj_T_RBRACK of Parse_info.t
-    | `Obj_T_REGEXP of Ast_ruby.string_contents list * string * Parse_info.t
+    | `Obj_T_REGEXP of Ast_ruby.interp list * string * Parse_info.t
     | `Obj_T_REGEXP_BEG of Parse_info.t
     | `Obj_T_REGEXP_MOD of string * Parse_info.t
     | `Obj_T_RPAREN of Parse_info.t
@@ -262,9 +262,9 @@ val pp :
     | `Obj_hash_elem_list of Ast_ruby.pattern list
     | `Obj_identifier of Ast_ruby.ident
     | `Obj_if_else_clauses of (Ast_ruby.tok * Ast_ruby.stmts) option
-    | `Obj_interp_code of Ast_ruby.string_contents list
-    | `Obj_interp_str of Ast_ruby.string_contents list
-    | `Obj_interp_str_work of Ast_ruby.string_contents list
+    | `Obj_interp_code of Ast_ruby.interp list
+    | `Obj_interp_str of Ast_ruby.interp list
+    | `Obj_interp_str_work of Ast_ruby.interp list
     | `Obj_keyword_as_id of Ast_ruby.ident
     | `Obj_lhs of Ast_ruby.pattern
     | `Obj_lhs_assign_op of

--- a/lang_ruby/parsing/parser_ruby_helpers.ml
+++ b/lang_ruby/parsing/parser_ruby_helpers.ml
@@ -325,7 +325,7 @@ let fix_broken_assoc l op r =
       let l' = replace_end l (Id((s,p),ik)) in
         l', Op_ASSOC, r
 *)
-  | Literal(Atom(sc, pos)) ->
+  | Atom(AtomFromString(sc, pos)) ->
       let astr,rest = match List.rev sc with
         | (Ast_ruby.StrChars s)::tl -> s,tl
         | _ -> "a",[]
@@ -335,7 +335,7 @@ let fix_broken_assoc l op r =
         then 
       let s' = String.sub astr 0 (len-1) in
       let sc' = List.rev ((Ast_ruby.StrChars s')::rest) in
-      let l' = replace_end l (Literal(Atom(sc',pos))) in
+      let l' = replace_end l ((Atom(AtomFromString(sc',pos)))) in
         l', Op_ASSOC, r
         else default
   | _ -> default

--- a/lang_ruby/parsing/parser_ruby_helpers.mli
+++ b/lang_ruby/parsing/parser_ruby_helpers.mli
@@ -27,7 +27,7 @@ val well_formed_return : Ast_ruby.expr list -> unit
 val well_formed_do : Ast_ruby.expr -> 'a -> unit
 
 val process_user_string :
-  string -> Ast_ruby.string_contents list -> Ast_ruby.tok -> Ast_ruby.expr
+  string -> Ast_ruby.interp list -> Ast_ruby.tok -> Ast_ruby.expr
 
 val assigned_id : string -> bool
 


### PR DESCRIPTION
The atom and string_kind types are messy, with the wrap at the wrong
place. This is the first part in a series to clean this.

test plan:
make
make test