### PR TITLE
commons/Common.ml: new timeout_function_float

### DIFF
--- a/commons/Common.mli
+++ b/commons/Common.mli
@@ -405,7 +405,7 @@ val save_excursion : 'a ref -> 'a -> (unit -> 'b) -> 'b
 
 (*s: signature [[Common.memoized]] *)
 val memoized : 
-  ?use_cache:bool -> ('a, 'b) Hashtbl.t -> 'a -> (unit -> 'b) -> 'b
+   ?use_cache:bool -> ('a, 'b) Hashtbl.t -> 'a -> (unit -> 'b) -> 'b
 (*e: signature [[Common.memoized]] *)
 
 (*s: exception [[Common.UnixExit]] *)
@@ -416,10 +416,9 @@ exception UnixExit of int
 exception Timeout
 (*e: exception [[Common.Timeout]] *)
 (*s: signature [[Common.timeout_function]] *)
-val timeout_function :
-  ?verbose:bool ->
-  int -> (unit -> 'a) -> 'a
+val timeout_function: ?verbose:bool -> int -> (unit -> 'a) -> 'a
 (*e: signature [[Common.timeout_function]] *)
+val timeout_function_float :?verbose:bool -> float -> (unit -> 'a) -> 'a
 
 (*s: type [[Common.prof]] *)
 type prof = ProfAll | ProfNone | ProfSome of string list


### PR DESCRIPTION
The alarm(1) syscall, which Common.timeout_function uses
supports only entire seconds. This new function use itimer which
can have microseconds granularity.

test plan:
make
used in semgrep, see other PR.