### PR TITLE
generic: Fix bug in constant propagation for Python

### DIFF
--- a/lang_GENERIC/analyze/Constant_propagation.ml
+++ b/lang_GENERIC/analyze/Constant_propagation.ml
@@ -182,7 +182,7 @@ let propagate2 lang prog =
              try Hashtbl.find stats (Ast.str_of_ident id, sid)
              with Not_found -> raise Impossible
           in
-          if (!(stats.rvalue) = 1) &&
+          if (!(stats.lvalue) = 1) &&
              (* restrict to Python Globals for now, but could be extended *)
              lang = Lang.Python &&
              kind = Global


### PR DESCRIPTION
A variable can be considered "final" when it's assigned just once
(i.e., `!stats.lvalue = 1`). And a variable that is used just once
(i.e., `!stats.rvalue = 1`) may still not hold a constant value.
Probably a typo?