### PR TITLE
Fix weird parsing error in old JS files for windows

### DIFF
--- a/tests/js/parsing/windows_weird_cr.js
+++ b/tests/js/parsing/windows_weird_cr.js
@@ -1,0 +1,3 @@
+// This is very weird windows file that has just \r to delimit newlines
+// instead of the usual \r\n under windows.
+if (foo){x = 1x = 2;}


### PR DESCRIPTION
This fixes https://github.com/returntocorp/enterprise/issues/377

test plan:
test file included