### PR TITLE
Do not consider lambdas in a var as a function

### DIFF
--- a/lang_js/analyze/ast_js.ml
+++ b/lang_js/analyze/ast_js.ml
@@ -349,7 +349,10 @@ and attribute =
 (* Definitions *)
 (*****************************************************************************)
 
-(* TODO: type definition = entity * definition_kind *)
+(* TODO: type definition = entity * definition_kind
+ * TODO: separate VarDef and FuncDef. Do not abuse VarDef for regular
+ * function definitions.
+ *)
 (* TODO: put type parameters, attributes (keyword attr and decorator) in entity
  *)
 

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -365,11 +365,14 @@ and def_of_var { v_name = x_name; v_kind = x_kind;
   let v2 = var_kind x_kind in 
   let ent = G.basic_entity v1 [v2] in
   let ty = option type_ ty in
-  (match x_init with
-  | Some (Fun (v3, _nTODO))   -> 
+  (match x_init, fst x_kind with
+  (* ugly: ast_js.ml does not currently have a separate FuncDef and
+   * VarDef so we abuse the x_kind to differentiate them.
+   *)
+  | Some (Fun (v3, _nTODO)), Const   -> 
       let def, more_attrs = fun_ v3 in
       { ent with G.attrs = ent.G.attrs @ more_attrs}, G.FuncDef def
-  | Some (Class (v3, _nTODO)) -> 
+  | Some (Class (v3, _nTODO)), Const -> 
       let def, more_attrs = class_ v3 in
       { ent with G.attrs = ent.G.attrs @ more_attrs}, G.ClassDef def
   | _ -> 


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/1691

test plan:
test file included in related semgrep PR.
Using misc_arrow2.js in semgrep repo below you can now see
a VarDef instead of a FuncDef when the arrow is stored in a var.

+ /home/pad/semgrep/_build/default/bin/Main.exe -dump_ast misc_arrow2.js
Pr(
  [DefStmt(
     ({name=("a", ()); attrs=[KeywordAttr((Const, ()))]; tparams=[];
       info={id_resolved=Ref(None); id_type=Ref(None);
             id_const_literal=Ref(None); };
       },
      FuncDef(
        {fparams=[]; frettype=None;
         fbody=Block([Return((), Some(L(Float(("1", ())))))]); })));
   DefStmt(
     ({name=("a", ()); attrs=[KeywordAttr((Const, ()))]; tparams=[];
       info={id_resolved=Ref(None); id_type=Ref(None);
             id_const_literal=Ref(None); };
       },
      FuncDef(
        {fparams=[]; frettype=None;
         fbody=Block([Return((), Some(L(Float(("1", ())))))]); })));
   DefStmt(
     ({name=("b", ()); attrs=[KeywordAttr((Var, ()))]; tparams=[];
       info={id_resolved=Ref(Some((Global, 1))); id_type=Ref(None);
             id_const_literal=Ref(None); };
       },
      VarDef(
        {
         vinit=Some(Lambda(
                      {fparams=[]; frettype=None;
                       fbody=Block([Return((), Some(L(Float(("2", ())))))]); }));
         vtype=None; })));
...