### PR TITLE
Add support for logical assignment operators

### DIFF
--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -519,6 +519,9 @@ and expr =
       | Range (* .. or ..., Ruby *)
       | Nullish (* ?? in Javascript *)
       | NotNullPostfix (* ! in Typescript, postfix operator *)
+      | LogAndAss (* &&= logical AND assignment, in Javascript *)
+      | LogOrAss (* ||= logical OR assignment, in Javascript *)
+      | LogNullAss (* ??= logical nullish assignment, in Javascript *)
 (*e: type [[AST_generic.arithmetic_operator]] *)
 (*s: type [[AST_generic.incr_decr]] *)
     and incr_decr = Incr | Decr (* '++', '--' *)
@@ -1633,6 +1636,7 @@ let is_boolean_operator = function
  | LSL | LSR | ASR (* L = logic, A = Arithmetic, SL = shift left *) 
  | BitOr | BitXor | BitAnd | BitNot | BitClear (* unary *)
  | Range | Nullish | NotNullPostfix
+ | LogAndAss | LogOrAss | LogNullAss
   -> false
  | And | Or | Xor | Not
  | Eq     | NotEq     

--- a/h_program-lang/meta_ast_generic_common.ml
+++ b/h_program-lang/meta_ast_generic_common.ml
@@ -40,6 +40,9 @@ let vof_arithmetic_operator =
   | Gt -> OCaml.VSum (("Gt", []))
   | GtE -> OCaml.VSum (("GtE", []))
   | Cmp -> OCaml.VSum (("Cmp", []))
+  | LogAndAss -> OCaml.VSum (("LogAndAss", []))
+  | LogOrAss -> OCaml.VSum (("LogOrAss", []))
+  | LogNullAss -> OCaml.VSum (("LogNullAss", []))
 
 let vof_incr_decr =
   function

--- a/lang_GENERIC/parsing/Meta_AST.ml
+++ b/lang_GENERIC/parsing/Meta_AST.ml
@@ -362,6 +362,9 @@ and vof_arithmetic_operator =
   | Gt -> OCaml.VSum (("Gt", []))
   | GtE -> OCaml.VSum (("GtE", []))
   | Cmp -> OCaml.VSum (("Cmp", []))
+  | LogAndAss -> OCaml.VSum (("LogAndAss", []))
+  | LogOrAss -> OCaml.VSum (("LogOrAss", []))
+  | LogNullAss -> OCaml.VSum (("LogNullAss", []))
 
 and vof_arguments v = vof_bracket (OCaml.vof_list vof_argument) v
 and vof_argument =

--- a/lang_php/analyze/foundation/abstract_interpreter_php.ml
+++ b/lang_php/analyze/foundation/abstract_interpreter_php.ml
@@ -733,6 +733,7 @@ and unaryOp uop v =
      |G.And|G.Or|G.Xor|G.Eq|G.NotEq|G.PhysEq|G.NotPhysEq
      |G.Range|G.RegexpMatch|G.NotMatch
      |G.Lt|G.LtE|G.Gt|G.GtE|G.Cmp|G.Concat|G.Nullish|G.NotNullPostfix
+     |G.LogAndAss|G.LogOrAss|G.LogNullAss
      ),_) -> raise Impossible
 
 and cast _env _heap (ty, _) v =


### PR DESCRIPTION
This is for javascript and typescript. It corresponds to `&&=`, `||=`, and `??=`.