### PR TITLE
Add bracket info to AST_generic.Tuple

### DIFF
--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -306,7 +306,7 @@ and expr =
   (*s: [[AST_generic.expr]] other composite cases *)
   (* special case of Container, at least 2 elements (except for Python where
    * you can actually have 1-uple, e.g., '(1,)' *) 
-  | Tuple of expr list 
+  | Tuple of expr list bracket
   (*x: [[AST_generic.expr]] other composite cases *)
   (* And-type (field.vinit should be a Some) *)
   | Record of field list bracket
@@ -826,7 +826,7 @@ and pattern =
   | PatId of ident * id_info (* Usually Local/Param, Global in toplevel let *)
 
   (* special cases of PatConstructor *)
-  | PatTuple of pattern list (* at least 2 elements *)
+  | PatTuple of pattern list bracket (* at least 2 elements *)
   (* less: generalize to other container_operator? *)
   | PatList of pattern list bracket
   | PatKeyVal of pattern * pattern (* a kind of PatTuple *)
@@ -1566,7 +1566,7 @@ let rec expr_to_pattern e =
   (* TODO: diconstruct e and generate the right pattern (PatLiteral, ...) *)
   match e with
   | Id (id, info) -> PatId (id, info)
-  | Tuple xs -> PatTuple (xs |> List.map expr_to_pattern)
+  | Tuple (t1, xs, t2) -> PatTuple (t1, xs  |> List.map expr_to_pattern, t2)
   | L l -> PatLiteral l
   | Container(List, (t1, xs, t2)) -> 
       PatList(t1, xs |> List.map expr_to_pattern, t2)
@@ -1582,7 +1582,7 @@ exception NotAnExpr
 let rec pattern_to_expr p =
   match p with
   | PatId (id, info) -> Id (id, info)
-  | PatTuple xs -> Tuple (xs |> List.map pattern_to_expr)
+  | PatTuple (t1, xs, t2) -> Tuple (t1, xs |> List.map pattern_to_expr, t2)
   | PatLiteral l -> L l
   | PatList (t1, xs, t2) -> 
       Container(List, (t1, xs |> List.map pattern_to_expr, t2))

--- a/h_program-lang/Parse_info.ml
+++ b/h_program-lang/Parse_info.ml
@@ -372,7 +372,7 @@ let compare_pos ii1 ii2 =
 
 let min_max_ii_by_pos xs =
   match xs with
-  | [] -> raise (NoTokenLocation "min_max, empty list")
+  | [] -> raise (NoTokenLocation "Match returned an empty list with no token location information; this may be fixed by adding enclosing token information (e.g. bracket or parend tokens) to the list's enclosing node type.")
   | [x] -> (x, x)
   | x::xs ->
       let pos_leq p1 p2 = (compare_pos p1 p2) =|= (-1) in

--- a/h_program-lang/Visitor_AST.ml
+++ b/h_program-lang/Visitor_AST.ml
@@ -189,7 +189,7 @@ and v_expr x =
   | Container ((v1, v2)) ->
       let v1 = v_container_operator v1 and v2 = v_bracket (v_list v_expr) v2
       in ()
-  | Tuple v1 -> let v1 = v_list v_expr v1 in ()
+  | Tuple v1 -> let v1 = v_bracket (v_list v_expr) v1 in ()
   | Record v1 -> let v1 = v_bracket (v_list v_field) v1 in ()
   | Constructor ((v1, v2)) ->
       let v1 = v_name v1 and v2 = v_list v_expr v2 in ()
@@ -513,7 +513,7 @@ and v_pattern x =
   | PatType v1 -> let v1 = v_type_ v1 in ()
   | PatConstructor ((v1, v2)) ->
       let v1 = v_name v1 and v2 = v_list v_pattern v2 in ()
-  | PatTuple v1 -> let v1 = v_list v_pattern v1 in ()
+  | PatTuple (_, v1, _) -> let v1 = v_list v_pattern v1 in ()
   | PatList v1 -> let v1 = v_bracket (v_list v_pattern) v1 in ()
   | PatKeyVal ((v1, v2)) -> let v1 = v_pattern v1 and v2 = v_pattern v2 in ()
   | PatUnderscore v1 -> let v1 = v_tok v1 in ()

--- a/lang_GENERIC/analyze/AST_to_IL.ml
+++ b/lang_GENERIC/analyze/AST_to_IL.ml
@@ -332,8 +332,8 @@ and expr env eorig =
       let kind = composite_kind kind in
       mk_e (Composite (kind, xs)) eorig
   | G.Tuple xs -> 
-      let xs = List.map (expr env) xs in
-      mk_e (Composite (CTuple, G.fake_bracket xs)) eorig
+      let xs = bracket_keep (List.map (expr env)) xs in
+      mk_e (Composite (CTuple, xs)) eorig
 
   | G.Record _ 
   -> todo (G.E eorig)

--- a/lang_GENERIC/analyze/lrvalue.ml
+++ b/lang_GENERIC/analyze/lrvalue.ml
@@ -107,7 +107,7 @@ let rec visit_expr hook lhs expr =
 
   (* possible lvalues (also rvalues, hence the call to recl, not reclvl) *)
 
-  | Tuple xs -> xs |> List.iter recl
+  | Tuple xs -> xs |> unbracket |> List.iter recl
 
   | Container (typ, xs) ->
     (match typ with

--- a/lang_GENERIC/parsing/Map_AST.ml
+++ b/lang_GENERIC/parsing/Map_AST.ml
@@ -162,7 +162,7 @@ and map_expr x =
       and v2 = map_bracket (map_of_list map_expr) v2
       in Container ((v1, v2))
   | Tuple v1 -> 
-        let v1 = map_of_list map_expr v1 in Tuple ((v1))
+        let v1 = map_bracket (map_of_list map_expr) v1 in Tuple ((v1))
   | Record v1 -> 
         let v1 = map_bracket (map_of_list map_field) v1 in
         Record ((v1))
@@ -542,7 +542,7 @@ and map_pattern =
       let v1 = map_name v1
       and v2 = map_of_list map_pattern v2
       in PatConstructor ((v1, v2))
-  | PatTuple v1 -> let v1 = map_of_list map_pattern v1 in PatTuple ((v1))
+  | PatTuple v1 -> let v1 = map_bracket (map_of_list map_pattern) v1 in PatTuple ((v1))
   | PatList v1 -> let v1 = map_bracket (map_of_list map_pattern) v1 in 
       PatList ((v1))
   | PatKeyVal ((v1, v2)) ->

--- a/lang_GENERIC/parsing/Meta_AST.ml
+++ b/lang_GENERIC/parsing/Meta_AST.ml
@@ -143,7 +143,7 @@ and vof_expr =
       and v2 = vof_bracket (OCaml.vof_list vof_expr) v2
       in OCaml.VSum (("Container", [ v1; v2 ]))
   | Tuple v1 ->
-      let v1 = OCaml.vof_list vof_expr v1 in OCaml.VSum (("Tuple", [ v1 ]))
+      let v1 = vof_bracket (OCaml.vof_list vof_expr) v1 in OCaml.VSum (("Tuple", [ v1 ]))
   | Record v1 ->
       let v1 = vof_bracket (OCaml.vof_list vof_field) v1 in 
       OCaml.VSum (("Record", [ v1 ]))
@@ -756,7 +756,7 @@ and vof_pattern =
              in OCaml.VTuple [ v1; v2 ])
       in OCaml.VSum (("PatAs", [ v1; v2 ]))
   | PatTuple v1 ->
-      let v1 = OCaml.vof_list vof_pattern v1
+      let v1 = vof_bracket (OCaml.vof_list vof_pattern) v1
       in OCaml.VSum (("PatTuple", [ v1 ]))
   | PatList v1 ->
       let v1 = vof_bracket (OCaml.vof_list vof_pattern) v1

--- a/lang_go/analyze/go_to_generic.ml
+++ b/lang_go/analyze/go_to_generic.ml
@@ -69,7 +69,7 @@ let list_to_tuple_or_expr xs =
   match xs with
   | [] -> raise Impossible
   | [x] -> x
-  | xs -> G.Tuple xs
+  | xs -> G.Tuple (G.fake_bracket xs)
 
 let mk_func_def params ret st =
  { G.
@@ -316,7 +316,7 @@ and init =
   | InitExpr v1 -> let v1 = expr v1 in v1
   | InitKeyValue ((v1, v2, v3)) ->
       let v1 = init v1 and _v2 = tok v2 and v3 = init v3 in
-      G.Tuple [v1; v3]
+      G.Tuple (G.fake_bracket [v1; v3])
   | InitBraces v1 -> let v1 = bracket (list init) v1 in
       G.Container (G.List, v1)
 
@@ -327,7 +327,8 @@ and init_for_composite_lit =
        let _v2 = tok v2 and v3 = init v3 in
        (match v1 with 
         | InitExpr (Id (id, _id_info)) -> G.ArgKwd (id, v3)
-        | _ -> G.Arg (G.Tuple [init v1; v3]))
+        | _ ->
+          G.Arg (G.Tuple (G.fake_bracket [init v1; v3])))
    | InitBraces v1 -> let v1 = bracket (list init) v1 in
        G.Arg (G.Container (G.List, v1))
 
@@ -456,7 +457,7 @@ and stmt_aux =
          let pattern = G.PatUnderscore (fake "_") in
          [G.For (t, G.ForEach (pattern, v2, v3), v4)]
       | Some (xs, _tokEqOrColonEqTODO) -> 
-          let pattern = G.PatTuple (xs |> List.map G.expr_to_pattern) in
+          let pattern = G.PatTuple (xs |> List.map G.expr_to_pattern |> G.fake_bracket) in
           [G.For (t, G.ForEach (pattern, v2, v3), v4)]
       )
   | Return ((v1, v2)) ->

--- a/lang_ml/analyze/ml_to_generic.ml
+++ b/lang_ml/analyze/ml_to_generic.ml
@@ -115,7 +115,7 @@ and expr =
   | Constructor ((v1, v2)) ->
       let v1 = name v1 and v2 = option expr v2 in
       G.Constructor (v1, Common.opt_to_list v2)
-  | Tuple v1 -> let v1 = list expr v1 in G.Tuple v1
+  | Tuple v1 -> let v1 = list expr v1 in G.Tuple (G.fake_bracket v1)
   | List v1 -> let v1 = bracket (list expr) v1 in G.Container (G.List, v1)
   | Sequence v1 -> let v1 = list expr v1 in G.Seq v1
   | Prefix ((v1, v2)) -> let v1 = wrap string v1 and v2 = expr v2 in
@@ -304,7 +304,7 @@ and pattern =
       let n = ("::", v2), G.empty_name_info in
       G.PatConstructor (n, [v1;v3])
   | PatTuple v1 -> let v1 = list pattern v1 in 
-                   G.PatTuple v1
+                   G.PatTuple (G.fake_bracket v1)
   | PatList v1 -> let v1 = bracket (list pattern) v1 in G.PatList v1
   | PatUnderscore v1 -> let v1 = tok v1 in G.PatUnderscore v1
   | PatRecord v1 ->

--- a/lang_php/analyze/foundation/php_to_generic.ml
+++ b/lang_php/analyze/foundation/php_to_generic.ml
@@ -281,7 +281,7 @@ and expr =
   | List v1 -> let v1 = bracket (list expr) v1 in
       G.Container(G.List, v1)
   | Arrow ((v1, _t, v2)) -> let v1 = expr v1 and v2 = expr v2 in
-      G.Tuple [v1; v2]
+      G.Tuple (G.fake_bracket [v1; v2])
   | Ref (t, v1) -> let v1 = expr v1 in
       G.Ref (t, v1)
   | Unpack v1 -> let v1 = expr v1 in

--- a/lang_ruby/analyze/ruby_to_generic.ml
+++ b/lang_ruby/analyze/ruby_to_generic.ml
@@ -75,7 +75,7 @@ let rec expr = function
   | ScopedId x -> scope_resolution x
   | Hash (_bool, xs) -> G.Container (G.Dict, bracket (list expr) xs)
   | Array (xs) -> G.Container (G.Array, bracket (list expr) xs)      
-  | Tuple xs -> G.Tuple (list expr xs)
+  | Tuple xs -> G.Tuple (G.fake_bracket (list expr xs))
   | Unary (op, e) -> 
     let e = expr e in
     unary op e
@@ -169,7 +169,7 @@ and formal_param = function
       G.ParamClassic p
   | Formal_tuple (_t1, xs, _t2) ->
       let xs = list formal_param_pattern xs in
-      let pat = G.PatTuple (xs) in
+      let pat = G.PatTuple (G.fake_bracket xs) in
       G.ParamPattern pat
   | ParamEllipsis tok -> G.ParamEllipsis tok
 
@@ -177,7 +177,7 @@ and formal_param_pattern = function
   | Formal_id id -> G.PatId (id, G.empty_id_info())
   | Formal_tuple (_t1, xs, _t2) ->
       let xs = list formal_param_pattern xs in
-      G.PatTuple (xs)
+      G.PatTuple (G.fake_bracket xs)
 
   | Formal_amp _ | Formal_star _ | Formal_rest _ 
   | Formal_default _ | Formal_hash_splat _ | Formal_kwd _ 
@@ -294,7 +294,7 @@ and binary (op, t) e1 e2 =
       in
      G.AssignOp (e1, (op, t), e2)
    | Op_ASSOC -> 
-      G.Tuple ([e1;e2])
+      G.Tuple (G.fake_bracket [e1;e2])
    | Op_DOT3 ->
      (* coupling: make sure to check for the string in generic_vs_generic *)
      G.Call (G.IdSpecial (G.Op G.Range, t), fb [G.Arg e1; G.Arg e2])
@@ -450,13 +450,13 @@ and exprs_to_label_ident = function
   | [x] -> let x = expr x in G.LDynamic x
   | xs -> 
       let xs = list expr xs in
-      G.LDynamic (G.Tuple xs)
+      G.LDynamic (G.Tuple (G.fake_bracket xs))
 
 and exprs_to_eopt = function
   | [] -> None
   | [x] -> Some (expr x)
   | xs -> let xs = list expr xs in
-      Some (G.Tuple xs)
+      Some (G.Tuple (G.fake_bracket xs))
 
 and pattern pat = 
   let e = expr pat in


### PR DESCRIPTION
This will allow us to return matches on empty tuples,
which currently fails as empty tuples have no
token information.

Adresses returntocorp/semgrep#1654