### PR TITLE
Parse 'implements' clause in typescript

### DIFF
--- a/lang_js/parsing/cst_js.ml
+++ b/lang_js/parsing/cst_js.ml
@@ -360,7 +360,7 @@ and stmt =
 (*****************************************************************************)
 (* Type *)
 (*****************************************************************************)
-(* typing-ext: facebook-ext: complex type annotations for Flow/Typescript
+(* typescript-ext: facebook-ext: complex type annotations for Flow/Typescript
  * See also https://www.typescriptlang.org/docs/handbook/advanced-types.html
  *)
 and type_ =
@@ -435,7 +435,7 @@ and func_decl = {
   f_params: parameter_binding comma_list paren;
   f_body: item list brace;
 
-  (* typing-ext: *)
+  (* typescript-ext: *)
   f_type_params: type_parameters option;
   f_return_type: type_opt;
 }
@@ -461,7 +461,7 @@ and func_decl = {
 
   and parameter = {
    p_name: name;
-  (* typing-ext: *)
+  (* typescript-ext: *)
    p_type: type_opt;
    (* es6: if not None, then can be followed only by other default parameters 
       or a dots parameter in a parameter comma_list *)
@@ -491,7 +491,7 @@ and func_decl = {
 and arrow_func = {
   a_async: tok option;
   a_params: arrow_params;
-  (* typing-ext: *)
+  (* typescript-ext: *)
   a_return_type: type_opt;
   a_tok: tok (* => *);
   a_body: arrow_body;
@@ -515,7 +515,7 @@ and var_binding =
   and variable_declaration = {
     v_name: name;
     v_init: init option;
-    (* typing-ext: *)
+    (* typescript-ext: *)
     v_type: type_opt;
   }
     and init = (tok (*=*) * expr)
@@ -532,7 +532,7 @@ and var_binding =
   and variable_declaration_pattern = {
     vpat: pattern;
     vpat_init: init option; (* None only when inside ForOf *)
-    (* typing-ext: *)
+    (* typescript-ext: *)
     vpat_type: type_opt;
   }
 
@@ -545,10 +545,11 @@ and class_decl = {
   c_tok: tok; (* 'class' *)
   (* None for anon classes in class expressions or 'export default' decls *)
   c_name: name option; 
-  (* typing-ext: *)
+  (* typescript-ext: *)
   c_type_params: type_parameter comma_list angle option;
-  (* TODO: c_implements *)
   c_extends: (tok (* extends *) * nominal_type) option;
+  (* typescript-ext: *)
+  c_implements: (tok (* implements *) * type_ comma_list) option;
   c_body: class_element list brace;
 }
 
@@ -573,7 +574,7 @@ and class_decl = {
 (* ------------------------------------------------------------------------- *)
 (* Interface definition *)
 (* ------------------------------------------------------------------------- *)
-(* typing-ext: not in regular JS *)
+(* typescript-ext: not in regular JS *)
 and interface_decl = {
   i_tok: tok; (* 'interface' *)
   i_name: name;
@@ -594,7 +595,7 @@ and item =
   | FunDecl of func_decl
   (* es6-ext: *)
   | ClassDecl of class_decl
-  (* typing-ext: *)
+  (* typescript-ext: *)
   | InterfaceDecl of interface_decl
   | ItemTodo of tok (* last tok, needed for ASI to work *)
 
@@ -618,7 +619,7 @@ and import =
    and name_import =
      | ImportNamespace of tok (* * *) * tok (* as *) * name
      | ImportNames of import_name comma_list brace
-     (* typing-ext: *)
+     (* typescript-ext: *)
      | ImportTypes of tok (* 'type' *) * import_name comma_list brace
    and import_default = name
    and import_name = name * (tok (* as *) * name) option

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -587,6 +587,7 @@ and
                  c_name = v_c_name;
                  c_type_params = v_c_type_params;
                  c_extends = v_c_extends;
+                 c_implements;
                  c_body = v_c_body
                } =
   let arg = v_tok v_c_tok in
@@ -596,6 +597,10 @@ and
     v_option
       (fun (v1, v2) -> let v1 = v_tok v1 and v2 = v_nominal_type v2 in ())
       v_c_extends in
+  let arg =
+    v_option
+      (fun (v1, v2) -> let v1 = v_tok v1 and v2 = v_comma_list v_type_ v2 in ())
+      c_implements in
   let arg = v_brace (v_list v_class_stmt) v_c_body in
   ()
 and


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/1753

test plan:
test file included with associated semgrep PR.

you can see the new c_implements "B" below for class "A"

$ /home/pad/semgrep/_build/default/pfff/cli/Main.exe -dump_ast misc_implements.ts
Pr(
  [DefStmt(
     ({name=("A", ()); attrs=[KeywordAttr((Const, ()))]; tparams=[];
       info={id_resolved=Ref(None); id_type=Ref(None);
             id_const_literal=Ref(None); };
       },
      ClassDef(
        {ckind=(Class, ()); cextends=[];
         cimplements=[TyName(
                        (("B", ()),
                         {name_qualifier=None; name_typeargs=None; }))];
         cmixins=[]; cbody=[]; })));
   DefStmt(
     ({name=("A2", ()); attrs=[KeywordAttr((Const, ()))]; tparams=[];
       info={id_resolved=Ref(None); id_type=Ref(None);
             id_const_literal=Ref(None); };
       },
      ClassDef(
        {ckind=(Class, ()); cextends=[]; cimplements=[]; cmixins=[];
         cbody=[]; })))])