### PR TITLE
Fixing triple token repeat for EncodedString in semgrep message

### DIFF
--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -468,7 +468,7 @@ and expr =
 
    (* used for interpolated strings constructs *)
    | ConcatString of concat_string_kind
-   | EncodedString of string wrap (* only for Python for now (e.g., b"foo") *)
+   | EncodedString of string (* only for Python for now (e.g., b"foo") *)
    (* TaggedString? for Javascript, for styled.div`bla{xx}`?
     * We could have this TaggedString where the first arg of Call
     * will be the tagging function, and the rest will be a Call ConcatString. 

--- a/h_program-lang/Visitor_AST.ml
+++ b/h_program-lang/Visitor_AST.ml
@@ -293,7 +293,7 @@ and v_special =
   | New -> ()
   | Spread -> ()
   | HashSplat -> ()
-  | EncodedString v1 -> let v1 = v_wrap v_string v1 in ()
+  | EncodedString v1 -> let v1 = v_string v1 in ()
   | Op v1 -> let v1 = v_arithmetic_operator v1 in ()
   | IncrDecr ((v1, v2)) -> let v1 = v_incr_decr v1 and v2 = v_prepost v2 in ()
   | ConcatString v1 -> let v1 = v_interpolated_kind v1 in ()

--- a/lang_GENERIC/parsing/Map_AST.ml
+++ b/lang_GENERIC/parsing/Map_AST.ml
@@ -276,7 +276,7 @@ and map_special x =
   | Sizeof | New | Spread | HashSplat 
     -> x
   | Op v1 -> let v1 = map_arithmetic_operator v1 in Op ((v1))
-  | EncodedString v1 -> let v1 = map_wrap map_of_string v1 in EncodedString ((v1))
+  | EncodedString v1 -> let v1 = map_of_string v1 in EncodedString ((v1))
   | IncrDecr ((v1, v2)) ->
       let v1 = map_of_incdec v1 and v2 = map_of_prepost v2 in IncrDecr ((v1, v2))
   | ConcatString v1 -> let v1 = map_of_interpolated_kind v1 in

--- a/lang_GENERIC/parsing/Meta_AST.ml
+++ b/lang_GENERIC/parsing/Meta_AST.ml
@@ -297,7 +297,7 @@ and vof_special =
   | Spread -> OCaml.VSum (("Spread", []))
   | HashSplat -> OCaml.VSum (("HashSplat", []))
   | EncodedString v1 ->
-      let v1 = vof_wrap OCaml.vof_string v1 in
+      let v1 = OCaml.vof_string v1 in
       OCaml.VSum (("EncodedString", [v1]))
   | Op v1 ->
       let v1 = vof_arithmetic_operator v1 in OCaml.VSum (("Op", [ v1 ]))

--- a/lang_python/analyze/Python_to_generic.ml
+++ b/lang_python/analyze/Python_to_generic.ml
@@ -155,9 +155,13 @@ let rec expr (x: expr) =
       G.L (G.String (v1))
   | EncodedStr (v1, pre) ->
       let v1 = wrap string v1 in
-      (* reuse same tok *)
-      let tok = snd v1 in
-      G.Call (G.IdSpecial (G.EncodedString (pre, tok), tok),
+      (* bugfix: do not reuse the same tok! otherwise in semgrep
+       * if a metavar is bound to an encoded string (e.g., r'foo'), and
+       * the metavar is used in the message, r'foo' will be displayed
+       * three times.
+       * todo: the right fix is to have EncodedStr of string wrap * string wrap
+       *)
+      G.Call (G.IdSpecial (G.EncodedString (pre), fake ""),
         fb [G.Arg (G.L (G.String (v1)))])
 
   | InterpolatedString xs ->

--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -129,6 +129,8 @@ type resolved_name =
 type expr =
   | Num of number (* n *)
   | Str of string wrap (* s *)
+  (* todo: we should split the token in r'foo' in two, one string wrap
+   * for the prefix and a string wrap for the string itself. *)
   | EncodedStr of string wrap * string (* prefix *)
   (* python3: now officially reserved keywords *)
   | Bool of bool wrap


### PR DESCRIPTION
This fixes https://github.com/returntocorp/semgrep/issues/1749

test plan:
$ /home/pad/semgrep/_build/default/bin/Main.exe -lang python -f tests/python/misc_encoded_string.sgrep tests/python/misc_encoded_string.py -pvar $PATH

tests/python/misc_encoded_string.py:2: r'^whitesource_list'

instead of 3 times the same thing.