### PR TITLE
remove resolved_name from ast_js

### DIFF
--- a/lang_js/analyze/graph_code_js.mli
+++ b/lang_js/analyze/graph_code_js.mli
@@ -6,6 +6,9 @@ val build:
 val kind_of_expr_opt: 
   Ast_js.var_kind Ast_js.wrap -> Ast_js.expr option -> Entity_code.entity_kind
 
+(* used to be in ast_js.ml *)
+type qualified_name = string
+(* deprecated *)
 val build_for_ai: Common.dirname -> Common.filename list ->
-  (Ast_js.qualified_name, Ast_js.var) Hashtbl.t *
+  (qualified_name, Ast_js.var) Hashtbl.t *
   (Common.filename (* readable *) * Ast_js.program) list

--- a/lang_js/analyze/highlight_js.ml
+++ b/lang_js/analyze/highlight_js.ml
@@ -74,7 +74,7 @@ let visit_program ~tag_hook _prefs (ast, toks) =
   let visitor = V.mk_visitor { V.default_visitor with
      V.ktop = (fun (k, _) t ->
        (match t with
-       | DefStmt {v_name = name; v_kind; v_init; v_resolved = _resolved; _ } ->
+       | DefStmt {v_name = name; v_kind; v_init; _ } ->
            let kind = Graph_code_js.kind_of_expr_opt v_kind v_init in
            tag_name name (Entity (kind, (Def2 fake_no_def2)));
        | _ -> ()
@@ -100,6 +100,7 @@ let visit_program ~tag_hook _prefs (ast, toks) =
          | Eval -> tag ii BadSmell
          | _ -> tag ii Builtin
          )
+(* TODO: use generic AST based highlighter 
       | Id (name, scope) ->
          (match !scope with
          | NotResolved | Global _ -> 
@@ -112,6 +113,7 @@ let visit_program ~tag_hook _prefs (ast, toks) =
       | Apply (Id (_name, {contents = Local | Param}), _) ->
          (* todo: tag_name name PointerCall; *)
          ()
+*)
       | Apply (ObjAccess (_, _, PN name), _) ->
          tag_name name (Entity (E.Method, (Use2 fake_no_use2)));
       | Fun (_, Some name) ->

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -31,7 +31,6 @@ module G = AST_generic
 let id = fun x -> x
 let option = Common.map_opt
 let list = List.map
-let vref f x = ref (f !x)
 
 let bool = id
 let string = id
@@ -57,19 +56,6 @@ let ident x = name x
 let filename v = wrap string v
 
 let label v = wrap string v
-
-(* note: we do not care anymore about the language-specific tagger.
- * we use instead the generic naming_ast.ml *)
-let resolved_name _x = 
-(* old:
-  let _qualified_name x = [x, fake "TODO qualified name"] in
-  match x with
-  | Local -> Some (G.Local, G.sid_TODO)
-  | Param -> Some (G.Param, G.sid_TODO)
-  | Global x -> Some (G.ImportedEntity (qualified_name x), G.sid_TODO)
-  | NotResolved -> None
-*)
-  None
 
 type special_result = 
   | SR_Special of G.special wrap
@@ -192,11 +178,9 @@ and expr (x: expr) =
   | Num v1 -> let v1 = wrap string v1 in G.L (G.Float v1)
   | String v1 -> let v1 = wrap string v1 in G.L (G.String v1)
   | Regexp v1 -> let v1 = wrap string v1 in G.L (G.Regexp v1)
-  | Id (v1, refresolved) -> 
+  | Id (v1) -> 
       let v1 = name v1 in
-      let v3 = { (G.empty_id_info ()) with
-                 G.id_resolved = vref resolved_name refresolved } in
-      G.Id (v1, v3)
+      G.Id (v1, G.empty_id_info())
 
   | IdSpecial (v1) -> 
       let x = special v1 in
@@ -365,7 +349,7 @@ and case =
 and type_ x = x 
 
 and def_of_var { v_name = x_name; v_kind = x_kind; 
-                 v_init = x_init; v_resolved = x_resolved; v_type = ty } =
+                 v_init = x_init; v_type = ty } =
   let v1 = name x_name in
   let v2 = var_kind x_kind in 
   let ent = G.basic_entity v1 [v2] in
@@ -382,20 +366,16 @@ and def_of_var { v_name = x_name; v_kind = x_kind;
       { ent with G.attrs = ent.G.attrs @ more_attrs}, G.ClassDef def
   | _ -> 
        let v3 = option expr x_init in 
-       let v4 = vref resolved_name x_resolved in
-       ent.G.info.G.id_resolved := !v4;
        ent, G.VarDef { G.vinit = v3; G.vtype = ty }
    )
 
 and var_of_var { v_name = x_name; v_kind = x_kind; 
-                 v_init = x_init; v_resolved = x_resolved; v_type } =
+                 v_init = x_init; v_type } =
   let v1 = name x_name in
   let v2 = var_kind x_kind in 
   let ent = G.basic_entity v1 [v2] in
   let v3 = option expr x_init in 
-  let v4 = vref resolved_name x_resolved in
   let v_type = option type_ v_type in
-  ent.G.info.G.id_resolved := !v4;
   ent, { G.vinit = v3; vtype = v_type }
 
 

--- a/lang_js/analyze/map_ast_js.ml
+++ b/lang_js/analyze/map_ast_js.ml
@@ -82,15 +82,6 @@ and map_bracket:'a. ('a -> 'a) -> 'a bracket -> 'a bracket =
 and map_name v = map_wrap map_of_string v
 and map_ident x = map_name x
   
-and map_qualified_name v = map_of_string v
-  
-and map_resolved_name =
-  function
-  | Local -> Local
-  | Param -> Param
-  | Global v1 -> let v1 = map_qualified_name v1 in Global ((v1))
-  | NotResolved -> NotResolved
-  
 and map_special =
   function
   | Null -> Null
@@ -178,10 +169,9 @@ and map_expr =
   | Num v1 -> let v1 = map_wrap map_of_string v1 in Num ((v1))
   | String v1 -> let v1 = map_wrap map_of_string v1 in String ((v1))
   | Regexp v1 -> let v1 = map_wrap map_of_string v1 in Regexp ((v1))
-  | Id ((v1, v2)) ->
+  | Id ((v1)) ->
       let v1 = map_name v1
-      and v2 = map_of_ref map_resolved_name v2
-      in Id ((v1, v2))
+      in Id ((v1))
   | IdSpecial v1 -> let v1 = map_wrap map_special v1 in IdSpecial ((v1))
   | Assign ((v1, v2, v3)) ->
       let v1 = map_expr v1 and v2 = map_tok v2 and v3 = map_expr v3 in
@@ -317,15 +307,12 @@ and
             v_kind = v_v_kind;
             v_init = v_v_init;
             v_type = vt;
-            v_resolved = v_v_resolved
           } =
-  let v_v_resolved = map_of_ref map_resolved_name v_v_resolved in
   let v_v_init = map_of_option map_expr v_v_init in
   let v_v_kind = map_wrap map_var_kind v_v_kind in
   let vt = map_of_option map_type_ vt in
   let v_v_name = map_name v_v_name in 
-    { v_name = v_v_name; v_kind = v_v_kind; v_init = v_v_init; v_type = vt;
-      v_resolved = v_v_resolved }
+  { v_name = v_v_name; v_kind = v_v_kind; v_init = v_v_init; v_type = vt; }
 
 (* TODO? call Map_AST with local kinfo? meh *)
 and map_type_ x = x

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -148,7 +148,7 @@ and v_expr (x: expr) =
   | Num v1 -> let v1 = v_wrap v_string v1 in ()
   | String v1 -> let v1 = v_wrap v_string v1 in ()
   | Regexp v1 -> let v1 = v_wrap v_string v1 in ()
-  | Id (v1, _) -> let v1 = v_name v1 in ()
+  | Id (v1) -> let v1 = v_name v1 in ()
   | IdSpecial v1 -> let v1 = v_wrap v_special v1 in ()
   | Assign ((v1, v2, v3)) -> 
         let v1 = v_expr v1 and v2 = v_tok v2 and v3 = v_expr v3 in ()
@@ -258,12 +258,10 @@ and v_resolved_name _ = ()
 
 
 
-and v_var { v_name = v_v_name; v_kind = v_v_kind; v_init = v_v_init; 
-            v_resolved = v_v_resolved; v_type = vt } =
+and v_var { v_name = v_v_name; v_kind=v_v_kind; v_init = v_v_init; v_type=vt} =
   let arg = v_name v_v_name in
   let arg = v_wrap v_var_kind v_v_kind in 
   let arg = v_option v_expr v_v_init in 
-  let arg = v_ref_do_not_visit v_resolved_name v_v_resolved in
   v_option v_type_ vt;
   ()
 and v_var_kind = function | Var -> () | Let -> () | Const -> ()


### PR DESCRIPTION
We now use the generic AST Naming_AST.ml to resolve names.

test plan:
make
make test