### PR TITLE
Support variadic parameters in generic AST for PHP

### DIFF
--- a/lang_php/analyze/foundation/php_to_generic.ml
+++ b/lang_php/analyze/foundation/php_to_generic.ml
@@ -36,6 +36,7 @@ let list     = List.map
 let bool   = id
 let string = id
 
+(* raise AST_generic.Error *)
 let error = AST_generic.error
 let fake  = AST_generic.fake
 let fb = AST_generic.fake_bracket
@@ -244,8 +245,7 @@ and expr =
       let v1 = expr v1 and v2 = expr v2 in 
       G.ArrayAccess (v1, (t1, v2, t2))
   | Array_get ((_v1, (t1, None, _))) ->
-      raise (Parse_info.Ast_builder_error 
-             ("should be handled in Assign caller", t1))
+      error t1 "$var[] should be handled in Assign caller"
   | Obj_get ((v1, t, Id [v2])) -> 
       let v1 = expr v1 and v2 = ident v2 in
       G.DotAccess (v1, t, G.FId v2)
@@ -405,16 +405,21 @@ and hint_type =
              match v1 with
              | G.L (G.String (s, t)) -> 
                 G.basic_field (s,t) None (Some v2)
-             | _ -> error tok "HintShape with non-string keys not supported"
+             | _ -> 
+                G.FieldStmt (G.OtherStmt (G.OS_Todo, 
+                     [G.TodoK ("HintShape with non-string keys not supported",
+                        tok)]))
           )
           v1
       in 
       G.TyRecordAnon (tok, (t1, v1, t2))
 
   | HintTypeConst (_, tok,_) -> 
-    error tok "HintTypeConst not supported, facebook-ext"
+      G.OtherType (G.OT_Todo, 
+         [G.TodoK ("HintTypeConst not supported, facebook-ext", tok)])
   | HintVariadic (tok, _) -> 
-    error tok "HintVariadic not supported"
+      G.OtherType (G.OT_Todo, 
+         [G.TodoK ("HintVariadic not supported", tok)])
 
 and class_name v = hint_type v
 

--- a/tests/php/parsing/variadic_parameter.php
+++ b/tests/php/parsing/variadic_parameter.php
@@ -1,0 +1,3 @@
+<?php
+function foo( ...$args ) {
+}


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/1807

test plan:
```
$ /home/pad/semgrep/_build/default/pfff/cli/Main.exe -parse_js -dump_ast variadic_parameter.php
Pr(
  [DefStmt(
     ({name=("foo", ()); attrs=[]; tparams=[];
       info={id_resolved=Ref(None); id_type=Ref(None);
             id_const_literal=Ref(None); };
       },
      FuncDef(
        {fkind=(Function, ());
         fparams=[ParamClassic(
                    {pname=Some(("$args", ())); pdefault=None;
                     ptype=Some(OtherType(OT_Todo,
                                  [TodoK(("HintVariadic not supported", ()))]));
                     pattrs=[KeywordAttr((Variadic, ()))];
                     pinfo={id_resolved=Ref(None); id_type=Ref(None);
                            id_const_literal=Ref(None); };
                     })];
         frettype=None; fbody=Block([]); })))])
```