### PR TITLE
Allow partial function signature and class header for Javascript patterns

### DIFF
--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -1723,4 +1723,5 @@ let sc = Parse_info.fake_info ";"
 let exprstmt e = ExprStmt (e, sc)
 let fieldEllipsis t = FieldStmt (exprstmt (Ellipsis t))
 let empty_fbody = Block (fake_bracket [])
+let empty_cbody = fake_bracket []
 (*e: pfff/h_program-lang/AST_generic.ml *)

--- a/h_program-lang/Visitor_AST.ml
+++ b/h_program-lang/Visitor_AST.ml
@@ -571,6 +571,9 @@ and v_def_as_partial ent defkind =
   | FuncDef def ->
      let partial_def = { def with fbody = empty_fbody } in
      v_partial ~recurse:false (PartialDef (ent, FuncDef partial_def))
+  | ClassDef def ->
+     let partial_def = { def with cbody = empty_cbody } in
+     v_partial ~recurse:false (PartialDef (ent, ClassDef partial_def))
   | _ -> ()
 
 (* The recurse argument is subtle. It is needed because we

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -530,6 +530,11 @@ and module_directive x =
 
 and program v = list toplevel v
 
+and partial = function
+  | PartialDef v1 -> 
+      let v1 = definition v1 in
+      G.PartialDef v1
+
 and any =
   function
   | Expr v1 -> let v1 = expr v1 in G.E v1
@@ -538,3 +543,6 @@ and any =
   | Program v1 -> let v1 = program v1 in G.Pr v1
   | Pattern v1 -> let v1 = pattern v1 in G.P v1
   | Type v1 -> let v1 = type_ v1 in G.T v1
+  | Partial v1 -> 
+      let v1 = partial v1 in 
+      G.Partial v1

--- a/lang_js/parsing/ast_js.ml
+++ b/lang_js/parsing/ast_js.ml
@@ -505,6 +505,11 @@ and program = toplevel list
 (*****************************************************************************)
 (* Any *)
 (*****************************************************************************)
+
+and partial = 
+ (* the stmt will be empty in f_body and c_body *)
+ | PartialDef of definition
+
 (* this is now mutually recursive with the previous types because of StmtTodo*)
 and any = 
   | Expr of expr
@@ -513,6 +518,7 @@ and any =
   | Pattern of pattern
   | Type of type_
   | Program of program
+  | Partial of partial
 
  [@@deriving show { with_path = false} ] (* with tarzan *)
 

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -381,6 +381,12 @@ sgrep_spatch_pattern:
  | module_item              EOF  { fix_sgrep_module_item $1 }
  | module_item module_item+ EOF  { Stmts (List.flatten ($1::$2)) }
 
+ (* partials *) 
+ | T_FUNCTION id? call_signature EOF
+   { Partial (PartialDef (mk_def ($2, mk_FuncDef [] $3 (fb [])))) }
+ | T_CLASS binding_id? generics? class_heritage EOF
+   { Partial (PartialDef (mk_def ($2, mk_ClassDef $1 $3 $4 (fb [])))) }
+
 (*************************************************************************)
 (* Namespace *)
 (*************************************************************************)

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -397,6 +397,10 @@ and v_any =
   | Pattern v1 -> v_pattern v1
   | Type v1 -> v_type_ v1
   | Program v1 -> let v1 = v_program v1 in ()
+  | Partial v1 -> v_partial v1
+
+and v_partial = function
+  | PartialDef def -> v_def def
 
 and v_program v = v_list v_toplevel v
 


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/1756

test plan:
test files included and

$ /home/pad/semgrep/_build/default/bin/Main.exe -lang js -f tests/js/partial_class.sgrep tests/js/partial_class.js
 tests/js/partial_class.js
tests/js/partial_class.js:2
 class A {

$ /home/pad/semgrep/_build/default/bin/Main.exe -lang js -f tests/js/partial_function.sgrep tests/js/partial_function.js
 tests/js/partial_function.js
tests/js/partial_function.js:3
 function foo(a, b, c) {