### PR TITLE
Allow method definition as a toplevel semgrep pattern

### DIFF
--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -1432,6 +1432,7 @@ and any =
   | T of type_
   | P of pattern
   | At of attribute
+  | Fld of field
 
   | Partial of partial
 
@@ -1449,7 +1450,6 @@ and any =
   | Ar of argument
   | Dk of definition_kind
   | Di of dotted_ident
-  | Fld of field
   | Lbli of label_ident
   | Fldi of field_ident
   | Tk of tok

--- a/h_program-lang/Visitor_AST.ml
+++ b/h_program-lang/Visitor_AST.ml
@@ -30,6 +30,7 @@ type visitor_in = {
   kstmts: (stmt list  -> unit) * visitor_out -> stmt list -> unit;
   ktype_: (type_  -> unit) * visitor_out -> type_  -> unit;
   kpattern: (pattern  -> unit) * visitor_out -> pattern  -> unit;
+  kfield: (field  -> unit) * visitor_out -> field  -> unit;
   kpartial: (partial  -> unit) * visitor_out -> partial  -> unit;
 
   kdef: (definition  -> unit) * visitor_out -> definition  -> unit;
@@ -55,6 +56,7 @@ let default_visitor =
     kstmt   = (fun (k,_) x -> k x);
     ktype_   = (fun (k,_) x -> k x);
     kpattern   = (fun (k,_) x -> k x);
+    kfield   = (fun (k,_) x -> k x);
     kpartial = (fun (k,_) x -> k x);
 
     kdef   = (fun (k,_) x -> k x);
@@ -696,8 +698,9 @@ and v_vardef_as_assign_expr ventity = function
     v_expr (vardef_to_assign (ventity, vdef))
   | _ -> ()
 
-and v_field =
-  function
+and v_field x =
+  let k x =
+  match x with
   | FieldDynamic ((v1, v2, v3)) ->
       let v1 = v_expr v1
       and v2 = v_list v_attribute v2
@@ -707,6 +710,8 @@ and v_field =
       let t = v_tok t in
       let v1 = v_expr v1 in ()
   | FieldStmt v1 -> let v1 = v_stmt v1 in ()
+  in
+  vin.kfield (k, all_functions) x
 
 and v_type_definition { tbody = v_tbody } =
   let arg = v_type_definition_kind v_tbody in ()

--- a/h_program-lang/Visitor_AST.mli
+++ b/h_program-lang/Visitor_AST.mli
@@ -10,6 +10,7 @@ type visitor_in = {
   kstmts: (stmt list  -> unit) * visitor_out -> stmt list -> unit;
   ktype_: (type_  -> unit) * visitor_out -> type_  -> unit;
   kpattern: (pattern  -> unit) * visitor_out -> pattern  -> unit;
+  kfield: (field  -> unit) * visitor_out -> field  -> unit;
   kpartial: (partial  -> unit) * visitor_out -> partial  -> unit;
 
   kdef: (definition  -> unit) * visitor_out -> definition  -> unit;

--- a/h_program-lang/ast_fuzzy.ml
+++ b/h_program-lang/ast_fuzzy.ml
@@ -70,6 +70,8 @@ open Common
  *  - xpath? but do programming languages need the full power of xpath?
  *    usually an AST just have 3 different kinds of nodes, Defs, Stmts,
  *    and Exprs.
+ *  - spacegrep by Martin Jambon, relies on indentation in addition to
+ *    bracket tokens (works great on files like YAML)
  * 
  * See also lang_cpp/parsing_cpp/test_parsing_cpp and its parse_cpp_fuzzy()
  * and dump_cpp_fuzzy() functions. Most of the code related to Ast_fuzzy
@@ -131,7 +133,16 @@ type tree =
    *)
   | Dots of tok
 
+  (* Should we split Tok in 
+   * | Kwd of string wrap 
+   * | Id of string wrap 
+   * | OtherTok of string wrap
+   * ?
+   * Maybe, but at least you can build a hash from the Parse_info.t to
+   * the origin token if you need a better classification of Tok.
+   *)
   | Tok of string wrap
+
 and trees = tree list
  (* with tarzan *)
 

--- a/lang_js/analyze/highlight_js.ml
+++ b/lang_js/analyze/highlight_js.ml
@@ -239,7 +239,8 @@ let visit_program ~tag_hook _prefs (ast, toks) =
     (* Punctuation *)
 
     | T.T_LCURLY (ii) | T.T_RCURLY (ii) | T.T_LCURLY_SEMGREP ii
-    | T.T_LPAREN (ii) | T.T_LPAREN_ARROW (ii) | T.T_RPAREN (ii)
+    | T.T_LPAREN (ii) | T.T_LPAREN_ARROW (ii) | T.T_LPAREN_METHOD_SEMGREP ii
+    | T.T_RPAREN (ii)
     | T.T_LBRACKET (ii) | T.T_RBRACKET (ii)
     | T.T_SEMICOLON (ii)
     | T.T_COMMA (ii)

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -546,6 +546,9 @@ and partial = function
 
 and any =
   function
+  | Property v1 -> 
+      let v1 = property v1 in 
+      G.Fld v1
   | Expr v1 -> let v1 = expr v1 in G.E v1
   | Stmt v1 -> let v1 = stmt v1 in G.S v1
   | Stmts v1 -> let v1 = List.map stmt v1 in G.Ss v1

--- a/lang_js/parsing/ast_js.ml
+++ b/lang_js/parsing/ast_js.ml
@@ -516,6 +516,7 @@ and any =
   | Stmt of stmt
   | Stmts of stmt list
   | Pattern of pattern
+  | Property of property
   | Type of type_
   | Program of program
   | Partial of partial

--- a/lang_js/parsing/token_helpers_js.ml
+++ b/lang_js/parsing/token_helpers_js.ml
@@ -96,6 +96,7 @@ let visitor_info_of_tok f = function
   | T_RCURLY ii -> T_RCURLY (f ii)
   | T_LPAREN ii -> T_LPAREN (f ii)
   | T_LPAREN_ARROW ii -> T_LPAREN_ARROW (f ii)
+  | T_LPAREN_METHOD_SEMGREP ii -> T_LPAREN_METHOD_SEMGREP (f ii)
   | T_LCURLY_SEMGREP ii -> T_LCURLY_SEMGREP (f ii)
   | T_RPAREN ii -> T_RPAREN (f ii)
   | T_LBRACKET ii -> T_LBRACKET (f ii)

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -391,6 +391,7 @@ and v_module_directive x =
 
 and v_any =
   function
+  | Property v1 -> v_property v1
   | Expr v1 -> let v1 = v_expr v1 in ()
   | Stmt v1 -> let v1 = v_stmt v1 in ()
   | Stmts v1 -> let v1 = v_list v_stmt v1 in ()


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/1852
This also add a new kfield visitor that will be useful when
matching semgrep fields

test plan:
```
+ /home/pad/semgrep/_build/default/bin/Main.exe -lang ts -dump_pattern misc_method.sgrep
Fld(
  FieldStmt(
    DefStmt(
      ({name=("bar", ()); attrs=[]; tparams=[];
        info={id_resolved=Ref(None); id_type=Ref(None);
              id_const_literal=Ref(None); };
        },
       FuncDef(
         {fkind=(Method, ()); fparams=[]; frettype=None;
          fbody=Block([ExprStmt(Ellipsis(()), ())]); })))))
```