### PR TITLE
analyze: AST_to_IL: Translate most (all?) lvalue expressions

### DIFF
--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -1588,6 +1588,11 @@ let basic_id_info resolved =
   }
 (*e: function [[AST_generic.basic_id_info]] *)
 
+let id_of_name (id, nameinfo) =
+  match nameinfo.name_qualifier with
+  | None | Some (QDots []) -> Id (id, empty_id_info ())
+  | _ -> IdQualified ((id, nameinfo), empty_id_info())
+
 let name_of_id id = 
   (id, empty_name_info)
 

--- a/lang_GENERIC/analyze/IL.ml
+++ b/lang_GENERIC/analyze/IL.ml
@@ -100,7 +100,7 @@ type 'a bracket = tok * 'a * tok
 (*****************************************************************************)
 
 (*s: type [[IL.ident]] *)
-type ident = string wrap
+type ident = G.ident
 (*e: type [[IL.ident]] *)
  [@@deriving show] (* with tarzan *)
 
@@ -133,7 +133,7 @@ type lval = {
   and base = 
     | Var of name
     | VarSpecial of var_special wrap
-    (* for C *)
+    (* aka DeRef, e.g. *E in C *)
     | Mem of exp
 (*e: type [[IL.base]] *)
 

--- a/lang_ml/analyze/ml_to_generic.ml
+++ b/lang_ml/analyze/ml_to_generic.ml
@@ -43,11 +43,6 @@ let fake = G.fake
 
 let add_attrs ent attrs = 
   { ent with G.attrs = attrs }
-
-let id_of_name (id, nameinfo) = 
-  match nameinfo.G.name_qualifier with
-  | None | Some (G.QDots []) -> G.Id (id, G.empty_id_info ())
-  | _ -> G.IdQualified ((id, nameinfo), G.empty_id_info())
   
 (*****************************************************************************)
 (* Entry point *)
@@ -110,7 +105,7 @@ and expr =
       let v3 = tok v3 in
       G.DeepEllipsis (v1, v2, v3)
   | L v1 -> let v1 = literal v1 in G.L v1
-  | Name v1 -> let v1 = name v1 in id_of_name v1
+  | Name v1 -> let v1 = name v1 in G.id_of_name v1
   | Constructor ((v1, v2)) ->
       let v1 = name v1 and v2 = option expr v2 in
       G.Constructor (v1, Common.opt_to_list v2)
@@ -181,7 +176,7 @@ and expr =
       )
   | New ((v1, v2)) -> let v1 = tok v1 and v2 = name v2 in 
                       G.Call (G.IdSpecial (G.New, v1), 
-                              G.fake_bracket [G.Arg (id_of_name v2)])
+                              G.fake_bracket [G.Arg (G.id_of_name v2)])
   | ObjAccess ((v1, t, v2)) -> 
       let v1 = expr v1 and v2 = ident v2 in
       let t = tok t in


### PR DESCRIPTION
This is a WIP, just FYI, so that you know what I'm working on. But feel free to comment already if you see something wrong. I'll complete it ASAP.

This patch should translate most (all?) kinds of lvalue expressions from Generic AST to IL.