### PR TITLE
Simplify and fix unicode hack

### DIFF
--- a/h_program-lang/Parse_info.ml
+++ b/h_program-lang/Parse_info.ml
@@ -583,7 +583,14 @@ let tokenize_all_and_adjust_pos ?(unicode_hack=false)
     if unicode_hack then
       let string =
         Common.profile_code "Unicode.input_and_replace_non_ascii" (fun () ->
-          Unicode.input_and_replace_non_ascii chan
+          (*
+             This breaks java (and perhaps other) characters constants.
+             UTF-8 characters become something invalid like this:
+               char c = 'ZZZ'
+             There's a hack in the java lexer to support such invalid
+             character literals.
+          *)
+          Unicode.input_and_replace_non_ascii ~replacement_byte:'Z' chan
         ) in
       Lexing.from_string string
     else

--- a/h_program-lang/Parse_info.ml
+++ b/h_program-lang/Parse_info.ml
@@ -576,17 +576,18 @@ let complete_token_location_large filename table x =
  *  - we can have comments as tokens (useful for codemap/efuns) and
  *    skip them easily with one Common.exclude
  *)
-let tokenize_all_and_adjust_pos ?(unicode_hack=false) 
+let tokenize_all_and_adjust_pos ?(unicode_hack=false)
  file tokenizer visitor_tok is_eof =
  Common.with_open_infile file (fun chan ->
-  let lexbuf = 
-     if unicode_hack && Unicode.file_contains_non_ascii file
-     then
-       let string = 
-            Common.profile_code "Unicode.asciify" (fun () ->
-                Unicode.UTF8.asciify chan) in
-       Lexing.from_string string 
-     else Lexing.from_channel chan
+  let lexbuf =
+    if unicode_hack then
+      let string =
+        Common.profile_code "Unicode.input_and_replace_non_ascii" (fun () ->
+          Unicode.input_and_replace_non_ascii chan
+        ) in
+      Lexing.from_string string
+    else
+      Lexing.from_channel chan
   in
   let table     = full_charpos_to_pos_large file in
   let adjust_info ii = 

--- a/h_program-lang/Unicode.ml
+++ b/h_program-lang/Unicode.ml
@@ -2,70 +2,15 @@
    Utilities for dealing with Unicode issues.
 *)
 
-exception Found
-
-(* could probably be faster, but seems "good enough" *)
-let file_contains_non_ascii file =
-  (* copy-paste of Common.read_file without Bytes.to_string *)
-  let ic = open_in file  in
-  let size = in_channel_length ic in
-  let buf = Bytes.create size in
-  really_input ic buf 0 size;
+let input_all ic =
+  (* works only on regular files *)
+  let s = really_input_string ic (in_channel_length ic) in
   close_in ic;
-  try
-    buf |> Bytes.iter (fun char ->
-        if Char.code char > 128
-        then raise Found
-    );
-    false
-  with Found -> true
+  s
 
-module UTF8 = struct
-  (* Guess the length of the original UTF-8 sequence by re-encoding the
-     character. This is quite inefficient. *)
-  let get_length uchar =
-    let buf = Buffer.create 8 in
-    let enc = Uutf.encoder `UTF_8 (`Buffer buf) in
-    ignore (Uutf.encode enc uchar);
-    ignore (Uutf.encode enc `End);
-    Buffer.length buf
-
-  let asciify ic =
-    let src = `Channel ic in
-    let buf = Buffer.create 4096 in
-    let dec =
-      Uutf.decoder
-        ~nln:(`ASCII (Uchar.of_char '\n'))
-        ~encoding:`UTF_8 src
-    in
-    let rec translate () =
-      match Uutf.decode dec with
-      | `Uchar x as uchar ->
-          let code = Uchar.to_int x in
-          if code < 128 then
-            (* Waste as little time as possible here since most characters
-               are ascii and need no translation. *)
-            Buffer.add_char buf (Char.chr code)
-          else (
-            let len = get_length uchar in
-            let replacement_string =
-              if Uucp.White.is_white_space x then
-                String.make len ' '
-              else
-                String.make len 'Z'
-            in
-            Buffer.add_string buf replacement_string
-          );
-          translate ()
-      | `End ->
-          ()
-      | `Malformed s ->
-          (* Keep it and hope for the best. *)
-          Buffer.add_string buf s;
-          translate ()
-      | `Await ->
-          assert false
-    in
-    translate ();
-    Buffer.contents buf
-end
+let input_and_replace_non_ascii ?(replacement_byte = 'X') ic =
+  input_all ic
+  |> String.map (fun c ->
+    if Char.code c >= 128 then replacement_byte
+    else c
+  )

--- a/h_program-lang/Unicode.ml
+++ b/h_program-lang/Unicode.ml
@@ -8,7 +8,7 @@ let input_all ic =
   close_in ic;
   s
 
-let input_and_replace_non_ascii ?(replacement_byte = 'X') ic =
+let input_and_replace_non_ascii ~replacement_byte ic =
   input_all ic
   |> String.map (fun c ->
     if Char.code c >= 128 then replacement_byte

--- a/h_program-lang/Unicode.mli
+++ b/h_program-lang/Unicode.mli
@@ -10,4 +10,4 @@
    lexers that only support ascii.
 *)
 val input_and_replace_non_ascii :
-  ?replacement_byte:char -> in_channel -> string
+  replacement_byte:char -> in_channel -> string

--- a/h_program-lang/Unicode.mli
+++ b/h_program-lang/Unicode.mli
@@ -2,17 +2,12 @@
    Utilities for dealing with Unicode issues.
 *)
 
-val file_contains_non_ascii: Common.filename -> bool
+(*
+   Convert each non-ascii byte by one ascii byte.
+   The default replacement byte is 'X'.
 
-module UTF8 : sig
-  (*
-     Convert non-ascii whitespace to space characters and
-     other characters to 'Z' characters. The number of replacement
-     characters is adjusted to as to match the number of bytes of the original
-     character.
-
-     This is meant to be used as a hack to tolerate non-ascii input in
-     lexers that only support ascii.
-  *)
-  val asciify : in_channel -> string
-end
+   This is meant to be used as a hack to tolerate non-ascii input in
+   lexers that only support ascii.
+*)
+val input_and_replace_non_ascii :
+  ?replacement_byte:char -> in_channel -> string


### PR DESCRIPTION
Previously, iff a target file was found to contain some non-ascii characters, it would be rewritten using a UTF-8 decoder/encoder. This was incorrectly translating CRLF line endings to LF, resulting in match locations that are no longer valid match locations in the original file.

The fix here simplifies things in two ways:

* All input files are rewritten, not just those containing some unicode characters.
* The input program is rewritten using straightforward byte-for-byte substitution.

Fixes https://github.com/returntocorp/semgrep/issues/2111