### PR TITLE
Don't translate CRLF to LF in UTF-8 hack.

### DIFF
--- a/h_program-lang/Unicode.ml
+++ b/h_program-lang/Unicode.ml
@@ -35,7 +35,6 @@ module UTF8 = struct
     let buf = Buffer.create 4096 in
     let dec =
       Uutf.decoder
-        ~nln:(`ASCII (Uchar.of_char '\n'))
         ~encoding:`UTF_8 src
     in
     let rec translate () =


### PR DESCRIPTION
Another attempt to fix https://github.com/returntocorp/semgrep/issues/2111
