### PR TITLE
analyze: Treat TODOs as warnings instead of errors

### DIFF
--- a/lang_GENERIC/analyze/AST_to_IL.ml
+++ b/lang_GENERIC/analyze/AST_to_IL.ml
@@ -71,15 +71,37 @@ let sgrep_construct any_generic =
   error_any any_generic "Sgrep Construct"
 (*e: function [[AST_to_IL.sgrep_construct]] *)
 
-(*s: function [[AST_to_IL.todo]] *)
-let todo any_generic =
-  error_any any_generic "TODO Construct"
-(*e: function [[AST_to_IL.todo]] *)
-
 (*s: function [[AST_to_IL.impossible]] *)
 let impossible any_generic =
   error_any any_generic "Impossible Construct"
 (*e: function [[AST_to_IL.impossible]] *)
+
+exception Todo of G.any
+
+let todo gany =
+  raise (Todo gany)
+
+let todo_warning gany =
+  let toks = Lib_AST.ii_of_any gany in
+  let msg = spf
+      "Unsupported construct may affect the accuracy of dataflow analyses" in
+  try
+    warning (List.hd toks) msg
+  with Parse_info.NoTokenLocation _ ->
+    pr2 msg
+
+let exp_todo gany eorig =
+  todo_warning (G.E eorig);
+  { e=TodoExp gany; eorig; }
+
+let instr_todo gany eorig =
+  todo_warning (G.E eorig);
+  { i=TodoInstr gany; iorig=eorig; }
+
+let stmt_todo gany =
+  todo_warning gany;
+  [{ s=TodoStmt gany; }]
+
 
 (*****************************************************************************)
 (* Helpers *)
@@ -239,9 +261,14 @@ and pattern_assign_statements env exp eorig pat =
 (* Assign *)
 (*****************************************************************************)
 and assign env lhs _tok rhs_exp eorig =
-  let lval = lval env lhs in
-  add_instr env (mk_i (Assign (lval, rhs_exp)) eorig);
-  mk_e (Lvalue lval) lhs
+  (* TODO: tuples and objects as LHS *)
+  try
+    let lval = lval env lhs in
+    add_instr env (mk_i (Assign (lval, rhs_exp)) eorig);
+    mk_e (Lvalue lval) lhs
+  with Todo gany ->
+    add_instr env (instr_todo gany eorig);
+    exp_todo gany lhs
 
 (*****************************************************************************)
 (* Expression *)
@@ -249,7 +276,7 @@ and assign env lhs _tok rhs_exp eorig =
 (* less: we could pass in an optional lval that we know the caller want
  * to assign into, which would avoid creating useless fresh_var intermediates.
 *)
-and expr env eorig =
+and expr_aux env eorig =
   match eorig with
   | G.Call (G.IdSpecial (G.Op op, tok), args) ->
       let args = arguments env args in
@@ -431,6 +458,9 @@ and expr env eorig =
     -> sgrep_construct (G.E eorig)
   | G.OtherExpr (_, _) -> todo (G.E eorig)
 
+and expr env eorig =
+  try expr_aux env eorig
+  with Todo gany -> exp_todo gany eorig
 
 and expr_opt env = function
   | None ->
@@ -526,8 +556,7 @@ let for_var_or_expr_list env xs =
 (*****************************************************************************)
 (* Statement *)
 (*****************************************************************************)
-(*s: function [[AST_to_IL.stmt]] *)
-let rec stmt env st =
+let rec stmt_aux env st =
   match st with
   | G.ExprStmt (e, _) ->
       (* optimize? pass context to expr when no need for return value? *)
@@ -640,7 +669,10 @@ let rec stmt env st =
 
   | G.DisjStmt _ -> sgrep_construct (G.S st)
   | G.OtherStmt _ | G.OtherStmtWithStmt _ -> todo (G.S st)
-(*e: function [[AST_to_IL.stmt]] *)
+
+and stmt env st =
+  try stmt_aux env st
+  with Todo gany -> stmt_todo gany
 
 (*****************************************************************************)
 (* Entry point *)

--- a/lang_GENERIC/analyze/CFG_build.ml
+++ b/lang_GENERIC/analyze/CFG_build.ml
@@ -14,7 +14,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
  * license.txt for more details.
 *)
-open Common
 open IL
 module F = IL (* to be even more similar to controlflow_build.ml *)
 
@@ -147,7 +146,7 @@ let rec (cfg_stmt: state -> F.nodei option -> stmt -> F.nodei option) =
 
   | Label _
   | Goto _
-    -> raise Todo
+    -> cfg_todo state previ stmt
 
   | Return (tok, e) ->
       let newi = state.g#add_node { F.n = F.NReturn (tok, e); } in
@@ -159,13 +158,19 @@ let rec (cfg_stmt: state -> F.nodei option -> stmt -> F.nodei option) =
 
   | Try _
   | Throw (_, _)
-    -> raise Todo
+    -> cfg_todo state previ stmt
 
   | MiscStmt x ->
       let newi = state.g#add_node { F.n = F.NOther x } in
       state.g |> add_arc_opt (previ, newi);
       Some newi
 
+  | TodoStmt _ -> cfg_todo state previ stmt
+
+and cfg_todo state previ stmt =
+  let newi = state.g#add_node { F.n = F.NTodo stmt } in
+  state.g |> add_arc_opt (previ, newi);
+  Some newi
 
 and cfg_stmt_list state previ xs =
   xs |> List.fold_left (fun previ stmt ->

--- a/lang_GENERIC/analyze/Dataflow_tainting.ml
+++ b/lang_GENERIC/analyze/Dataflow_tainting.ml
@@ -118,7 +118,8 @@ let (transfer: config -> flow:F.cfg -> unit Dataflow.transfn) =
          then config.found_tainted_sink x in'
        end
    | Enter | Exit | TrueNode | FalseNode | Join
-   | NCond _| NReturn _ | NThrow _ | NOther _ -> ()
+   | NCond _| NReturn _ | NThrow _ | NOther _
+   | NTodo _ -> ()
   );
 
 
@@ -149,7 +150,8 @@ let (transfer: config -> flow:F.cfg -> unit Dataflow.transfn) =
         )
 
     | Enter | Exit | TrueNode | FalseNode | Join
-    | NCond _| NReturn _ | NThrow _ | NOther _ -> None
+    | NCond _| NReturn _ | NThrow _ | NOther _
+    | NTodo _ -> None
   in
   let kill_ni_opt =
     (* if there was a source(), no need to look for a sanitize() given
@@ -187,7 +189,8 @@ let (transfer: config -> flow:F.cfg -> unit Dataflow.transfn) =
              )
         )
     | Enter | Exit | TrueNode | FalseNode | Join
-    | NCond _| NReturn _ | NThrow _ | NOther _ -> None
+    | NCond _| NReturn _ | NThrow _ | NOther _
+    | NTodo _ -> None
   in
   let gen_ni = option_to_varmap gen_ni_opt in
   let kill_ni = option_to_varmap kill_ni_opt in

--- a/lang_GENERIC/analyze/Display_IL.ml
+++ b/lang_GENERIC/analyze/Display_IL.ml
@@ -37,8 +37,9 @@ let short_string_of_node_kind nkind =
        | Call (_lopt, exp, _) ->
            string_of_exp exp ^ "(...)"
        | CallSpecial _ -> "<special>"
+       | TodoInstr _ -> "<to-do instr>"
       )
-
+  | NTodo _ -> "<to-do stmt>"
 
 (* using internally graphviz dot and ghostview on X11 *)
 let (display_cfg: cfg -> unit) = fun flow ->

--- a/lang_GENERIC/analyze/IL.ml
+++ b/lang_GENERIC/analyze/IL.ml
@@ -193,6 +193,7 @@ and exp_kind =
   (* This could be put in call_special, but dumped IL are then less readable
    * (they are too many intermediate _tmp variables then) *)
   | Operator of G.operator wrap * exp list
+  | TodoExp of G.any (* some construct that we still don't support *)
   (*e: type [[IL.exp_kind]] *)
 
 (*s: type [[IL.composite_kind]] *)
@@ -229,6 +230,7 @@ and instr_kind =
   | AssignAnon of lval * anonymous_entity
   | Call of lval option * exp (* less: enforce lval? *) * argument list
   | CallSpecial of lval option * call_special wrap * argument list
+  | TodoInstr of G.any (* some construct that we still don't support *)
   (* todo: PhiSSA! *)
 (*e: type [[IL.instr_kind]] *)
 
@@ -296,6 +298,8 @@ and stmt_kind =
   | Throw of tok * exp (* less: enforce lval here? *)
 
   | MiscStmt of other_stmt
+
+  | TodoStmt of G.any (* some construct that we still don't support *)
   (*e: type [[IL.stmt_kind]] *)
 
 (*s: type [[IL.other_stmt]] *)
@@ -341,6 +345,8 @@ and node_kind =
   | NThrow  of tok * exp
 
   | NOther of other_stmt
+
+  | NTodo of stmt
   (*e: type [[IL.node_kind]] *)
 [@@deriving show { with_path = false }] (* with tarzan *)
 
@@ -387,6 +393,7 @@ let lvar_of_instr_opt x =
        | VarSpecial _ | Mem _ -> None
       )
   | Call _ | CallSpecial _ -> None
+  | TodoInstr _-> None
 (*e: function [[IL.lvar_of_instr_opt]] *)
 
 (*s: function [[IL.exps_of_instr]] *)
@@ -396,6 +403,7 @@ let exps_of_instr x =
   | AssignAnon _ -> []
   | Call (_, e1, args) -> e1::args
   | CallSpecial (_, _, args) -> args
+  | TodoInstr _ -> []
 (*e: function [[IL.exps_of_instr]] *)
 
 (*s: function [[IL.rvars_of_exp]] *)
@@ -408,6 +416,7 @@ let rec rvars_of_exp e =
   | Cast (_, e) -> rvars_of_exp e
   | Composite (_, (_, xs, _)) | Operator (_, xs) -> rvars_of_exps xs
   | Record ys -> rvars_of_exps (ys |> List.map snd)
+  | TodoExp _ -> []
 
 and rvars_of_exps xs =
   xs |> List.map (rvars_of_exp) |> List.flatten


### PR DESCRIPTION
This should allow data-flow analyses to work in the presence of
unsuported features---losing on precision or recall, of course.