### PR TITLE
Add WithUsingResource to generic AST

### DIFF
--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -725,6 +725,7 @@ and stmt =
 
   | Throw of tok (* 'raise' in OCaml, 'throw' in Java/PHP *) * expr * sc
   | Try of tok * stmt * catch list * finally option
+  | WithUsingResource of tok (* 'with' in Python, 'using' in C# *) * stmt (* resource acquisition *) * stmt (* block *)
   | Assert of tok * expr * expr option (* message *) * sc
   (*e: [[AST_generic.stmt]] other cases *)
   (*s: [[AST_generic.stmt]] toplevel and nested construct cases *)

--- a/h_program-lang/AST_generic.ml
+++ b/h_program-lang/AST_generic.ml
@@ -725,7 +725,7 @@ and stmt =
 
   | Throw of tok (* 'raise' in OCaml, 'throw' in Java/PHP *) * expr * sc
   | Try of tok * stmt * catch list * finally option
-  | WithUsingResource of tok (* 'with' in Python, 'using' in C# *) * stmt (* resource acquisition *) * stmt (* block *)
+  | WithUsingResource of tok (* 'with' in Python, 'using' in C# *) * stmt (* resource acquisition *) * stmt (* newscope: block *)
   | Assert of tok * expr * expr option (* message *) * sc
   (*e: [[AST_generic.stmt]] other cases *)
   (*s: [[AST_generic.stmt]] toplevel and nested construct cases *)

--- a/h_program-lang/Visitor_AST.ml
+++ b/h_program-lang/Visitor_AST.ml
@@ -458,6 +458,10 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           and v2 = v_list v_catch v2
           and v3 = v_option v_finally v3
           in ()
+      | WithUsingResource (t, v1, v2) ->
+          let t = v_tok t in
+          let v1 = v_stmt v1 and v2 = v_stmt v2 in
+          ()
       | Assert (t, v1, v2, sc) ->
           let t = v_tok t in
           let v1 = v_expr v1 and v2 = v_option v_expr v2 in

--- a/lang_GENERIC/analyze/AST_to_IL.ml
+++ b/lang_GENERIC/analyze/AST_to_IL.ml
@@ -635,12 +635,12 @@ let rec stmt env st =
   | G.Throw (tok, e, _) ->
       let ss, e = expr_with_pre_stmts env e in
       ss @ [mk_s (Throw (tok, e))]
-  | G.Try (_, _, _, _)
-    -> todo (G.S st)
+  | G.Try (_, _, _, _) ->
+      todo (G.S st)
   | G.WithUsingResource (_, stmt1, stmt2) ->
-    let stmt1 = stmt env stmt1 in
-    let stmt2 = stmt env stmt2 in
-    stmt1 @ stmt2
+      let stmt1 = stmt env stmt1 in
+      let stmt2 = stmt env stmt2 in
+      stmt1 @ stmt2
 
   | G.DisjStmt _ -> sgrep_construct (G.S st)
   | G.OtherStmt _ | G.OtherStmtWithStmt _ -> todo (G.S st)

--- a/lang_GENERIC/analyze/AST_to_IL.ml
+++ b/lang_GENERIC/analyze/AST_to_IL.ml
@@ -637,6 +637,10 @@ let rec stmt env st =
       ss @ [mk_s (Throw (tok, e))]
   | G.Try (_, _, _, _)
     -> todo (G.S st)
+  | G.WithUsingResource (_, stmt1, stmt2) ->
+    let stmt1 = stmt env stmt1 in
+    let stmt2 = stmt env stmt2 in
+    stmt1 @ stmt2
 
   | G.DisjStmt _ -> sgrep_construct (G.S st)
   | G.OtherStmt _ | G.OtherStmtWithStmt _ -> todo (G.S st)

--- a/lang_GENERIC/analyze/controlflow.ml
+++ b/lang_GENERIC/analyze/controlflow.ml
@@ -192,6 +192,7 @@ let simple_node_of_stmt_opt stmt =
     |A.Switch (_, _, _)
     |A.Return _|A.Continue _|A.Break _|A.Label (_, _)|A.Goto _
     |A.Throw _|A.Try (_, _, _, _)
+    |A.WithUsingResource (_, _, _)
     |A.OtherStmtWithStmt _
     |A.DisjStmt _
     ) -> None

--- a/lang_GENERIC/analyze/controlflow_build.ml
+++ b/lang_GENERIC/analyze/controlflow_build.ml
@@ -589,6 +589,9 @@ let rec (cfg_stmt: state -> F.nodei option -> stmt -> F.nodei option) =
       state.g |> add_arc_opt (previ, newi);
       cfg_stmt state (Some newi) st
 
+  | WithUsingResource (_, stmts1, stmts2) ->
+      cfg_stmt_list state previ [stmts1; stmts2]
+
   (* for dataflow purpose, such definitions are really the same than
    * an assignment. Liveness analysis does not make any difference between
    * a definition and an assign.

--- a/lang_GENERIC/parsing/Map_AST.ml
+++ b/lang_GENERIC/parsing/Map_AST.ml
@@ -449,6 +449,11 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           and v2 = map_of_list map_catch v2
           and v3 = map_of_option map_finally v3
           in Try (t, v1, v2, v3)
+      | WithUsingResource (t, v1, v2) ->
+          let t = map_tok t in
+          let v1 = map_stmt v1 in
+          let v2 = map_stmt v2 in
+          WithUsingResource ((t, v1, v2))
       | Assert (t, v1, v2, sc) ->
           let t = map_tok t in
           let v1 = map_expr v1 in

--- a/lang_GENERIC/parsing/Meta_AST.ml
+++ b/lang_GENERIC/parsing/Meta_AST.ml
@@ -620,6 +620,11 @@ and vof_stmt =
       and v2 = OCaml.vof_list vof_catch v2
       and v3 = OCaml.vof_option vof_finally v3
       in OCaml.VSum ("Try", [ t; v1; v2; v3 ])
+  | WithUsingResource (t, v1, v2) ->
+      let t = vof_tok t in
+      let v1 = vof_stmt v1 in
+      let v2 = vof_stmt v2 in
+      OCaml.VSum (("WithUsingResource", [ t; v1; v2 ]))
   | Assert (t, v1, v2, sc) ->
       let t = vof_tok t in
       let v1 = vof_expr v1 in


### PR DESCRIPTION
Obtain a resource using some expression or variable declaration, and dispose of
that value at the end of the block.

The first statement would be a ExprStmt or DefStmt to acquire some resource,
and the second statement would be the block where the resource is used.

E.g. in python:
```python
with fopen(file) as fp:
	...
```

E.g. in C#:
```csharp
using (var reader = new StringReader(manyLines))
{ ... }
```

E.g. in Java:
```java
try (Foo f = new Foo())
{ ... }
```

Resolves #342