### PR TITLE
AST-to-IL: Translate tuple LHS and simple record expressions

### DIFF
--- a/lang_GENERIC/analyze/AST_to_IL.ml
+++ b/lang_GENERIC/analyze/AST_to_IL.ml
@@ -189,6 +189,8 @@ let bracket_keep f (t1, x, t2) =
 (*****************************************************************************)
 let rec lval env eorig =
   match eorig with
+  | G.Id (("_", tok), _) -> (* wildcard *)
+      fresh_lval env tok
   | G.Id (id, id_info) ->
       let lval = lval_of_id_info env id id_info in
       lval

--- a/lang_GENERIC/analyze/AST_to_IL.ml
+++ b/lang_GENERIC/analyze/AST_to_IL.ml
@@ -526,6 +526,9 @@ and arguments env xs =
 and argument env arg =
   match arg with
   | G.Arg e -> expr env e
+  | G.ArgKwd (_, e) ->
+      (* TODO: Handle the keyword/label somehow (when relevant). *)
+      expr env e
   | _ -> todo (G.Ar arg)
 
 and record env ((_tok, origfields, _) as record_def) =


### PR DESCRIPTION
Also:
- Translate wildcards `_` as fresh variables.
- Translate keyword arguments while ignoring the keyword/label for now.