### PR TITLE
add 'depend' make target to install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ as well as the docs/manual/ directory.
 
 ## Usage for `pfff`
 ```sh
-$ ./pfff -parse_php demos/foo.php
+$ pfff -parse_php demos/foo.php
 ```
 or
 ```sh
-$ ./pfff -dump_php demos/foo.php
+$ pfff -dump_php demos/foo.php
 ```
 
-You can also look at `./pfff --help`
+You can also look at `pfff --help`
 
 ## Usage for `pfff_db`
 ```sh

--- a/configure
+++ b/configure
@@ -328,7 +328,6 @@ if($error2) {
 }
 
 pr2 "To compile $project type:
-  \$ $MAKE_PROGRAM depend
   \$ $MAKE_PROGRAM
 To test $project simply type:
   \$ $projectcmdline

--- a/install.txt
+++ b/install.txt
@@ -1,6 +1,8 @@
 To install pfff, you must first install recent versions of:
- - OCaml (at least 4.02.3)
+ - OCaml (at least 4.07.0)
    see http://caml.inria.fr/download.en.html
+ - opam - http://opam.ocaml.org
+ - dune - `opam install dune`, https://opam.ocaml.org/packages/dune/
  - SWI-prolog
    if you want the interactive code query tool
  - Java (for bddbddb)
@@ -9,7 +11,8 @@ To install pfff, you must first install recent versions of:
 If you want most of the good things just type:
 
   $ ./configure
+  $ opam install . --deps-only
   $ make
 
-This should generate a few binaries at the toplevel directory such
-as pfff.  To install binaries and libraries, run `make install`.
+This should generate a few binaries in `_build/install/default/bin/` such
+as `pfff`.  To install binaries and libraries, run `make install`.

--- a/install.txt
+++ b/install.txt
@@ -9,9 +9,7 @@ To install pfff, you must first install recent versions of:
 If you want most of the good things just type:
 
   $ ./configure
-  $ make depend
   $ make
-  $ make opt
 
 This should generate a few binaries at the toplevel directory such
-as pfff.
+as pfff.  To install binaries and libraries, run `make install`.

--- a/install_linux.txt
+++ b/install_linux.txt
@@ -6,5 +6,6 @@ packages usually not present in a default install:
 
 Then:
   $ ./configure
+  $ opam install . --deps-only
   $ make
   $ make install

--- a/install_linux.txt
+++ b/install_linux.txt
@@ -6,6 +6,5 @@ packages usually not present in a default install:
 
 Then:
   $ ./configure
-  $ make depend
   $ make
-  $ make opt
+  $ make install

--- a/install_windows.txt
+++ b/install_windows.txt
@@ -8,8 +8,8 @@ Then, install a few Cygwin packages:
 Once OPAM is installed, you will need to install a compatible
 version of OCaml and a few OPAM packages:
  - opam init
- - opam switch 4.02.3
- - opam install json-wheel
+ - opam switch 4.07.0
+ - opam install dune json-wheel
 
 
 Troubles?


### PR DESCRIPTION
PR corrects the installation instructions - currently install.txt and install-linux.txt as well as https://github.com/returntocorp/pfff/wiki say to run `make depend`, but this target is not or no longer present in the Makefile.  `make opt` is also unknown.
The PR add the `depend` target with `opam install . --deps-only` and removes `make opt`.  I believe we should remove `make opt` from the Wiki page.

https://github.com/returntocorp/pfff/blob/develop/install.txt#L12
https://github.com/returntocorp/pfff/blob/develop/install_linux.txt#L9