### PR TITLE
refactoring AST_generic.stmt as a record

### DIFF
--- a/lang_GENERIC/analyze/AST_to_IL.ml
+++ b/lang_GENERIC/analyze/AST_to_IL.ml
@@ -19,6 +19,8 @@ open IL
 module G = AST_generic
 module H = AST_generic_helpers
 
+[@@@warning "-40-42"]
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)
@@ -539,7 +541,7 @@ and record env ((_tok, origfields, _) as record_def) =
   let fields =
     origfields
     |> List.map (function
-      | G.FieldStmt (G.DefStmt ({G. name=G.EId (id, _);tparams=[];_}, def_kind)) ->
+      | G.FieldStmt ({s=G.DefStmt ({G. name=G.EId (id, _);tparams=[];_}, def_kind);_}) ->
           let fdeforig =
             match def_kind with
             (* TODO: Consider what to do with vtype. *)
@@ -614,7 +616,7 @@ let for_var_or_expr_list env xs =
 (* Statement *)
 (*****************************************************************************)
 let rec stmt_aux env st =
-  match st with
+  match st.G.s with
   | G.ExprStmt (e, _) ->
       (* optimize? pass context to expr when no need for return value? *)
       let ss, _eIGNORE = expr_with_pre_stmts env e in

--- a/lang_GENERIC/analyze/Test_analyze_generic.ml
+++ b/lang_GENERIC/analyze/Test_analyze_generic.ml
@@ -25,7 +25,7 @@ let test_typing_generic file =
 let test_cfg_generic file =
   let ast = Parse_generic.parse_program file in
   ast |> List.iter (fun item ->
-    (match item with
+    (match item.s with
      | DefStmt (_ent, FuncDef def) ->
          (try
             let flow = Controlflow_build.cfg_of_func def in
@@ -50,7 +50,7 @@ module DataflowX = Dataflow.Make (struct
 let test_dfg_generic file =
   let ast = Parse_generic.parse_program file in
   ast |> List.iter (fun item ->
-    (match item with
+    (match item.s with
      | DefStmt (_ent, FuncDef def) ->
          let flow = Controlflow_build.cfg_of_func def in
          pr2 "Reaching definitions";
@@ -109,7 +109,7 @@ let test_cfg_il file =
   Naming_AST.resolve lang ast;
 
   ast |> List.iter (fun item ->
-    (match item with
+    (match item.s with
      | DefStmt (_ent, FuncDef def) ->
          let xs = AST_to_IL.stmt def.fbody in
          let cfg = CFG_build.cfg_of_stmts xs in
@@ -134,7 +134,7 @@ let test_dfg_tainting file =
   Naming_AST.resolve lang ast;
 
   ast |> List.iter (fun item ->
-    (match item with
+    (match item.s with
      | DefStmt (_ent, FuncDef def) ->
          let xs = AST_to_IL.stmt def.fbody in
          let flow = CFG_build.cfg_of_stmts xs in

--- a/lang_GENERIC/analyze/controlflow.ml
+++ b/lang_GENERIC/analyze/controlflow.ml
@@ -180,7 +180,7 @@ let short_string_of_node node =
 (* Converters *)
 (*****************************************************************************)
 let simple_node_of_stmt_opt stmt =
-  match stmt with
+  match stmt.s with
   | A.ExprStmt (e, _)      -> Some (ExprStmt e)
   | A.Assert (t, e1, e2, _sc) -> Some (Assert (t, e1, e2))
   | A.DefStmt x       -> Some (DefStmt x)
@@ -198,11 +198,11 @@ let simple_node_of_stmt_opt stmt =
     ) -> None
 
 let any_of_simple_node = function
-  | ExprStmt e      -> A.S (A.ExprStmt (e, A.sc))
-  | Assert (t, e1, e2) -> A.S (A.Assert (t, e1, e2, A.sc))
-  | DefStmt x       -> A.S (A.DefStmt x)
-  | DirectiveStmt x -> A.S (A.DirectiveStmt x)
-  | OtherStmt (a,b) -> A.S (A.OtherStmt (a,b))
+  | ExprStmt e      -> A.S (A.ExprStmt (e, A.sc) |> A.s)
+  | Assert (t, e1, e2) -> A.S (A.Assert (t, e1, e2, A.sc) |> A.s)
+  | DefStmt x       -> A.S (A.DefStmt x |> A.s)
+  | DirectiveStmt x -> A.S (A.DirectiveStmt x |> A.s)
+  | OtherStmt (a,b) -> A.S (A.OtherStmt (a,b) |> A.s)
   | Parameter x -> A.Pa x
 
 

--- a/lang_GENERIC/analyze/controlflow_build.ml
+++ b/lang_GENERIC/analyze/controlflow_build.ml
@@ -131,7 +131,7 @@ let rec (cfg_stmt: state -> F.nodei option -> stmt -> F.nodei option) =
 
   let i () = info_opt (S stmt) in
 
-  match stmt with
+  match stmt.s with
   | Label _ | Goto _ -> raise Todo
 
   | Block (_, stmts, _) ->
@@ -144,7 +144,7 @@ let rec (cfg_stmt: state -> F.nodei option -> stmt -> F.nodei option) =
        *                 |-> newfakelse
       *)
       let node, stmt =
-        (match stmt with
+        (match stmt.s with
          | While (_, e, stmt) ->
              F.WhileHeader e, stmt
          | For (_, forheader, stmt) ->
@@ -354,7 +354,7 @@ let rec (cfg_stmt: state -> F.nodei option -> stmt -> F.nodei option) =
   | Continue (_, _TODOlabelid, _) | Break (_, _TODOlabelid, _) ->
 
       let is_continue, node =
-        match stmt with
+        match stmt.s with
         | Continue _ -> true,  F.Continue
         | Break _    -> false, F.Break
         | _ -> raise Impossible

--- a/lang_GENERIC_base/Highlight_AST.ml
+++ b/lang_GENERIC_base/Highlight_AST.ml
@@ -159,7 +159,7 @@ let visit_program
                       )
                   | AndType (_, xs, _) ->
                       xs |> List.iter (function
-                        | FieldStmt (DefStmt ({ name = EId (id, _); _}, _))->
+                        | FieldStmt ({s=DefStmt({name=EId (id, _); _}, _);_})->
                             tag_id id (Entity (Field, (Def2 fake_no_def2)));
                         | _ ->  ()
                       );
@@ -268,7 +268,7 @@ let visit_program
 *)
 
       V.kstmt = (fun (k, _) x ->
-        match x with
+        match x.s with
         | Try (_try_tok, _e (*, tok_with*), _match_cases, _finally) ->
             (*tag tok_with (KeywordExn); *)
             (*k (Try (try_tok, e, tok_with, []));*)
@@ -361,7 +361,7 @@ let visit_program
         | Record (_, xs, _) ->
             xs |> List.iter (fun x ->
               match x with
-              | FieldStmt (DefStmt ({ name = EId (id, _idinfo); _}, _)) ->
+              | FieldStmt ({s=DefStmt ({ name = EId (id, _idinfo); _}, _);_})->
                   tag_id id (Entity (Field, (Use2 fake_no_use2)));
               | _ -> ()
             );

--- a/lang_GENERIC_base/Map_AST.ml
+++ b/lang_GENERIC_base/Map_AST.ml
@@ -400,87 +400,91 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
   and map_other_attribute_operator x  = x
 
   and map_stmt x =
-    let k x = match x with
-      | DisjStmt (v1, v2) -> let v1 = map_stmt v1 in let v2 = map_stmt v2 in
-          DisjStmt (v1, v2)
-      | ExprStmt (v1, t) ->
-          let v1 = map_expr v1 in
-          let t = map_tok t in
-          ExprStmt (v1, t)
-      | DefStmt v1 -> let v1 = map_definition v1 in DefStmt v1
-      | DirectiveStmt v1 -> let v1 = map_directive v1 in DirectiveStmt v1
-      | Block v1 -> let v1 = map_bracket (map_of_list map_stmt) v1 in Block v1
-      | If (t, v1, v2, v3) ->
-          let t = map_tok t in
-          let v1 = map_expr v1
-          and v2 = map_stmt v2
-          and v3 = map_of_option map_stmt v3
-          in If (t, v1, v2, v3)
-      | While (t, v1, v2) ->
-          let t = map_tok t in
-          let v1 = map_expr v1 and v2 = map_stmt v2 in While (t, v1, v2)
-      | DoWhile (t, v1, v2) ->
-          let t = map_tok t in
-          let v1 = map_stmt v1 and v2 = map_expr v2 in DoWhile (t, v1, v2)
-      | For (t, v1, v2) ->
-          let t = map_tok t in
-          let v1 = map_for_header v1 and v2 = map_stmt v2 in For (t, v1, v2)
-      | Switch (v0, v1, v2) ->
-          let v0 = map_tok v0 in
-          let v1 = map_of_option map_expr v1
-          and v2 = map_of_list map_case_and_body v2
-          in Switch (v0, v1, v2)
-      | Return (t, v1, sc) ->
-          let t = map_tok t in
-          let v1 = map_of_option map_expr v1 in
-          let sc = map_tok sc in
-          Return (t, v1, sc)
-      | Continue (t, v1, sc) ->
-          let t = map_tok t in
-          let v1 = map_label_ident v1 in
-          let sc = map_tok sc in
-          Continue (t, v1, sc)
-      | Break (t, v1, sc) ->
-          let t = map_tok t in
-          let v1 = map_label_ident v1 in
-          let sc = map_tok sc in
-          Break (t, v1, sc)
-      | Label (v1, v2) ->
-          let v1 = map_label v1 and v2 = map_stmt v2 in Label (v1, v2)
-      | Goto (t, v1) ->
-          let t = map_tok t in
-          let v1 = map_label v1 in Goto (t, v1)
-      | Throw (t, v1, sc) ->
-          let t = map_tok t in
-          let v1 = map_expr v1 in
-          let sc = map_tok sc in
-          Throw (t, v1, sc)
-      | Try (t, v1, v2, v3) ->
-          let t = map_tok t in
-          let v1 = map_stmt v1
-          and v2 = map_of_list map_catch v2
-          and v3 = map_of_option map_finally v3
-          in Try (t, v1, v2, v3)
-      | WithUsingResource (t, v1, v2) ->
-          let t = map_tok t in
-          let v1 = map_stmt v1 in
-          let v2 = map_stmt v2 in
-          WithUsingResource ((t, v1, v2))
-      | Assert (t, v1, v2, sc) ->
-          let t = map_tok t in
-          let v1 = map_expr v1 in
-          let v2 = map_of_option map_expr v2 in
-          let sc = map_tok sc in
-          Assert (t, v1, v2, sc)
-      | OtherStmtWithStmt (v1, v2, v3) ->
-          let v1 = map_other_stmt_with_stmt_operator v1
-          and v2 = map_of_option map_expr v2
-          and v3 = map_stmt v3
-          in OtherStmtWithStmt (v1, v2, v3)
-      | OtherStmt (v1, v2) ->
-          let v1 = map_other_stmt_operator v1
-          and v2 = map_of_list map_any v2
-          in OtherStmt (v1, v2)
+    let k x =
+      let skind =
+        match x.s with
+        | DisjStmt (v1, v2) -> let v1 = map_stmt v1 in let v2 = map_stmt v2 in
+            DisjStmt (v1, v2)
+        | ExprStmt (v1, t) ->
+            let v1 = map_expr v1 in
+            let t = map_tok t in
+            ExprStmt (v1, t)
+        | DefStmt v1 -> let v1 = map_definition v1 in DefStmt v1
+        | DirectiveStmt v1 -> let v1 = map_directive v1 in DirectiveStmt v1
+        | Block v1 -> let v1 = map_bracket (map_of_list map_stmt) v1 in Block v1
+        | If (t, v1, v2, v3) ->
+            let t = map_tok t in
+            let v1 = map_expr v1
+            and v2 = map_stmt v2
+            and v3 = map_of_option map_stmt v3
+            in If (t, v1, v2, v3)
+        | While (t, v1, v2) ->
+            let t = map_tok t in
+            let v1 = map_expr v1 and v2 = map_stmt v2 in While (t, v1, v2)
+        | DoWhile (t, v1, v2) ->
+            let t = map_tok t in
+            let v1 = map_stmt v1 and v2 = map_expr v2 in DoWhile (t, v1, v2)
+        | For (t, v1, v2) ->
+            let t = map_tok t in
+            let v1 = map_for_header v1 and v2 = map_stmt v2 in For (t, v1, v2)
+        | Switch (v0, v1, v2) ->
+            let v0 = map_tok v0 in
+            let v1 = map_of_option map_expr v1
+            and v2 = map_of_list map_case_and_body v2
+            in Switch (v0, v1, v2)
+        | Return (t, v1, sc) ->
+            let t = map_tok t in
+            let v1 = map_of_option map_expr v1 in
+            let sc = map_tok sc in
+            Return (t, v1, sc)
+        | Continue (t, v1, sc) ->
+            let t = map_tok t in
+            let v1 = map_label_ident v1 in
+            let sc = map_tok sc in
+            Continue (t, v1, sc)
+        | Break (t, v1, sc) ->
+            let t = map_tok t in
+            let v1 = map_label_ident v1 in
+            let sc = map_tok sc in
+            Break (t, v1, sc)
+        | Label (v1, v2) ->
+            let v1 = map_label v1 and v2 = map_stmt v2 in Label (v1, v2)
+        | Goto (t, v1) ->
+            let t = map_tok t in
+            let v1 = map_label v1 in Goto (t, v1)
+        | Throw (t, v1, sc) ->
+            let t = map_tok t in
+            let v1 = map_expr v1 in
+            let sc = map_tok sc in
+            Throw (t, v1, sc)
+        | Try (t, v1, v2, v3) ->
+            let t = map_tok t in
+            let v1 = map_stmt v1
+            and v2 = map_of_list map_catch v2
+            and v3 = map_of_option map_finally v3
+            in Try (t, v1, v2, v3)
+        | WithUsingResource (t, v1, v2) ->
+            let t = map_tok t in
+            let v1 = map_stmt v1 in
+            let v2 = map_stmt v2 in
+            WithUsingResource ((t, v1, v2))
+        | Assert (t, v1, v2, sc) ->
+            let t = map_tok t in
+            let v1 = map_expr v1 in
+            let v2 = map_of_option map_expr v2 in
+            let sc = map_tok sc in
+            Assert (t, v1, v2, sc)
+        | OtherStmtWithStmt (v1, v2, v3) ->
+            let v1 = map_other_stmt_with_stmt_operator v1
+            and v2 = map_of_option map_expr v2
+            and v3 = map_stmt v3
+            in OtherStmtWithStmt (v1, v2, v3)
+        | OtherStmt (v1, v2) ->
+            let v1 = map_other_stmt_operator v1
+            and v2 = map_of_list map_any v2
+            in OtherStmt (v1, v2)
+      in
+      { x with s = skind }
     in
     vin.kstmt (k, all_functions) x
 

--- a/lang_GENERIC_base/Meta_AST.ml
+++ b/lang_GENERIC_base/Meta_AST.ml
@@ -557,8 +557,9 @@ and vof_other_attribute_operator =
   | OA_AnnotThrow -> OCaml.VSum ("OA_AnnotThrow", [])
   | OA_Expr -> OCaml.VSum ("OA_Expr", [])
   | OA_Default -> OCaml.VSum ("OA_Default", [])
-and vof_stmt =
-  function
+and vof_stmt st =
+  (* todo: dump also the s_id? *)
+  match st.s with
   | DisjStmt (v1, v2) -> let v1 = vof_stmt v1 in let v2 = vof_stmt v2 in
       OCaml.VSum ("DisjStmt", [v1; v2])
   | ExprStmt (v1, t) ->

--- a/lang_GENERIC_base/Visitor_AST.ml
+++ b/lang_GENERIC_base/Visitor_AST.ml
@@ -414,7 +414,8 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
 
   and v_stmt x =
     let k x =
-      match x with
+      (* todo? visit the s_id too? *)
+      match x.s with
       | DisjStmt (v1, v2) -> let v1 = v_stmt v1 in let v2 = v_stmt v2 in ()
       | ExprStmt (v1, t) ->
           let v1 = v_expr v1 in

--- a/lang_c/analyze/c_to_generic.ml
+++ b/lang_c/analyze/c_to_generic.ml
@@ -249,45 +249,46 @@ and argument v =
 and const_expr v =
   expr v
 
-let rec stmt =
-  function
-  | DefStmt x -> definition x
-  | DirStmt x -> directive x
+let rec stmt st =
+  (match st with
+   | DefStmt x -> definition x
+   | DirStmt x -> directive x
 
-  | CaseStmt x -> case_stmt x
+   | CaseStmt x -> case_stmt x
 
-  | ExprSt (v1, t) -> let v1 = expr v1 in G.ExprStmt (v1, t)
-  | Block v1 -> let v1 = bracket (list stmt) v1 in G.Block v1
-  | If (t, v1, v2, v3) ->
-      let v1 = expr v1 and v2 = stmt v2 and v3 = option stmt v3 in
-      G.If (t, v1, v2, v3)
-  | Switch (v0, v1, v2) ->
-      let v0 = info v0 in
-      let v1 = expr v1
-      and v2 = list case v2 |> List.map (fun x -> G.CasesAndBody x)  in
-      G.Switch (v0, Some v1, v2)
-  | While (t, v1, v2) -> let v1 = expr v1 and v2 = stmt v2 in
-      G.While (t, v1, v2)
-  | DoWhile (t, v1, v2) -> let v1 = stmt v1 and v2 = expr v2 in
-      G.DoWhile (t, v1, v2)
-  | For (t, v1, v2, v3, v4) ->
-      let init = expr_or_vars v1
-      and v2 = option expr v2
-      and v3 = option expr v3
-      and v4 = stmt v4
-      in
-      let header = G.ForClassic (init, v2, v3) in
-      G.For (t, header, v4)
-  | Return (t, v1) -> let v1 = option expr v1 in G.Return (t, v1, G.sc)
-  | Continue t -> G.Continue (t, G.LNone, G.sc)
-  | Break t -> G.Break (t, G.LNone, G.sc)
-  | Label (v1, v2) -> let v1 = name v1 and v2 = stmt v2 in
-      G.Label (v1, v2)
-  | Goto (t, v1) -> let v1 = name v1 in G.Goto (t, v1)
-  | Vars v1 -> let v1 = list var_decl v1 in
-      G.stmt1 (v1 |> List.map (fun v -> G.DefStmt v))
-  | Asm v1 -> let v1 = list expr v1 in
-      G.OtherStmt (G.OS_Asm, v1 |> List.map (fun e -> G.E e))
+   | ExprSt (v1, t) -> let v1 = expr v1 in G.ExprStmt (v1, t)
+   | Block v1 -> let v1 = bracket (list stmt) v1 in G.Block v1
+   | If (t, v1, v2, v3) ->
+       let v1 = expr v1 and v2 = stmt v2 and v3 = option stmt v3 in
+       G.If (t, v1, v2, v3)
+   | Switch (v0, v1, v2) ->
+       let v0 = info v0 in
+       let v1 = expr v1
+       and v2 = list case v2 |> List.map (fun x -> G.CasesAndBody x)  in
+       G.Switch (v0, Some v1, v2)
+   | While (t, v1, v2) -> let v1 = expr v1 and v2 = stmt v2 in
+       G.While (t, v1, v2)
+   | DoWhile (t, v1, v2) -> let v1 = stmt v1 and v2 = expr v2 in
+       G.DoWhile (t, v1, v2)
+   | For (t, v1, v2, v3, v4) ->
+       let init = expr_or_vars v1
+       and v2 = option expr v2
+       and v3 = option expr v3
+       and v4 = stmt v4
+       in
+       let header = G.ForClassic (init, v2, v3) in
+       G.For (t, header, v4)
+   | Return (t, v1) -> let v1 = option expr v1 in G.Return (t, v1, G.sc)
+   | Continue t -> G.Continue (t, G.LNone, G.sc)
+   | Break t -> G.Break (t, G.LNone, G.sc)
+   | Label (v1, v2) -> let v1 = name v1 and v2 = stmt v2 in
+       G.Label (v1, v2)
+   | Goto (t, v1) -> let v1 = name v1 in G.Goto (t, v1)
+   | Vars v1 -> let v1 = list var_decl v1 in
+       (G.stmt1 (v1 |> List.map (fun v -> G.s (G.DefStmt v)))).G.s
+   | Asm v1 -> let v1 = list expr v1 in
+       G.OtherStmt (G.OS_Asm, v1 |> List.map (fun e -> G.E e))
+  ) |> G.s
 
 and expr_or_vars v1 =
   match v1 with
@@ -348,7 +349,7 @@ and func_def {
   entity, G.FuncDef { G.
                       fparams = params;
                       frettype = Some ret;
-                      fbody = G.Block v3;
+                      fbody = G.s (G.Block v3);
                       fkind = G.Function, G.fake "";
                     }
 

--- a/lang_ml/analyze/ml_to_generic.ml
+++ b/lang_ml/analyze/ml_to_generic.ml
@@ -41,7 +41,6 @@ let error = G.error
 (* TODO: each use of this is usually the sign of a todo to improve
  * AST_generic.ml or ast_ml.ml *)
 let fake = G.fake
-let s = G.s
 
 let add_attrs ent attrs =
   { ent with G.attrs = attrs }
@@ -192,13 +191,13 @@ and expr =
       let defs =
         v2 |> List.map (function
           | Left (ent, params, tret, expr) ->
-              s (G.DefStmt (ent, mk_var_or_func tlet params tret expr))
+              G.DefStmt (ent, mk_var_or_func tlet params tret expr) |> G.s
           | Right (pat, e) ->
               let exp = G.LetPattern (pat, e) in
               G.exprstmt exp
         )
       in
-      let st = s (G.Block (G.fake_bracket (defs @ [G.exprstmt v3]))) in
+      let st = G.Block (G.fake_bracket (defs @ [G.exprstmt v3])) |> G.s in
       G.OtherExpr (G.OE_StmtExpr, [G.S st])
   | Fun (t, v1, v2) ->
       let v1 = list parameter v1
@@ -232,12 +231,12 @@ and expr =
       let catches = v2 |> List.map (fun (pat, e) ->
         fake "catch", pat, G.exprstmt e
       ) in
-      let st = s (G.Try (t, G.exprstmt v1, catches, None)) in
+      let st = G.Try (t, G.exprstmt v1, catches, None) |> G.s in
       G.OtherExpr (G.OE_StmtExpr, [G.S st])
 
   | While (t, v1, v2) ->
       let v1 = expr v1 and v2 = expr v2 in
-      let st = G.s (G.While (t, v1, G.exprstmt v2)) in
+      let st = G.While (t, v1, G.exprstmt v2) |> G.s in
       G.OtherExpr (G.OE_StmtExpr, [G.S st])
 
   | For (t, v1, v2, v3, v4, v5) ->
@@ -255,7 +254,7 @@ and expr =
                          G.fake_bracket [G.Arg n; G.Arg v4]) in
       let header = G.ForClassic ([G.ForInitVar (ent, var)],
                                  Some cond, Some next) in
-      let st = G.s (G.For (t, header, G.exprstmt v5)) in
+      let st = G.For (t, header, G.exprstmt v5) |> G.s in
       G.OtherExpr (G.OE_StmtExpr, [G.S st])
 
   | ExprTodo (t, xs) ->
@@ -420,8 +419,8 @@ and type_def_kind =
                           (match v3 with
                            | Some tok -> [G.attr G.Mutable tok]
                            | None -> []) in
-                      G.FieldStmt (G.s (G.DefStmt
-                                          (ent, G.FieldDefColon { G.vinit = None; vtype = Some v2 })))
+                      G.FieldStmt (G.DefStmt
+                                     (ent, G.FieldDefColon { G.vinit = None; vtype = Some v2 }) |> G.s )
                    ))
           v1
       in G.AndType v1


### PR DESCRIPTION
This will allow us to store more information at each stmt node,
e.g., an id, a set of metavariable, whatever helps to improve
the performance of stmts matching in semgrep.

test plan:
make
make test