### PR TITLE
WIP analyze: dataflow: Constness analysis

### DIFF
--- a/lang_GENERIC/analyze/AST_to_IL.ml
+++ b/lang_GENERIC/analyze/AST_to_IL.ml
@@ -138,7 +138,7 @@ let lval_of_id_info _env id id_info =
         -1
   in
   let var = id, sid in
-  { base = Var var; offset = NoOffset; constness = id_info.id_const_literal; }
+  { base = Var var; offset = NoOffset; constness = id_info.id_constness; }
 (*e: function [[AST_to_IL.lval_of_id_info]] *)
 
 let lval_of_id_qualified env name id_info =
@@ -210,7 +210,7 @@ let rec lval env eorig =
       let base, base_constness = nested_lval env tok e1orig in
       (match field with
        | G.EId (id, idinfo) ->
-           { base; offset = Dot id; constness = idinfo.id_const_literal; }
+           { base; offset = Dot id; constness = idinfo.id_constness; }
        | G.EName gname ->
            let attr = expr env (H.id_of_name gname) in
            { base; offset = Index attr; constness = base_constness; }

--- a/lang_GENERIC/analyze/Constant_propagation.ml
+++ b/lang_GENERIC/analyze/Constant_propagation.ml
@@ -17,6 +17,9 @@ open AST_generic
 module H = AST_generic_helpers
 module V = Visitor_AST
 
+(* TODO: Check that all functionality provided by this module is a subset of
+   what Dataflow_constness provides; if so, then we could retire this one. *)
+
 (*****************************************************************************)
 (* Prelude *)
 (*****************************************************************************)

--- a/lang_GENERIC/analyze/Constant_propagation.ml
+++ b/lang_GENERIC/analyze/Constant_propagation.ml
@@ -276,7 +276,7 @@ let propagate2 lang prog =
                H.has_keyword_attr Final attrs
                (* TODO later? (!(stats.rvalue) = 1) *)
             then begin
-              id_info.id_const_literal := Some literal;
+              id_info.id_constness := Some (Lit literal);
               add_constant_env id (sid, literal) env;
             end;
             k x
@@ -292,14 +292,14 @@ let propagate2 lang prog =
          | Id (id, id_info)->
              (match find_id env id id_info with
               | Some literal ->
-                  id_info.id_const_literal := Some literal
+                  id_info.id_constness := Some (Lit literal)
               | _ -> ()
              );
 
          | DotAccess (IdSpecial (This, _), _, EId (id, id_info)) ->
              (match find_id env id id_info with
               | Some literal ->
-                  id_info.id_const_literal := Some literal
+                  id_info.id_constness := Some (Lit literal)
               | _ -> ()
              );
 
@@ -321,7 +321,7 @@ let propagate2 lang prog =
                      (lang = Lang.Python || lang = Lang.Ruby) &&
                      kind = Global
                   then begin
-                    id_info.id_const_literal := Some literal;
+                    id_info.id_constness := Some (Lit literal);
                     add_constant_env id (sid, literal) env;
                   end;
                   k x

--- a/lang_GENERIC/analyze/Dataflow_constness.ml
+++ b/lang_GENERIC/analyze/Dataflow_constness.ml
@@ -1,0 +1,317 @@
+(* Iago Abal
+ *
+ * Copyright (C) 2020 r2c
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file license.txt.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * license.txt for more details.
+*)
+open Common
+open IL
+
+module G = AST_generic
+module F = IL
+module D = Dataflow
+module VarMap = Dataflow.VarMap
+
+(*****************************************************************************)
+(* Types *)
+(*****************************************************************************)
+
+(* The type of an unknown constant. *)
+type ctype =
+  | Cbool
+  | Cint
+  | Cstr
+  | Cany
+
+type constness = Lit of AST_generic.literal | Cst of ctype | Dyn
+
+(* map for each node/var whether a variable is constant *)
+type mapping = constness Dataflow.mapping
+
+module DataflowX = Dataflow.Make (struct
+    type node = F.node
+    type edge = F.edge
+    type flow = (node, edge) Ograph_extended.ograph_mutable
+    let short_string_of_node n =
+      Display_IL.short_string_of_node_kind n.F.n
+  end)
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+let string_of_ctype = function
+  | Cbool -> "bool"
+  | Cint  -> "int"
+  | Cstr  -> "str"
+  | Cany  -> "???"
+
+let string_of_constness = function
+  | Dyn   -> "dyn"
+  | Cst t -> Printf.sprintf "cst(%s)" (string_of_ctype t)
+  | Lit l ->
+      match l with
+      | G.Bool (b, _)   -> Printf.sprintf "lit(%b)" b
+      | G.Int (s, _)    -> Printf.sprintf "lit(%s)" s
+      | G.String (s, _) -> Printf.sprintf "lit(\"%s\")" s
+      | ___else___      -> "lit(???)"
+
+let str_of_name ((s, _tok), sid) =
+  spf "%s:%d" s sid
+
+(*****************************************************************************)
+(* Constness *)
+(*****************************************************************************)
+
+(* TODO: Use Lib_AST.abstract_position_info_any (G.E (G.Literal l1)) and =*=. *)
+let eq_literal l1 l2 =
+  match l1, l2 with
+  | G.Bool  (b1, _),  G.Bool  (b2, _)  -> b1 =:= b2
+  | G.Int   (s1, _),  G.Int   (s2, _)
+  | G.Float (s1, _),  G.Float (s2, _)
+  | G.Char  (s1, _),  G.Char   (s2, _)
+  | G.String (s1, _), G.String (s2, _) -> s1 =$= s2
+  (* add more cases if needed *)
+  | ___else___ -> false
+
+let eq_ctype t1 t2 = t1 = t2
+
+let ctype_of_literal = function
+  | G.Bool _   -> Cbool
+  | G.Int _    -> Cint
+  | G.String _ -> Cstr
+  | ___else___ -> Cany
+
+let eq c1 c2 =
+  match c1, c2 with
+  | Lit l1, Lit l2 -> eq_literal l1 l2
+  | Cst t1, Cst t2 -> eq_ctype t1 t2
+  | Dyn,    Dyn    -> true
+  | ___else___     -> false
+
+let union_ctype t1 t2 = if eq_ctype t1 t2 then t1 else Cany
+
+let union c1 c2 =
+  match c1, c2 with
+  | _ when eq c1 c2 -> c1
+  | _any,   Dyn
+  | Dyn,    _any    -> Dyn
+  | Lit l1, Lit l2  ->
+      let t1 = ctype_of_literal l1
+      and t2 = ctype_of_literal l2 in
+      Cst (union_ctype t1 t2)
+  | Lit l1, Cst t2
+  | Cst t2, Lit l1 ->
+      let t1 = ctype_of_literal l1 in
+      Cst (union_ctype t1 t2)
+  | Cst t1, Cst t2 ->
+      Cst (union_ctype t1 t2)
+(*
+let refine c1 c2 =
+  match c1, c2 with
+  | _ when eq c1 c2 -> c1
+  | c,   Dyn
+  | Dyn,    c    -> c
+  | Lit _, Lit _
+  | Lit _, Cst _
+  | Cst _, Cst _ -> c1
+  | Cst _, Lit _ -> c2
+
+let refine_constness c_ref c' =
+  match !c_ref with
+  | None -> c_ref := Some c'
+  | Some c -> c_ref := Some (refine c1 c2) *)
+
+(*****************************************************************************)
+(* Constness evaluation *)
+(*****************************************************************************)
+
+let literal_of_bool b =
+  let b_str = string_of_bool b in
+  (* TODO: use proper token when possible? *)
+  let tok   = Parse_info.fake_info b_str in
+  G.Bool(b, tok)
+
+let literal_of_int i =
+  let i_str = string_of_int i in
+  (* TODO: use proper token when possible? *)
+  let tok   = Parse_info.fake_info i_str in
+  G.Int(i_str, tok)
+
+let int_of_literal = function
+  | G.Int (str, _) -> int_of_string_opt str
+  | ___else___     -> None
+
+let literal_of_string s =
+  (* TODO: use proper token when possible? *)
+  let tok = Parse_info.fake_info s in
+  G.String(s, tok)
+
+let eval_unop_bool op b =
+  match op with
+  | G.Not -> Lit (literal_of_bool (not b))
+  | _else -> Cst Cbool
+
+let eval_binop_bool op b1 b2 =
+  match op with
+  | G.Or  -> Lit (literal_of_bool (b1 || b2))
+  | G.And -> Lit (literal_of_bool (b1 && b2))
+  | _else -> Cst Cbool
+
+let eval_unop_int op opt_i =
+  match op, opt_i with
+  | G.Plus,  Some i -> Lit (literal_of_int i)
+  | G.Minus, Some i -> Lit (literal_of_int (-i))
+  | ___else____     -> Cst Cint
+
+let eval_binop_int op opt_i1 opt_i2 =
+  match op, opt_i1, opt_i2 with
+  (* TODO: Handle overflows and division by zero. *)
+  | G.Plus,  Some i1, Some i2 -> Lit (literal_of_int (i1 + i2))
+  | G.Minus, Some i1, Some i2 -> Lit (literal_of_int (i1 - i2))
+  | G.Mult,  Some i1, Some i2 -> Lit (literal_of_int (i1 * i2))
+  | G.Div,   Some i1, Some i2 -> Lit (literal_of_int (i1 / i2))
+  | ___else____     -> Cst Cint
+
+let eval_binop_string op s1 s2 =
+  match op with
+  | G.Plus
+  | G.Concat -> Lit (literal_of_string (s1 ^ s2))
+  | __else__ -> Cst Cstr
+
+let rec eval (env :constness D.env) exp : constness =
+  match exp.e with
+  | Lvalue lval -> eval_lval env lval
+  | Literal li -> Lit li
+  | Operator (op, args) -> eval_op env op args
+  | Composite _
+  | Record _
+  | Cast _
+  | TodoExp _
+    -> Dyn
+
+and eval_lval env lval =
+  match lval with
+  | { base=Var x; offset=NoOffset; constness=_; } ->
+      let opt_c = D.VarMap.find_opt (str_of_name x) env in
+      opt_c ||| Dyn
+  | ___else___ ->
+      Dyn
+
+and eval_op env op args =
+  let cs = List.map (eval env) args in
+  match fst op, cs with
+  | G.Plus, [c1]             -> c1
+  | op,     [Lit (G.Bool (b, _))] -> eval_unop_bool op b
+  | op,     [Lit (G.Int _ as li)] -> eval_unop_int op (int_of_literal li)
+  | op,     [Lit (G.Bool (b1, _)); Lit (G.Bool (b2, _))] ->
+      eval_binop_bool op b1 b2
+  | op,     [Lit (G.Int _ as li1); Lit (G.Int _ as li2)] ->
+      eval_binop_int op (int_of_literal li1) (int_of_literal li2)
+  | op,     [Lit (G.String (s1, _)); Lit (G.String (s2, _))] ->
+      eval_binop_string op s1 s2
+  | _op,    [Cst _ as c1]    -> c1
+  | _op,    [Cst t1; Cst t2] -> Cst (union_ctype t1 t2)
+  | _op,    [Lit l1; Cst t2]
+  | _op,    [Cst t2; Lit l1] ->
+      let t1 = ctype_of_literal l1 in
+      Cst (union_ctype t1 t2)
+  | ___else___ -> Dyn
+
+(*****************************************************************************)
+(* Transfer *)
+(*****************************************************************************)
+
+let literal_of_ctype = function
+  (* TODO: This is just a hack so that Semgrep's "..." can match it. *)
+  | Cstr  -> Some (literal_of_string "...")
+  | _else -> None
+
+let literal_of_constness = function
+  | Lit l -> Some l
+  | Cst t -> literal_of_ctype t
+  | Dyn   -> None
+
+let union_env =
+  Dataflow.varmap_union union
+
+let (transfer: flow:F.cfg -> constness Dataflow.transfn) =
+  fun ~flow ->
+  (* the transfer function to update the mapping at node index ni *)
+  fun mapping ni ->
+
+  let in' =
+    (flow#predecessors ni)#fold (fun acc (ni_pred, _) ->
+      union_env acc mapping.(ni_pred).D.out_env
+    ) VarMap.empty
+  in
+  let node = flow#nodes#assoc ni in
+
+  (* Set the constness of variables in the RHS according to in'. *)
+  lvals_of_node node.n
+  |> List.iter (function
+    | {base = Var var; constness; _} ->
+        (match D.VarMap.find_opt (str_of_name var) in' with
+         | None   -> constness := None
+         | Some c -> constness := literal_of_constness c
+        )
+    | ___else___ -> ()
+  );
+
+  (* Compute output mapping. *)
+  let out' =
+    match node.F.n with
+    | Enter | Exit | TrueNode | FalseNode | Join
+    | NCond _ | NGoto _ | NReturn _ | NThrow _ | NOther _
+    | NTodo _
+      -> in'
+    | NInstr instr ->
+        match instr.i with
+        (* TODO: Handle base=Mem e case. *)
+        | Assign ({base=Var var; offset=NoOffset; constness;}, exp) ->
+            let cexp = eval in' exp in
+            constness := literal_of_constness cexp;
+            D.VarMap.add (str_of_name var) cexp in'
+        | ___else___ ->
+            let lvar_opt = IL.lvar_of_instr_opt instr in
+            match lvar_opt with
+            | None      -> in'
+            | Some lvar -> D.VarMap.add (str_of_name lvar) Dyn in'
+  in
+
+  {D. in_env = in'; out_env = out'}
+
+(*****************************************************************************)
+(* Entry points *)
+(*****************************************************************************)
+
+let (fixpoint: F.cfg -> mapping) = fun flow ->
+  DataflowX.fixpoint
+    ~eq
+    ~init:(DataflowX.new_node_array flow (Dataflow.empty_inout ()))
+    ~trans:(transfer ~flow)
+    (* constness is a forward analysis! *)
+    ~forward:true
+    ~flow
+
+let propagate_constants ast =
+  (* TODO: Handle constants defined in higher scopes. *)
+  let module V = Visitor_AST in
+  let v = V.mk_visitor
+      { V.default_visitor with
+        V.kfunction_definition = (fun (_k, _) def ->
+          let xs = AST_to_IL.stmt def.G.fbody in
+          let flow = CFG_build.cfg_of_stmts xs in
+          let mapping = fixpoint flow in
+          ignore(mapping)
+        );
+      } in
+  v (G.Pr ast)

--- a/lang_GENERIC/analyze/Dataflow_constness.mli
+++ b/lang_GENERIC/analyze/Dataflow_constness.mli
@@ -1,18 +1,7 @@
 
-type ctype =
-  | Cbool
-  | Cint
-  | Cstr
-  | Cany
+type mapping = AST_generic.constness Dataflow.mapping
 
-type constness =
-  | Lit of AST_generic.literal
-  | Cst of ctype
-  | Dyn
-
-type mapping = constness Dataflow.mapping
-
-val string_of_constness : constness -> string
+val string_of_constness : AST_generic.constness -> string
 
 val fixpoint : IL.cfg -> mapping
 

--- a/lang_GENERIC/analyze/Dataflow_constness.mli
+++ b/lang_GENERIC/analyze/Dataflow_constness.mli
@@ -1,0 +1,26 @@
+
+type ctype =
+  | Cbool
+  | Cint
+  | Cstr
+  | Cany
+
+type constness =
+  | Lit of AST_generic.literal
+  | Cst of ctype
+  | Dyn
+
+type mapping = constness Dataflow.mapping
+
+val string_of_constness : constness -> string
+
+val fixpoint : IL.cfg -> mapping
+
+(** Flow-sensitive constant-propagation.
+ * Refines (does not simply overwrite) constness info, that is, it
+ * respects previous constant propagation analyses.
+ * Works by side effect on the generic AST by modifying its refs.
+ *
+ * !Note that this assumes Naming_AST.resolve has been called before!
+*)
+val propagate_constants : AST_generic.program -> unit

--- a/lang_GENERIC/analyze/Dataflow_constness.mli
+++ b/lang_GENERIC/analyze/Dataflow_constness.mli
@@ -3,13 +3,17 @@ type mapping = AST_generic.constness Dataflow.mapping
 
 val string_of_constness : AST_generic.constness -> string
 
-val fixpoint : IL.cfg -> mapping
-
 (** Flow-sensitive constant-propagation.
- * Refines (does not simply overwrite) constness info, that is, it
- * respects previous constant propagation analyses.
- * Works by side effect on the generic AST by modifying its refs.
+ *
+ * Returns a mapping, but it also updates the [IL.lval.constness] refs
+ * accordingly. The constness refs in IL are shared with the Generic AST,
+ * so running this analysis also updates constness info in the Generic AST.
+ * When updating the AST, it respects previous constant propagation passes,
+ * updating constness info when it can deduce more specific facts, but
+ * leaves it untouched otherwise.
  *
  * !Note that this assumes Naming_AST.resolve has been called before!
 *)
-val propagate_constants : AST_generic.program -> unit
+val fixpoint : IL.cfg -> mapping
+
+val update_constness : IL.cfg -> mapping -> unit

--- a/lang_GENERIC/analyze/IL.ml
+++ b/lang_GENERIC/analyze/IL.ml
@@ -127,7 +127,7 @@ type name = ident * G.sid
 type lval = {
   base: base;
   offset: offset;
-  constness: G.literal option ref; (* TODO: constness ref *)
+  constness: G.constness option ref; (* TODO: constness ref *)
   (* todo: ltype: typ; *)
 }
 (*e: type [[IL.lval]] *)

--- a/lang_GENERIC_base/AST_generic.ml
+++ b/lang_GENERIC_base/AST_generic.ml
@@ -319,7 +319,7 @@ and id_info = {
   (* sgrep: this is for sgrep constant propagation hack.
    * todo? associate only with Id?
   *)
-  id_const_literal: literal option ref;
+  id_constness: constness    option ref;
 }
 (*e: type [[AST_generic.id_info]] *)
 
@@ -483,6 +483,15 @@ and literal =
   | Imag of string wrap (* Go, Python *) | Ratio of string wrap (* Ruby *)
   | Atom of string wrap (* Ruby *)
 (*e: type [[AST_generic.literal]] *)
+
+(* The type of an unknown constant. *)
+and const_type =
+  | Cbool
+  | Cint
+  | Cstr
+  | Cany
+
+and constness = Lit of literal | Cst of const_type | NotCst
 
 (*s: type [[AST_generic.container_operator]] *)
 and container_operator =
@@ -846,7 +855,7 @@ and for_header =
   | ForEllipsis of tok (* ... *)
   (* Lua *)
   | ForIn of for_var_or_expr list (* init *) *
-               expr list (* pattern 'in' expr *)
+             expr list (* pattern 'in' expr *)
 (*e: type [[AST_generic.for_header]] *)
 
 (*s: type [[AST_generic.for_var_or_expr]] *)
@@ -1069,7 +1078,7 @@ and keyword_attribute =
   | Ctor | Dtor
   | Getter | Setter
   | LocalDef (* Lua *)
-  (*e: type [[AST_generic.keyword_attribute]] *)
+(*e: type [[AST_generic.keyword_attribute]] *)
 
 (*s: type [[AST_generic.other_attribute_operator]] *)
 and other_attribute_operator =
@@ -1614,14 +1623,14 @@ let empty_var =
 (*s: function [[AST_generic.empty_id_info]] *)
 let empty_id_info () =
   { id_resolved = ref None; id_type = ref None;
-    id_const_literal = ref None;
+    id_constness = ref None;
   }
 (*e: function [[AST_generic.empty_id_info]] *)
 
 (*s: function [[AST_generic.basic_id_info]] *)
 let basic_id_info resolved =
   { id_resolved = ref (Some resolved); id_type = ref None;
-    id_const_literal = ref None;
+    id_constness = ref None;
   }
 (*e: function [[AST_generic.basic_id_info]] *)
 

--- a/lang_GENERIC_base/Map_AST.ml
+++ b/lang_GENERIC_base/Map_AST.ml
@@ -116,14 +116,14 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     let v_name_qualifier = map_of_option map_qualifier v_name_qualifier
     in { name_qualifier = v_name_qualifier; name_typeargs = v_name_typeargs  }
   and map_id_info { id_resolved = v_id_resolved; id_type = v_id_type;
-                    id_const_literal = v3
+                    id_constness = v3
                   } =
-    let v3 = map_of_ref (map_of_option map_literal) v3 in
+    let v3 = map_of_ref (map_of_option map_constness) v3 in
     let v_id_type = map_of_ref (map_of_option map_type_) v_id_type in
     let v_id_resolved =
       map_of_ref (map_of_option map_resolved_name) v_id_resolved
     in { id_resolved = v_id_resolved; id_type = v_id_type;
-         id_const_literal = v3
+         id_constness = v3
        }
 
 
@@ -271,6 +271,19 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | Regexp v1 -> let v1 = map_wrap map_of_string v1 in Regexp v1
     | Null v1 -> let v1 = map_tok v1 in Null v1
     | Undefined v1 -> let v1 = map_tok v1 in Undefined v1
+
+  and map_const_type =
+    function
+    | Cbool -> Cbool
+    | Cint  -> Cint
+    | Cstr  -> Cstr
+    | Cany  -> Cany
+
+  and map_constness =
+    function
+    | Lit v1 -> let v1 = map_literal v1 in Lit v1
+    | Cst v1 -> let v1 = map_const_type v1 in Cst v1
+    | NotCst -> NotCst
 
   and map_container_operator =
     function | Array -> Array | List -> List | Set -> Set | Dict -> Dict

--- a/lang_GENERIC_base/Meta_AST.ml
+++ b/lang_GENERIC_base/Meta_AST.ml
@@ -77,11 +77,11 @@ and
   let bnd = ("name_qualifier", arg) in
   let bnds = bnd :: bnds in OCaml.VDict bnds
 and vof_id_info { id_resolved = v_id_resolved; id_type = v_id_type;
-                  id_const_literal = v3;
+                  id_constness = v3;
                 } =
   let bnds = [] in
-  let arg = OCaml.vof_ref (OCaml.vof_option vof_literal) v3 in
-  let bnd = ("id_const_literal", arg) in
+  let arg = OCaml.vof_ref (OCaml.vof_option vof_constness) v3 in
+  let bnd = ("id_constness", arg) in
   let bnds = bnd :: bnds in
   let arg = OCaml.vof_ref (OCaml.vof_option vof_type_) v_id_type in
   let bnd = ("id_type", arg) in
@@ -281,6 +281,17 @@ and vof_literal =
       in OCaml.VSum ("Regexp", [ v1 ])
   | Null v1 -> let v1 = vof_tok v1 in OCaml.VSum ("Null", [ v1 ])
   | Undefined v1 -> let v1 = vof_tok v1 in OCaml.VSum ("Undefined", [ v1 ])
+and vof_const_type =
+  function
+  | Cbool -> OCaml.VSum ("Cbool", [])
+  | Cint  -> OCaml.VSum ("Cint",  [])
+  | Cstr  -> OCaml.VSum ("Cstr",  [])
+  | Cany  -> OCaml.VSum ("Cany",  [])
+and vof_constness =
+  function
+  | Lit v1 -> let v1 = vof_literal v1 in OCaml.VSum ("Lit", [ v1 ])
+  | Cst v1 -> let v1 = vof_const_type v1 in OCaml.VSum ("Cst", [ v1 ])
+  | NotCst -> OCaml.VSum ("NotCst", [])
 and vof_container_operator =
   function
   | Array -> OCaml.VSum ("Array", [])

--- a/lang_GENERIC_base/Visitor_AST.ml
+++ b/lang_GENERIC_base/Visitor_AST.ml
@@ -167,7 +167,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
 
   and v_id_info
       { id_resolved = v_id_resolved; id_type = v_id_type;
-        id_const_literal = _IGNORED;
+        id_constness = _IGNORED;
       } =
     let arg = v_ref_do_not_visit (v_option v_resolved_name) v_id_resolved in
     let arg = v_ref_do_not_visit (v_option v_type_) v_id_type in ()


### PR DESCRIPTION
Needs more work and some testing, but I appreciate if you can take a quick look and give me some feedback already.

Given this input:

```python
def foo(x):
    a = 1
    b = 2
    c = a + b
    if x > 0:
        d = 2*c
    else:
        d = c+1
    return d
```

You get (`-dfg_constness`):

```
Constness
 0 <-        :         <enter> IN=                  OUT =                
 1 <-      11:          <exit> IN= a:2:lit(1) b:3:lit(2) c:4:lit(3) d:5:cst(int)   OUT = a:2:lit(1) b:3:lit(2) c:4:lit(3) d:5:cst(int) 
 2 <-       0:         a = ... IN=                  OUT =     a:2:lit(1) 
 3 <-       2:         b = ... IN=     a:2:lit(1)   OUT = a:2:lit(1) b:3:lit(2) 
 4 <-       3:         c = ... IN= a:2:lit(1) b:3:lit(2)   OUT = a:2:lit(1) b:3:lit(2) c:4:lit(3) 
 5 <-       4:       cond(...) IN= a:2:lit(1) b:3:lit(2) c:4:lit(3)   OUT = a:2:lit(1) b:3:lit(2) c:4:lit(3) 
 6 <-       5:     <TRUE path> IN= a:2:lit(1) b:3:lit(2) c:4:lit(3)   OUT = a:2:lit(1) b:3:lit(2) c:4:lit(3) 
 7 <-       5:    <FALSE path> IN= a:2:lit(1) b:3:lit(2) c:4:lit(3)   OUT = a:2:lit(1) b:3:lit(2) c:4:lit(3) 
 8 <-       6:         d = ... IN= a:2:lit(1) b:3:lit(2) c:4:lit(3)   OUT = a:2:lit(1) b:3:lit(2) c:4:lit(3) d:5:lit(6) 
 9 <-       7:         d = ... IN= a:2:lit(1) b:3:lit(2) c:4:lit(3)   OUT = a:2:lit(1) b:3:lit(2) c:4:lit(3) d:5:lit(4) 
10 <-     8,9:          <join> IN= a:2:lit(1) b:3:lit(2) c:4:lit(3) d:5:cst(int)   OUT = a:2:lit(1) b:3:lit(2) c:4:lit(3) d:5:cst(int) 
11 <-      10:     return ...; IN= a:2:lit(1) b:3:lit(2) c:4:lit(3) d:5:cst(int)   OUT = a:2:lit(1) b:3:lit(2) c:4:lit(3) d:5:cst(int)
```
