### PR TITLE
Use deriving eq to automatically generate equal_xxx functions for generic AST

### DIFF
--- a/lang_GENERIC/analyze/Dataflow_constness.ml
+++ b/lang_GENERIC/analyze/Dataflow_constness.ml
@@ -62,7 +62,7 @@ let str_of_name ((s, _tok), sid) =
 (* Constness *)
 (*****************************************************************************)
 
-(* TODO: Use Lib_AST.abstract_position_info_any (G.E (G.Literal l1)) and =*=. *)
+(* TODO: use the new AST_generic.eq_xxx functions from deriving eq *)
 let eq_literal l1 l2 =
   match l1, l2 with
   | G.Bool  (b1, _),  G.Bool  (b2, _)  -> b1 =:= b2

--- a/lang_GENERIC_base/Lib_AST.ml
+++ b/lang_GENERIC_base/Lib_AST.ml
@@ -44,6 +44,10 @@ let ii_of_any any =
 (*****************************************************************************)
 (* Abstract position *)
 (*****************************************************************************)
+(* update: you should now use AST_generic.equal_any which internally
+ * does not care about position information.
+*)
+
 (*s: function [[Lib_AST.abstract_position_visitor]] *)
 let abstract_position_visitor recursor =
   let hooks = { M.default_visitor with

--- a/lang_GENERIC_base/dune
+++ b/lang_GENERIC_base/dune
@@ -6,5 +6,5 @@
    commons
    pfff-h_program-lang
  )
- (preprocess (pps ppx_deriving.show))
+ (preprocess (pps ppx_deriving.show ppx_deriving.eq))
 )


### PR DESCRIPTION
The use of Lib_AST.abstract_info_xxx is a bit ugly and potentially also
slower than using deriving eq with some well placed adhoc equal functions
(e.g., equal_tok to abstract away information position).
This also abstract away the constness that we need when we will plug
Iago's dataflow-based constness analysis.

test plan:
make test