### PR TITLE
Adding id_info in alias in import directives

### DIFF
--- a/lang_GENERIC_base/AST_generic.ml
+++ b/lang_GENERIC_base/AST_generic.ml
@@ -1491,7 +1491,8 @@ and directive =
 (*e: type [[AST_generic.directive]] *)
 
 (*s: type [[AST_generic.alias]] *)
-and alias = ident (* as name *)
+(* ... as name *)
+and alias = ident * id_info
 (*e: type [[AST_generic.alias]] *)
 
 (*s: type [[AST_generic.other_directive_operator]] *)

--- a/lang_GENERIC_base/Map_AST.ml
+++ b/lang_GENERIC_base/Map_AST.ml
@@ -840,7 +840,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | ImportAs (t, v1, v2) ->
         let t = map_tok t in
         let v1 = map_module_name v1
-        and v2 = map_of_option map_ident v2
+        and v2 = map_of_option map_ident_and_id_info v2
         in ImportAs (t, v1, v2)
     | ImportAll (t, v1, v2) ->
         let t = map_tok t in
@@ -863,8 +863,13 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
         let t = map_tok t in
         PackageEnd t
 
+  and map_ident_and_id_info (v1, v2) =
+    let v1 = map_ident v1 in
+    let v2 = map_id_info v2 in
+    (v1, v2)
+
   and map_alias (v1, v2) =
-    let v1 = map_ident v1 and v2 = map_of_option map_ident v2 in (v1, v2)
+    let v1 = map_ident v1 and v2 = map_of_option map_ident_and_id_info v2 in (v1, v2)
 
   and map_other_directive_operator x = x
 

--- a/lang_GENERIC_base/Meta_AST.ml
+++ b/lang_GENERIC_base/Meta_AST.ml
@@ -1103,6 +1103,10 @@ and vof_class_kind_bis =
   | Interface -> OCaml.VSum ("Interface", [])
   | Trait -> OCaml.VSum ("Trait", [])
   | AtInterface -> OCaml.VSum ("AtInterface", [])
+and vof_ident_and_id_info (v1, v2) =
+  let v1 = vof_ident v1 in
+  let v2 = vof_id_info v2 in
+  OCaml.VTuple [v1; v2]
 and vof_directive =
   function
   | ImportFrom (t, v1, v2, v3) ->
@@ -1113,7 +1117,7 @@ and vof_directive =
   | ImportAs (t, v1, v2) ->
       let t = vof_tok t in
       let v1 = vof_module_name v1
-      and v2 = OCaml.vof_option vof_ident v2
+      and v2 = OCaml.vof_option vof_ident_and_id_info v2
       in OCaml.VSum ("ImportAs", [ t; v1; v2 ])
   | ImportAll (t, v1, v2) ->
       let t = vof_tok t in
@@ -1137,7 +1141,7 @@ and vof_directive =
       in OCaml.VSum ("OtherDirective", [ v1; v2 ])
 and vof_alias (v1, v2) =
   let v1 = vof_ident v1
-  and v2 = OCaml.vof_option vof_ident v2
+  and v2 = OCaml.vof_option vof_ident_and_id_info v2
   in v1, v2
 and vof_other_directive_operator =
   function

--- a/lang_GENERIC_base/Naming_AST.ml
+++ b/lang_GENERIC_base/Naming_AST.ml
@@ -495,27 +495,30 @@ let resolve2 lang prog =
       (* sgrep: the import aliases *)
       V.kdir = (fun (k, _v) x ->
         (match x with
-         | ImportFrom (_, DottedName xs, id, Some alias) ->
+         | ImportFrom (_, DottedName xs, id, Some (alias, id_info)) ->
              (* for python *)
              let sid = H.gensym () in
              let resolved = untyped_ent (ImportedEntity (xs @ [id]), sid) in
+             set_resolved env id_info resolved;
              add_ident_imported_scope alias resolved env.names;
          | ImportFrom (_, DottedName xs, id, None) ->
              (* for python *)
              let sid = H.gensym () in
              let resolved = untyped_ent (ImportedEntity (xs @ [id]), sid) in
              add_ident_imported_scope id resolved env.names;
-         | ImportAs (_, DottedName xs, Some alias) ->
+         | ImportAs (_, DottedName xs, Some (alias, id_info)) ->
              (* for python *)
              let sid = H.gensym () in
              let resolved = untyped_ent (ImportedModule (DottedName xs), sid) in
+             set_resolved env id_info resolved;
              add_ident_imported_scope alias resolved env.names;
 
-         | ImportAs (_, FileName (s, tok), Some alias) ->
+         | ImportAs (_, FileName (s, tok), Some (alias, id_info)) ->
              (* for Go *)
              let sid = H.gensym () in
              let base = Filename.basename s, tok in
              let resolved = untyped_ent (ImportedModule (DottedName [base]), sid) in
+             set_resolved env id_info resolved;
              add_ident_imported_scope alias resolved env.names;
 
          | _ -> ()

--- a/lang_GENERIC_base/Visitor_AST.ml
+++ b/lang_GENERIC_base/Visitor_AST.ml
@@ -832,7 +832,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           let v1 = v_module_name v1 and _ = v_alias (v2, v3) in ()
       | ImportAs (t, v1, v2) ->
           let t = v_tok t in
-          let v1 = v_module_name v1 and v2 = v_option v_ident v2 in ()
+          let v1 = v_module_name v1 and v2 = v_option v_ident_and_id_info v2 in ()
       | ImportAll (t, v1, v2) ->
           let t = v_tok t in
           let v1 = v_module_name v1 and v2 = v_tok v2 in ()
@@ -849,8 +849,14 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           let v1 = v_other_directive_operator v1 and v2 = v_list v_any v2 in ()
     in
     vin.kdir (k, all_functions) x
-  and v_alias (v1, v2) = let v1 = v_ident v1 and v2 = v_option v_ident v2 in ()
+  and v_alias (v1, v2) =
+    let v1 = v_ident v1
+    and v2 = v_option v_ident_and_id_info v2
+    in ()
   and v_other_directive_operator _ = ()
+
+  and v_ident_and_id_info (v1, v2) =
+    v_ident v1; v_id_info v2
 
   and v_program v = v_stmts v
   and v_any =

--- a/lang_go/analyze/go_to_generic.ml
+++ b/lang_go/analyze/go_to_generic.ml
@@ -592,7 +592,7 @@ let top_func () =
         *)
         G.ImportAs (itok, module_name, None)
     | ImportNamed v1 -> let v1 = ident v1 in
-        G.ImportAs (itok, module_name, Some v1)
+        G.ImportAs (itok, module_name, Some (v1, G.empty_id_info()))
     | ImportDot v1 -> let v1 = tok v1 in
         G.ImportAll (itok, module_name, v1)
 

--- a/lang_js/analyze/js_to_generic.ml
+++ b/lang_js/analyze/js_to_generic.ml
@@ -534,16 +534,20 @@ and property x =
 
 and toplevel x = stmt x
 
+and alias v1 =
+  let v1 = name v1 in
+  v1, G.empty_id_info()
+
 and module_directive x =
   match x with
   | ReExportNamespace (v1, _v2, _v3, v4) ->
       let v4 = filename v4 in
       G.OtherDirective (G.OI_ReExportNamespace, [G.Tk v1; G.I v4])
   | Import (t, v1, v2, v3) ->
-      let v1 = name v1 and v2 = option name v2 and v3 = filename v3 in
+      let v1 = name v1 and v2 = option alias v2 and v3 = filename v3 in
       G.ImportFrom (t, G.FileName v3, v1, v2)
   | ModuleAlias (t, v1, v2) ->
-      let v1 = name v1 and v2 = filename v2 in
+      let v1 = alias v1 and v2 = filename v2 in
       G.ImportAs (t, G.FileName v2, Some v1)
   (* sgrep: we used to convert this in an OI_ImportEffect, but
    * we now want import "foo" to be used to match any form of import

--- a/lang_php/analyze/php_to_generic.ml
+++ b/lang_php/analyze/php_to_generic.ml
@@ -172,7 +172,7 @@ let rec stmt_aux =
       [G.DirectiveStmt (G.Package (t, v1)) |> G.s] @ v2 @
       [G.DirectiveStmt (G.PackageEnd t2) |> G.s]
   | NamespaceUse (t, v1, v2) ->
-      let v1 = qualified_ident v1 and v2 = option ident v2 in
+      let v1 = qualified_ident v1 and v2 = option alias v2 in
       [G.DirectiveStmt (G.ImportAs (t, G.DottedName v1, v2)) |> G.s]
 
   | StaticVars (t, v1) ->
@@ -194,6 +194,10 @@ let rec stmt_aux =
             let e = expr e in
             G.OtherStmt (G.OS_GlobalComplex, [G.E e]) |> G.s
       )
+
+and alias x =
+  let x = ident x in
+  x, G.empty_id_info()
 
 and stmt x =
   G.stmt1 (stmt_aux x)

--- a/lang_python/analyze/Python_to_generic.ml
+++ b/lang_python/analyze/Python_to_generic.ml
@@ -662,7 +662,7 @@ and stmt_aux x =
       [G.Assert (t, v1, v2, G.sc) |> G.s]
 
   | ImportAs (t, v1, v2) ->
-      let mname = module_name v1 and nopt = option name v2 in
+      let mname = module_name v1 and nopt = option ident_and_id_info v2 in
       [G.DirectiveStmt (G.ImportAs (t, mname, nopt)) |> G.s]
   | ImportAll (t, v1, v2) ->
       let mname = module_name v1 and v2 = info v2 in
@@ -709,6 +709,10 @@ and stmt_aux x =
       stmt_aux (ExprStmt (Call (id, fb [Arg e])))
 
 (*e: function [[Python_to_generic.stmt_aux]] *)
+
+and ident_and_id_info x =
+  let x = name x in
+  x, G.empty_id_info()
 
 (*s: function [[Python_to_generic.stmt]] *)
 and stmt x =
@@ -758,7 +762,7 @@ and decorator (t, v1, v2) =
 
 (*s: function [[Python_to_generic.alias]] *)
 and alias (v1, v2) =
-  let v1 = name v1 and v2 = option name v2 in
+  let v1 = name v1 and v2 = option ident_and_id_info v2 in
   v1, v2
 (*e: function [[Python_to_generic.alias]] *)
 


### PR DESCRIPTION
We do have an id_info at the definition and use sites for variables;
we should have it also at the definition and use sites of an imported
entity.

This will help https://github.com/returntocorp/semgrep/issues/2304

test plan:
make test