### PR TITLE
generic: constness: Fix eq_literal

### DIFF
--- a/lang_GENERIC/analyze/Dataflow_constness.ml
+++ b/lang_GENERIC/analyze/Dataflow_constness.ml
@@ -62,16 +62,7 @@ let str_of_name ((s, _tok), sid) =
 (* Constness *)
 (*****************************************************************************)
 
-(* TODO: use the new AST_generic.eq_xxx functions from deriving eq *)
-let eq_literal l1 l2 =
-  match l1, l2 with
-  | G.Bool  (b1, _),  G.Bool  (b2, _)  -> b1 =:= b2
-  | G.Int   (s1, _),  G.Int   (s2, _)
-  | G.Float (s1, _),  G.Float (s2, _)
-  | G.Char  (s1, _),  G.Char   (s2, _)
-  | G.String (s1, _), G.String (s2, _) -> s1 =$= s2
-  (* add more cases if needed *)
-  | ___else___ -> false
+let eq_literal l1 l2 = G.equal_literal l1 l2
 
 let eq_ctype t1 t2 = t1 = t2
 

--- a/lang_GENERIC/analyze/Unit_dataflow.ml
+++ b/lang_GENERIC/analyze/Unit_dataflow.ml
@@ -1,0 +1,30 @@
+open Common
+open OUnit
+
+(*****************************************************************************)
+(* Unit tests *)
+(*****************************************************************************)
+
+let timeout_secs = 1
+
+let unittest =
+  "dataflow_python" >::: [
+
+    (* Just checking that it terminates without crashing. *)
+    "regression files" >:: (fun () ->
+      let dir = Config_pfff.tests_path "python/dataflow" in
+      let files = Common2.glob (spf "%s/*.py" dir)in
+      files |> List.iter (fun file ->
+        let ast = Parse_generic.parse_program file in
+        let lang = List.hd (Lang.langs_of_filename file) in
+        Naming_AST.resolve lang ast;
+        try
+          timeout_function timeout_secs (fun () ->
+            Constant_propagation.propagate_basic lang ast;
+            Constant_propagation.propagate_dataflow ast)
+        with Timeout -> assert_failure (
+          spf "constant propagation should finish in less than %ds: %s"
+            timeout_secs file)
+      )
+    );
+  ]

--- a/lang_GENERIC/analyze/Unit_dataflow.mli
+++ b/lang_GENERIC/analyze/Unit_dataflow.mli
@@ -1,0 +1,5 @@
+(* Returns the testsuite for dataflow analyses. To be concatenated by
+ * the caller (e.g. in pfff/main_test.ml ) with other testsuites and
+ * run via OUnit.run_test_tt
+*)
+val unittest: OUnit.test

--- a/tests/Test.ml
+++ b/tests/Test.ml
@@ -103,6 +103,7 @@ let test regexp =
       (* generic AST tests *)
       Unit_naming_generic.unittest;
       Unit_typing_generic.unittest;
+      Unit_dataflow.unittest;
     ]
   in
   let suite =

--- a/tests/python/dataflow/while.py
+++ b/tests/python/dataflow/while.py
@@ -1,0 +1,3 @@
+def run(self):
+    while not self._should_stop:
+        response = None


### PR DESCRIPTION
The previous definition could cause an infinite loop, e.g.:

    def run():
        while c:
            response = None

Here the old `eq_literal` would say that `None` and `None` were
different, hence we never reached a fixpoint.