### PR TITLE
Add a few common Rust constructs

### DIFF
--- a/lang_GENERIC/analyze/AST_to_IL.ml
+++ b/lang_GENERIC/analyze/AST_to_IL.ml
@@ -539,6 +539,7 @@ and call_special _env (x, tok) =
    | G.HashSplat
    | G.ForOf
    | G.NextArrayIndex
+   | G.Metavar
      -> todo (G.E (G.IdSpecial (x, tok)))
   ), tok
 

--- a/lang_GENERIC/analyze/AST_to_IL.ml
+++ b/lang_GENERIC/analyze/AST_to_IL.ml
@@ -539,7 +539,6 @@ and call_special _env (x, tok) =
    | G.HashSplat
    | G.ForOf
    | G.NextArrayIndex
-   | G.Metavar
      -> todo (G.E (G.IdSpecial (x, tok)))
   ), tok
 

--- a/lang_GENERIC_base/AST_generic.ml
+++ b/lang_GENERIC_base/AST_generic.ml
@@ -277,7 +277,7 @@ type name = ident * name_info
 (*s: type [[AST_generic.name_info]] *)
 and name_info = {
   name_qualifier: qualifier option;
-  name_typeargs: type_arguments option; (* Java *)
+  name_typeargs: type_arguments option; (* Java/Rust *)
 }
 (* todo: not enough in OCaml with functor and type args or C++ templates*)
 (*e: type [[AST_generic.name_info]] *)
@@ -286,7 +286,6 @@ and qualifier =
   | QTop of tok (* ::, Ruby, C++, also '`' abuse for PolyVariant in OCaml *)
   | QDots of dotted_ident (* Java, OCaml *)
   | QExpr of expr * tok (* Ruby *)
-  | QType of type_ (* Rust trait disambiguation *)
 (*e: type [[AST_generic.qualifier]] *)
 
 (* This is used to represent field names, where sometimes the name
@@ -562,7 +561,6 @@ and special =
   (* less: should be lift up and transformed in Assign at stmt level *)
   | IncrDecr of (incr_decr * prefix_postfix)
 
-  | Metavar (* Rust macros *)
 (*e: type [[AST_generic.special]] *)
 
 (* mostly binary operators.
@@ -925,6 +923,7 @@ and other_stmt_operator =
 and pattern =
   | PatLiteral of literal
   (* Or-Type, used also to match OCaml exceptions *)
+  (* Used with Rust path expressions, with an empty pattern list *)
   | PatConstructor of name * pattern list
   (* And-Type*)
   | PatRecord of (name * pattern) list bracket
@@ -960,9 +959,6 @@ and pattern =
   | PatEllipsis of tok
   | DisjPat of pattern * pattern
   (*e: [[AST_generic.pattern]] semgrep extensions cases *)
-
-  (* Rust *)
-  | PatPathExpr of expr (* Qualified identifier with support for trait disambiguation *)
 
   | OtherPat of other_pattern_operator * any list
   (*e: type [[AST_generic.pattern]] *)
@@ -1098,7 +1094,6 @@ and keyword_attribute =
   | Getter | Setter
   (* Rust *)
   | Unsafe
-  | Borrowed (* &T, &mut T *)
   | DefaultImpl (* unstable, RFC 1210 *)
 (*e: type [[AST_generic.keyword_attribute]] *)
 
@@ -1362,8 +1357,6 @@ and or_type_element =
   | OrEnum of ident * expr option
   (* Java? *)
   | OrUnion of ident * type_
-  (* Rust *)
-  | OrEnumStruct of ident * field list bracket
 
   | OtherOr of other_or_type_element_operator * any list
   (*e: type [[AST_generic.or_type_element]] *)

--- a/lang_GENERIC_base/AST_generic_helpers.ml
+++ b/lang_GENERIC_base/AST_generic_helpers.ml
@@ -139,6 +139,7 @@ let is_boolean_operator = function
   | LSL | LSR | ASR (* L = logic, A = Arithmetic, SL = shift left *)
   | BitOr | BitXor | BitAnd | BitNot | BitClear (* unary *)
   | Range | Nullish | NotNullPostfix | Elvis | Length
+  | RangeInclusive
     -> false
   | And | Or | Xor | Not
   | Eq     | NotEq

--- a/lang_GENERIC_base/Map_AST.ml
+++ b/lang_GENERIC_base/Map_AST.ml
@@ -83,6 +83,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | QDots v -> QDots (map_dotted_ident v)
     | QTop t -> QTop (map_tok t)
     | QExpr (e, t) -> let e = map_expr e in let t = map_tok t in QExpr(e, t)
+    | QType t -> let t = map_type_ t in QType t
 
   and map_module_name =
     function
@@ -301,7 +302,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
   and map_special x =
     match x with
     | ForOf | Defined | This | Super | Self | Parent | Eval | Typeof | Instanceof
-    | Sizeof | New | Spread | HashSplat | NextArrayIndex
+    | Sizeof | New | Spread | HashSplat | NextArrayIndex | Metavar
       -> x
     | Op v1 -> let v1 = map_arithmetic_operator v1 in Op v1
     | EncodedString v1 -> let v1 = map_of_string v1 in EncodedString v1
@@ -400,6 +401,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           map_of_option (fun (v1, v2) -> map_wrap map_of_bool v1, map_type_ v2) v2
         in
         TypeWildcard (v1, v2)
+    | TypeLifetime v1 -> let v1 = map_ident v1 in TypeLifetime v1
 
   and map_other_type_operator x = x
 
@@ -622,9 +624,9 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
            | (v1, v2) ->
                let v1 = map_ident v1 and v2 = map_id_info v2 in (v1, v2))
         in PatAs (v1, v2)
-
     | PatWhen (v1, v2) ->
         let v1 = map_pattern v1 and v2 = map_expr v2 in PatWhen (v1, v2)
+    | PatPathExpr v1 -> let v1 = map_expr v1 in PatPathExpr v1
     | OtherPat (v1, v2) ->
         let v1 = map_other_pattern_operator v1
         and v2 = map_of_list map_any v2
@@ -806,6 +808,8 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
         let v1 = map_ident v1 and v2 = map_of_option map_expr v2 in OrEnum (v1, v2)
     | OrUnion (v1, v2) ->
         let v1 = map_ident v1 and v2 = map_type_ v2 in OrUnion (v1, v2)
+    | OrEnumStruct (v1, v2) ->
+        let v1 = map_ident v1 and v2 = map_bracket (map_of_list map_field) v2 in OrEnumStruct (v1, v2)
     | OtherOr (v1, v2) ->
         let v1 = map_other_or_type_element_operator v1
         and v2 = map_of_list map_any v2

--- a/lang_GENERIC_base/Map_AST.ml
+++ b/lang_GENERIC_base/Map_AST.ml
@@ -83,7 +83,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | QDots v -> QDots (map_dotted_ident v)
     | QTop t -> QTop (map_tok t)
     | QExpr (e, t) -> let e = map_expr e in let t = map_tok t in QExpr(e, t)
-    | QType t -> let t = map_type_ t in QType t
 
   and map_module_name =
     function
@@ -302,7 +301,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
   and map_special x =
     match x with
     | ForOf | Defined | This | Super | Self | Parent | Eval | Typeof | Instanceof
-    | Sizeof | New | Spread | HashSplat | NextArrayIndex | Metavar
+    | Sizeof | New | Spread | HashSplat | NextArrayIndex
       -> x
     | Op v1 -> let v1 = map_arithmetic_operator v1 in Op v1
     | EncodedString v1 -> let v1 = map_of_string v1 in EncodedString v1
@@ -626,7 +625,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
         in PatAs (v1, v2)
     | PatWhen (v1, v2) ->
         let v1 = map_pattern v1 and v2 = map_expr v2 in PatWhen (v1, v2)
-    | PatPathExpr v1 -> let v1 = map_expr v1 in PatPathExpr v1
     | OtherPat (v1, v2) ->
         let v1 = map_other_pattern_operator v1
         and v2 = map_of_list map_any v2
@@ -808,8 +806,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
         let v1 = map_ident v1 and v2 = map_of_option map_expr v2 in OrEnum (v1, v2)
     | OrUnion (v1, v2) ->
         let v1 = map_ident v1 and v2 = map_type_ v2 in OrUnion (v1, v2)
-    | OrEnumStruct (v1, v2) ->
-        let v1 = map_ident v1 and v2 = map_bracket (map_of_list map_field) v2 in OrEnumStruct (v1, v2)
     | OtherOr (v1, v2) ->
         let v1 = map_other_or_type_element_operator v1
         and v2 = map_of_list map_any v2

--- a/lang_GENERIC_base/Meta_AST.ml
+++ b/lang_GENERIC_base/Meta_AST.ml
@@ -60,7 +60,6 @@ let rec vof_qualifier = function
   | QExpr (v1, v2) -> let v1 = vof_expr v1 in
       let v2 = vof_tok v2 in
       OCaml.VSum ("QExpr", [v1; v2])
-  | QType t -> let t = vof_type_ t in (OCaml.VSum ("QType", [ t ]))
 
 and vof_name (v1, v2) =
   let v1 = vof_ident v1 and v2 = vof_name_info v2 in OCaml.VTuple [ v1; v2 ]
@@ -326,7 +325,6 @@ and vof_special =
       let v = vof_inc_dec v in
       OCaml.VSum ("IncrDecr", [ v])
   | NextArrayIndex -> OCaml.VSum ("NextArrayIndex", [])
-  | Metavar -> OCaml.VSum ("Metavar", [])
 
 and vof_interpolated_kind = function
   | FString -> OCaml.VSum ("FString", [])
@@ -555,7 +553,6 @@ and vof_keyword_attribute =
   | Optional -> OCaml.VSum ("Optional", [])
   | NotNull -> OCaml.VSum ("NotNull", [])
   | Unsafe -> OCaml.VSum ("Unsafe", [])
-  | Borrowed -> OCaml.VSum ("Borrowed", [])
   | DefaultImpl -> OCaml.VSum ("DefaultImpl", [])
 
 and vof_attribute = function
@@ -843,7 +840,6 @@ and vof_pattern =
       let v1 = vof_pattern v1
       and v2 = vof_pattern v2
       in OCaml.VSum ("DisjPat", [ v1; v2 ])
-  | PatPathExpr v1 -> let v1 = vof_expr v1 in OCaml.VSum ("PatName", [ v1 ])
   | OtherPat (v1, v2) ->
       let v1 = vof_other_pattern_operator v1
       and v2 = OCaml.vof_list vof_any v2
@@ -1076,10 +1072,6 @@ and vof_or_type_element =
       let v1 = vof_ident v1
       and v2 = vof_type_ v2
       in OCaml.VSum ("OrUnion", [ v1; v2 ])
-  | OrEnumStruct (v1, v2) ->
-      let v1 = vof_ident v1
-      and v2 = vof_bracket (OCaml.vof_list vof_field) v2
-      in OCaml.VSum("OrEnumStruct", [ v1; v2 ])
   | OtherOr (v1, v2) ->
       let v1 = vof_other_or_type_element_operator v1
       and v2 = OCaml.vof_list vof_any v2

--- a/lang_GENERIC_base/Meta_AST.ml
+++ b/lang_GENERIC_base/Meta_AST.ml
@@ -60,6 +60,7 @@ let rec vof_qualifier = function
   | QExpr (v1, v2) -> let v1 = vof_expr v1 in
       let v2 = vof_tok v2 in
       OCaml.VSum ("QExpr", [v1; v2])
+  | QType t -> let t = vof_type_ t in (OCaml.VSum ("QType", [ t ]))
 
 and vof_name (v1, v2) =
   let v1 = vof_ident v1 and v2 = vof_name_info v2 in OCaml.VTuple [ v1; v2 ]
@@ -325,6 +326,7 @@ and vof_special =
       let v = vof_inc_dec v in
       OCaml.VSum ("IncrDecr", [ v])
   | NextArrayIndex -> OCaml.VSum ("NextArrayIndex", [])
+  | Metavar -> OCaml.VSum ("Metavar", [])
 
 and vof_interpolated_kind = function
   | FString -> OCaml.VSum ("FString", [])
@@ -356,6 +358,7 @@ and vof_arithmetic_operator =
   | NotNullPostfix -> OCaml.VSum ("NotNullPostfix", [])
   | Nullish -> OCaml.VSum ("Nullish", [])
   | Range -> OCaml.VSum ("Range", [])
+  | RangeInclusive -> OCaml.VSum ("RangeInclusive", [])
   | RegexpMatch -> OCaml.VSum ("RegexpMatch", [])
   | NotMatch -> OCaml.VSum ("NotMatch", [])
   | Concat -> OCaml.VSum ("Concat", [])
@@ -514,6 +517,8 @@ and vof_type_argument =
         OCaml.VTuple [v1; v2]
       ) v2 in
       OCaml.VSum ("TypeWildcard", [ v1; v2 ])
+  | TypeLifetime v1 ->
+      let v1 = vof_ident v1 in OCaml.VSum ("TypeLifetime", [ v1 ])
 and vof_other_type_operator =
   function
   | OT_Todo -> OCaml.VSum ("OT_Todo", [])
@@ -549,6 +554,9 @@ and vof_keyword_attribute =
   | Setter -> OCaml.VSum ("Setter", [])
   | Optional -> OCaml.VSum ("Optional", [])
   | NotNull -> OCaml.VSum ("NotNull", [])
+  | Unsafe -> OCaml.VSum ("Unsafe", [])
+  | Borrowed -> OCaml.VSum ("Borrowed", [])
+  | DefaultImpl -> OCaml.VSum ("DefaultImpl", [])
 
 and vof_attribute = function
   | KeywordAttr x -> let v1 = vof_wrap vof_keyword_attribute x in
@@ -835,6 +843,7 @@ and vof_pattern =
       let v1 = vof_pattern v1
       and v2 = vof_pattern v2
       in OCaml.VSum ("DisjPat", [ v1; v2 ])
+  | PatPathExpr v1 -> let v1 = vof_expr v1 in OCaml.VSum ("PatName", [ v1 ])
   | OtherPat (v1, v2) ->
       let v1 = vof_other_pattern_operator v1
       and v2 = OCaml.vof_list vof_any v2
@@ -1067,6 +1076,10 @@ and vof_or_type_element =
       let v1 = vof_ident v1
       and v2 = vof_type_ v2
       in OCaml.VSum ("OrUnion", [ v1; v2 ])
+  | OrEnumStruct (v1, v2) ->
+      let v1 = vof_ident v1
+      and v2 = vof_bracket (OCaml.vof_list vof_field) v2
+      in OCaml.VSum("OrEnumStruct", [ v1; v2 ])
   | OtherOr (v1, v2) ->
       let v1 = vof_other_or_type_element_operator v1
       and v2 = OCaml.vof_list vof_any v2

--- a/lang_GENERIC_base/Visitor_AST.ml
+++ b/lang_GENERIC_base/Visitor_AST.ml
@@ -124,7 +124,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | QDots v -> v_dotted_ident v
     | QTop t -> v_tok t
     | QExpr (e, t) -> v_expr e; v_tok t
-    | QType ty -> v_type_ ty
 
   and v_module_name =
     function
@@ -306,7 +305,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | Spread -> ()
     | HashSplat -> ()
     | NextArrayIndex -> ()
-    | Metavar -> ()
     | EncodedString v1 -> let v1 = v_string v1 in ()
     | Op v1 -> let v1 = v_arithmetic_operator v1 in ()
     | IncrDecr (v1, v2) -> let v1 = v_incr_decr v1 and v2 = v_prepost v2 in ()
@@ -582,7 +580,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           in ()
 
       | PatWhen (v1, v2) -> let v1 = v_pattern v1 and v2 = v_expr v2 in ()
-      | PatPathExpr v1 -> let v1 = v_expr v1 in ()
       | OtherPat (v1, v2) ->
           let v1 = v_other_pattern_operator v1 and v2 = v_list v_any v2 in ()
     in
@@ -785,9 +782,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
         let v1 = v_ident v1 and v2 = v_list v_type_ v2 in ()
     | OrEnum (v1, v2) -> let v1 = v_ident v1 and v2 = v_option v_expr v2 in ()
     | OrUnion (v1, v2) -> let v1 = v_ident v1 and v2 = v_type_ v2 in ()
-    | OrEnumStruct (v1, v2) ->
-        let v1 = v_ident v1
-        and v2 = v_bracket (v_list v_field) v2 in ()
     | OtherOr (v1, v2) ->
         let v1 = v_other_or_type_element_operator v1
         and v2 = v_list v_any v2

--- a/lang_GENERIC_base/Visitor_AST.ml
+++ b/lang_GENERIC_base/Visitor_AST.ml
@@ -124,6 +124,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | QDots v -> v_dotted_ident v
     | QTop t -> v_tok t
     | QExpr (e, t) -> v_expr e; v_tok t
+    | QType ty -> v_type_ ty
 
   and v_module_name =
     function
@@ -305,6 +306,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | Spread -> ()
     | HashSplat -> ()
     | NextArrayIndex -> ()
+    | Metavar -> ()
     | EncodedString v1 -> let v1 = v_string v1 in ()
     | Op v1 -> let v1 = v_arithmetic_operator v1 in ()
     | IncrDecr (v1, v2) -> let v1 = v_incr_decr v1 and v2 = v_prepost v2 in ()
@@ -373,6 +375,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
              v_wrap v_bool v1;
              v_type_ v2
         )
+    | TypeLifetime v1 -> let v1 = v_ident v1 in ()
 
   and v_other_type_operator _ = ()
 
@@ -579,6 +582,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           in ()
 
       | PatWhen (v1, v2) -> let v1 = v_pattern v1 and v2 = v_expr v2 in ()
+      | PatPathExpr v1 -> let v1 = v_expr v1 in ()
       | OtherPat (v1, v2) ->
           let v1 = v_other_pattern_operator v1 and v2 = v_list v_any v2 in ()
     in
@@ -781,6 +785,9 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
         let v1 = v_ident v1 and v2 = v_list v_type_ v2 in ()
     | OrEnum (v1, v2) -> let v1 = v_ident v1 and v2 = v_option v_expr v2 in ()
     | OrUnion (v1, v2) -> let v1 = v_ident v1 and v2 = v_type_ v2 in ()
+    | OrEnumStruct (v1, v2) ->
+        let v1 = v_ident v1
+        and v2 = v_bracket (v_list v_field) v2 in ()
     | OtherOr (v1, v2) ->
         let v1 = v_other_or_type_element_operator v1
         and v2 = v_list v_any v2


### PR DESCRIPTION
Related to the changes in semgrep.

Justifications for what was added:

- `Metavar`: Identifiers used in Rust macros. Unlike C, Rust macros are hygenic. Quoting the language docs, "[e]ach macro expansion happens in a distinct ‘syntax context’, and each variable is tagged with the syntax context where it was introduced." This `Metavar` will be used with `IdSpecial` to indicate special macro identifiers that can show up inline in code. The other macro parts were left out from this PR since Rust macros are radically different from C macros.
- `QType`: Rust dotted identifiers can be used to disambiguate multiple matching types in generic functions and similar, in case there is not enough information for the type checker to deduce the correct type. Example from [here](https://techblog.tonsser.com/posts/what-is-rusts-turbofish):

```rust
fn main() {
    let numbers: Vec<i32> = vec![
        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
    ];

    let even_numbers = numbers
        .into_iter()
        .filter(|n| n % 2 == 0)
        .collect::<Vec<i32>>();

    println!("{:?}", even_numbers);
}
```

In this case, there is not enough information for the type checker to determine what kind of collection you want to `collect` into, so we need to specify `::<Vec<i32>>` (nicknamed the "turbofish"). This is the qualifier that `QType` represents.

It's also possible to use syntax like this to disambiguate traits, so the type is part of the qualifier:
```rust
fn main() {
    let s = "Hello, World!";
    let string = <&str as Into<String>>::into(&s);
}
```

- `RangeInclusive`: Another range operator for inclusive ranges. There are two kinds of syntax in circulation (`...` and `..=`), as explained by https://github.com/rust-lang/rust/issues/28237. (Rust syntax is backward compatible as long as you don't specify the newer syntax version in the build options, so both need to be parseable.)
- `TypeLifetime`: Lifetimes are a major feature of Rust. See [here](https://doc.rust-lang.org/book/ch10-03-lifetime-syntax.html) for more information, but essentially you are able to encode how long a variable should remain in scope using a type parameter.
- `PatPathExpr`: This is used in range expression bounds and in patterns. It's normally one of `Id`, `IdQualified` or `IdSpecial`. The reason is due to the type disambiguation syntax that makes the path syntax an expression instead of a dotted identifier. There isn't yet a `pattern` that takes only a `name` either.
- `Unsafe`: One of the major features of Rust, allowing you to mark a region of code as memory unsafe.
- `Borrowed`: Used in function parameters like `&self` to indicate `self` is passed by reference instead of by value.
- `DefaultImpl`: This is an unstable syntax proposed by [RFC 1210](https://github.com/rust-lang/rfcs/blob/master/text/1210-impl-specialization.md) (`default fn foo() { ... }`). It was included in the parser, so I added it here also.
- `OrEnumStruct`: Enums in Rust are tagged unions. In fact, they are a strict superset of structs, since you can technically represent any struct with an enum. I don't think there was already anything that captured this distinction.