### PR TITLE
Add R Support

### DIFF
--- a/commons/file_type.ml
+++ b/commons/file_type.ml
@@ -50,7 +50,7 @@ and pl_type =
   | ObjectiveC of string
   | Swift
 
-  | Perl | Python | Ruby | Lua
+  | Perl | Python | Ruby | Lua | R
 
   | Erlang
   | Go | Rust
@@ -283,6 +283,8 @@ let file_type_of_file2 file =
   | "rs" -> PL Rust
   | "go" -> PL Go
   | "lua" -> PL Lua
+  | "r" | "R" -> PL R
+
 
   | _ when Common2.is_executable file -> Binary e
 

--- a/commons/file_type.mli
+++ b/commons/file_type.mli
@@ -16,7 +16,7 @@ and pl_type =
   | Script of string
   | C of string | Cplusplus of string | Java | Kotlin | Csharp | ObjectiveC of string
   | Swift
-  | Perl | Python | Ruby | Lua
+  | Perl | Python | Ruby | Lua | R
   | Erlang | Go | Rust
   | Beta
   | Pascal

--- a/lang_GENERIC/parsing/Parse_generic.ml
+++ b/lang_GENERIC/parsing/Parse_generic.ml
@@ -89,6 +89,8 @@ let parse_with_lang lang file =
       failwith "No Lua parser in pfff; use the one in tree-sitter"
   | Lang.Rust ->
       failwith "No Rust parser in pfff; use the one in tree-sitter"
+  | Lang.R ->
+      failwith "No R parser in pfff; use the one in tree-sitter"
 
 (*e: function [[Parse_generic.parse_with_lang]] *)
 
@@ -147,5 +149,7 @@ let parse_pattern lang str =
       failwith "No Lua generic parser in pfff; use the one in tree-sitter"
   | Lang.Rust ->
       failwith "No Rust generic parser in pfff; use the one in tree-sitter"
+  | Lang.R ->
+      failwith "No R generic parser in pfff; use the one in tree-sitter"
 (*e: function [[Parse_generic.parse_pattern]] *)
 (*e: pfff/lang_GENERIC/parsing/Parse_generic.ml *)

--- a/lang_GENERIC_base/Lang.ml
+++ b/lang_GENERIC_base/Lang.ml
@@ -49,6 +49,7 @@ type t =
   | Kotlin
   | Lua
   | Rust
+  | R
   (*e: type [[Lang.t]] *)
 
 (*****************************************************************************)
@@ -84,6 +85,7 @@ let list_of_lang = [
   "kt", Kotlin;
   "lua", Lua;
   "rs", Rust;
+  "r", R;
 ]
 (*e: constant [[Lang.list_of_lang]] *)
 
@@ -118,6 +120,7 @@ let langs_of_filename filename =
   | FT.PL (FT.Kotlin) -> [Kotlin]
   | FT.PL (FT.Lua) -> [Lua]
   | FT.PL (FT.Rust) -> [Rust]
+  | FT.PL (FT.R) -> [R]
   | _ -> []
 (*e: function [[Lang.langs_of_filename]] *)
 
@@ -140,6 +143,7 @@ let string_of_lang = function
   | Kotlin -> "Kotlin"
   | Lua -> "Lua"
   | Rust -> "Rust"
+  | R -> "R"
 (*e: function [[Lang.string_of_lang]] *)
 
 (*s: function [[Lang.ext_of_lang]] *)
@@ -160,6 +164,7 @@ let ext_of_lang = function
   | Kotlin -> ["kt"]
   | Lua -> ["lua"]
   | Rust -> ["rs"]
+  | R -> ["r", "R"]
 (*e: function [[Lang.ext_of_lang]] *)
 
 (*s: function [[Lang.find_source]] *)

--- a/lang_GENERIC_base/Lang.mli
+++ b/lang_GENERIC_base/Lang.mli
@@ -19,6 +19,7 @@ type t =
   | Kotlin
   | Lua
   | Rust
+  | R
   (*e: type [[Lang.t]] *)
 
 (*s: signature [[Lang.lang_of_string_map]] *)


### PR DESCRIPTION
Adds R to pfff as part of https://github.com/returntocorp/semgrep/issues/2360

One open question I have is around the file type for r, which can be both `r` and `R`. I've added ` | "r" | "R" -> PL R` in file_type.ml, but I believe this may conflict with `  | "R" | "Rd" -> PL (MiscPL e)`. Do I need to limit to lowercase `r` or is there some other way both of these file types can exist for multiple languages?