### PR TITLE
Add HasConstructor type constraint

### DIFF
--- a/lang_GENERIC_base/AST_generic.ml
+++ b/lang_GENERIC_base/AST_generic.ml
@@ -1240,6 +1240,7 @@ and type_parameter = ident * type_parameter_constraint list
 (*s: type [[AST_generic.type_parameter_constraint]] *)
 and type_parameter_constraint =
   | Extends of type_
+  | HasConstructor of tok
   (*e: type [[AST_generic.type_parameter_constraint]] *)
 
 (* ------------------------------------------------------------------------- *)

--- a/lang_GENERIC_base/Map_AST.ml
+++ b/lang_GENERIC_base/Map_AST.ml
@@ -701,6 +701,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
 
   and map_type_parameter_constraint =
     function | Extends v1 -> let v1 = map_type_ v1 in Extends v1
+             | HasConstructor t -> let t = map_tok t in HasConstructor t
 
   and map_function_kind x = x
 

--- a/lang_GENERIC_base/Meta_AST.ml
+++ b/lang_GENERIC_base/Meta_AST.ml
@@ -941,6 +941,7 @@ and vof_type_parameter_constraints v =
 and vof_type_parameter_constraint =
   function
   | Extends v1 -> let v1 = vof_type_ v1 in OCaml.VSum ("Extends", [ v1 ])
+  | HasConstructor t -> let t = vof_tok t in OCaml.VSum ("HasConstructor", [ t ])
 
 and vof_function_kind = function
   | Function -> OCaml.VSum ("Function", [])

--- a/lang_GENERIC_base/Visitor_AST.ml
+++ b/lang_GENERIC_base/Visitor_AST.ml
@@ -385,6 +385,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
   and v_type_parameter_constraints v = v_list v_type_parameter_constraint v
   and v_type_parameter_constraint =
     function | Extends v1 -> let v1 = v_type_ v1 in ()
+             | HasConstructor t -> let t = v_tok t in ()
   and v_attribute x =
     let k x =
       match x with


### PR DESCRIPTION
To indicate that a generic type has a constructor. E.g.
```csharp
public void SomeMethod<T>() where T : new() { ... }
```

The `T : new()` indicates that T has a parameterless constructor. Since
interfaces and abstract classes can't have constructors, having T extend some
type is not sufficient.

In C# it's only possible to supply a parameterless constructor.
`HasConstructor` could have a parameter list, but that seems not needed for
now.

For a complete list of type constraints, see [Constraints on type
parameters](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters).