### PR TITLE
Flush channels before forking so as to avoid duplicate output

### DIFF
--- a/commons_core/parallel.ml
+++ b/commons_core/parallel.ml
@@ -36,6 +36,7 @@ let backtrace_when_exn = ref true
  * returns a futur
 *)
 let invoke2 f x =
+  flush_all (); (* avoid duplicate output *)
   let input, output = Unix.pipe() in
   match Unix.fork() with
   (* error, could not create process, well compute now then *)


### PR DESCRIPTION
I was seeing duplicate output during debugging. This prevents it.
