### PR TITLE
Add parentheses to the go ast for TypeAssertions

### DIFF
--- a/lang_go/parsing/ast_go.ml
+++ b/lang_go/parsing/ast_go.ml
@@ -160,7 +160,7 @@ and expr =
   | Binary of expr * AST_generic_.operator wrap * expr
 
   (* x.(<type>), panic if false unless used as x, ok = x.(<type>) *)
-  | TypeAssert of expr * type_
+  | TypeAssert of expr * type_ bracket
   (* x.(type)
    * less: can appear only in a TypeSwitch, so could be moved there *)
   | TypeSwitchExpr of expr * tok (* 'type' *)

--- a/lang_go/parsing/parser_go.mly
+++ b/lang_go/parsing/parser_go.mly
@@ -612,7 +612,7 @@ pexpr_no_paren:
 |   pexpr "." sym { Selector ($1, $2, $3) }
 
 |   pexpr "." "(" expr_or_type ")"
-    { TypeAssert ($1, expr_or_type_to_type $2 $4) }
+    { TypeAssert ($1, ($3, expr_or_type_to_type $2 $4, $5)) }
     (* less: only inside a TypeSwitch, rewrite grammar? *)
 |   pexpr "." "(" LTYPE ")"
     { TypeSwitchExpr ($1, $3) }

--- a/lang_go/parsing/visitor_go.ml
+++ b/lang_go/parsing/visitor_go.ml
@@ -187,7 +187,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           and v2 = v_wrap v_arithmetic_operator v2
           and v3 = v_expr v3
           in ()
-      | TypeAssert (v1, v2) -> let v1 = v_expr v1 and v2 = v_type_ v2 in ()
+      | TypeAssert (v1, v2) -> let v1 = v_expr v1 and v2 = v_bracket v_type_ v2 in ()
       | TypeSwitchExpr (v1, v2) -> let v1 = v_expr v1 and v2 = v_tok v2 in ()
       | Ellipsis v1 -> let v1 = v_tok v1 in ()
       | TypedMetavar (v1, v2, v3) ->


### PR DESCRIPTION
TypeAssert takes the form ident.(type). The parentheses need to be included for autofix.

Test plan:

Make test and also verify that the target:

```
package main

func main() {
    // ruleid: type-assertion-bug
    PointerList(set.List())
    // ruleid: type-assertion-bug
    PointerList(setInterface.(*Set).List())
}
```

with the rule:

```
rules:
- id: type-assertion-bug
  pattern: |
    PointerList($VALUE.List())
  message: |
    Prefer `PointerSet()` for expanding *Set
  severity: WARNING
  fix: |
      PointerSet($VALUE)
  languages: [go]
```

fixes to

```PointerSet(set) ```
and
```PointerSet(setInterface.(*Set))```