### PR TITLE
Use stmt instead of stmt list for body of for/do/while

### DIFF
--- a/lang_php/analyze/ast_php.ml
+++ b/lang_php/analyze/ast_php.ml
@@ -278,12 +278,11 @@ and stmt =
   | If of tok * expr * stmt * stmt
   | Switch of tok * expr * case list
 
-  (* pad: not sure why we use stmt list instead of just stmt like for If *)
-  | While of tok * expr * stmt list
-  | Do of tok * stmt list * expr
-  | For of tok * expr list * expr list * expr list * stmt list
+  | While of tok * expr * stmt
+  | Do of tok * stmt * expr
+  | For of tok * expr list * expr list * expr list * stmt
   (* 'foreach ($xs as $k)','... ($xs as $k => $v)', '... ($xs as list($...))'*)
-  | Foreach of tok * expr * tok * foreach_pattern * stmt list
+  | Foreach of tok * expr * tok * foreach_pattern * stmt
 
   | Return of tok * expr option
   | Break of tok * expr option | Continue of tok * expr option

--- a/lang_php/analyze/ast_php_build.ml
+++ b/lang_php/analyze/ast_php_build.ml
@@ -197,7 +197,7 @@ and stmt env st acc =
       A.Expr (e, t) :: acc
   (* Why not just acc? because we abuse noop in the abstract interpreter? *)
   | EmptyStmt _ -> noop :: acc
-  | Block (_, stdl, _) -> List.fold_right (stmt_and_def env) stdl acc
+  | Block (lb, stdl, rb) -> A.Block (lb, List.fold_right (stmt_and_def env) stdl [], rb) :: acc
   | If (tok, (_, e, _), st, il, io) ->
       let e = expr env e in
       let st = stmt1 (stmt env st []) in
@@ -212,7 +212,7 @@ and stmt env st acc =
       let cst = colon_stmt env cst in
       A.While (tok, expr env e, cst) :: acc
   | Do (tok, st, _, (_, e, _), _) ->
-      A.Do (tok, stmt env st [], expr env e) :: acc
+      A.Do (tok, stmt1 (stmt env st []), expr env e) :: acc
   | For (tok, _, e1, _, e2, _, e3, _, st) ->
       let st = colon_stmt env st in
       let e1 = for_expr env e1 in
@@ -271,7 +271,7 @@ and stmt env st acc =
        | (_,[Common.Left((Name("ticks",_), (_,Sc(C(Int((("1"),_)))))))],_), _
          ->
            let cst = colon_stmt env colon_st in
-           cst @ acc
+           cst :: acc
 
        |  _ -> error tok "TODO: declare"
       )
@@ -835,8 +835,8 @@ and array_pair env = function
 and for_expr env el = List.map (expr env) (comma_list el)
 
 and colon_stmt env = function
-  | SingleStmt st -> stmt env st []
-  | ColonStmt (_, stl, _, _) -> List.fold_right (stmt_and_def env) stl []
+  | SingleStmt st -> stmt1 (stmt env st [])
+  | ColonStmt (_, stl, _, _) -> stmt1 (List.fold_right (stmt_and_def env) stl [])
 (*of tok (* : *) * stmt_and_def list * tok (* endxxx *) * tok (* ; *) *)
 
 and switch_case_list env = function

--- a/lang_php/analyze/graph_code_php.ml
+++ b/lang_php/analyze/graph_code_php.ml
@@ -724,13 +724,13 @@ and stmt_bis env x =
       casel env xs
   | While (_, e, xs) | Do (_, xs, e) ->
       expr env e;
-      stmtl env xs
+      stmt env xs
   | For (_, es1, es2, es3, xs) ->
       exprl env (es1 @ es2 @ es3);
-      stmtl env xs
+      stmt env xs
   | Foreach (_, e1, _, e2, xs) ->
       exprl env [e1;e2];
-      stmtl env xs;
+      stmt env xs;
   | Return (_, eopt)  | Break (_, eopt) | Continue (_, eopt) ->
       Common2.opt (expr env) eopt
   | Throw (_, e) -> expr env e


### PR DESCRIPTION
In php, the cst uses a stmt to represent the body of loops, as does the generic ast, but the ast uses a stmt list. This PR changes it to go directly through a statement. Additionally, blocks remain blocks, so that single statement blocks remain blocks.

Test plan: run make test in semgrep, with the added files in the associated PR