### PR TITLE
Convert TopLevel statements to statements

### DIFF
--- a/lang_php/analyze/ast_php_build.ml
+++ b/lang_php/analyze/ast_php_build.ml
@@ -93,7 +93,10 @@ and any_aux env = function
   | Stmt2 st ->
       let st = stmt1 (stmt env st []) in
       A.Stmt st
-  | Toplevel x -> any_aux env (Toplevels [x])
+  | Toplevel x ->
+    (match toplevel env x with
+    | [st] -> A.Stmt st
+    | sts -> A.Program sts)
   | Toplevels x | Program x -> let x = toplevels env x in A.Program x
   | _ -> failwith "TODO: PHP"
 

--- a/lang_php/analyze/ast_php_build.ml
+++ b/lang_php/analyze/ast_php_build.ml
@@ -94,9 +94,9 @@ and any_aux env = function
       let st = stmt1 (stmt env st []) in
       A.Stmt st
   | Toplevel x ->
-    (match toplevel env x with
-    | [st] -> A.Stmt st
-    | sts -> A.Program sts)
+      (match toplevel env x with
+       | [st] -> A.Stmt st
+       | sts -> A.Program sts)
   | Toplevels x | Program x -> let x = toplevels env x in A.Program x
   | _ -> failwith "TODO: PHP"
 


### PR DESCRIPTION
Currently, a TopLevel statement st is converted to Ss [st]. This commit converts it instead to S st.

Test plan: see associated semgrep commit