### PR TITLE
Added typed metavariables to javascript grammar

### DIFF
--- a/lang_js/analyze/graph_code_js.ml
+++ b/lang_js/analyze/graph_code_js.ml
@@ -512,7 +512,7 @@ and stmts env xs =
 and expr env e =
   match e with
   | ExprTodo _ | Cast _ | TypeAssert _ -> failwith "ExprTodo|Cast|..."
-  | Ellipsis _ | DeepEllipsis _ | ObjAccessEllipsis _ -> ()
+  | Ellipsis _ | DeepEllipsis _ | ObjAccessEllipsis _ | TypedMetavar _ -> ()
 
   | L (Bool _ | Num _ | String _ | Regexp _) -> ()
   | Id (n(*, scope*)) ->

--- a/lang_js/parsing/ast_js.ml
+++ b/lang_js/parsing/ast_js.ml
@@ -224,6 +224,7 @@ and expr =
   | Ellipsis of tok
   | DeepEllipsis of expr bracket
   | ObjAccessEllipsis of expr * tok (* ... *)
+  | TypedMetavar of ident * tok * type_
 
 and literal =
   | Bool of bool wrap

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -1311,6 +1311,7 @@ primary_expr_no_braces:
 
  (* simple! ECMA mixes this rule with arrow parameters (bad) *)
  | "(" expr ")" { $2 }
+ | "(" id ":" type_ ")" { TypedMetavar ($2, $3, $4) }
 
  (* xhp: do not put in 'expr', otherwise can't have xhp in function arg *)
  | xhp_html { Xml $1 }

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -161,6 +161,10 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
       | Obj v1 -> let v1 = v_obj_ v1 in ()
       | Ellipsis v1 -> let v1 = v_tok v1 in ()
       | DeepEllipsis v1 -> let v1 = v_bracket v_expr v1 in ()
+      | TypedMetavar (v1, t, v2) -> 
+          let v1 = v_ident v1 and v2 = v_type_ v2 in
+          let t = v_tok t in
+          ()
       | Class (v1, v2) -> let v1 = v_class_definition v1 in let v2 = v_option v_name v2 in ()
       | ObjAccess (v1, t, v2) ->
           let v1 = v_expr v1 and v2 = v_property_name v2 in

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -161,7 +161,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
       | Obj v1 -> let v1 = v_obj_ v1 in ()
       | Ellipsis v1 -> let v1 = v_tok v1 in ()
       | DeepEllipsis v1 -> let v1 = v_bracket v_expr v1 in ()
-      | TypedMetavar (v1, t, v2) -> 
+      | TypedMetavar (v1, t, v2) ->
           let v1 = v_ident v1 and v2 = v_type_ v2 in
           let t = v_tok t in
           ()


### PR DESCRIPTION
Use (ident : type) to indicate a typed metavariable in javascript. This will also add typed metavariables to typescript patterns, since patterns are parsed using pfff. In service of #2564, though LSP is needed for full type inference

Test plan: make test with test in https://github.com/returntocorp/semgrep/pull/2588