### PR TITLE
Allow ellipsis in ArrayGet

### DIFF
--- a/lang_php/parsing/parser_php.mly
+++ b/lang_php/parsing/parser_php.mly
@@ -1256,7 +1256,7 @@ lambda_body:
 (* auxillary bis *)
 (*----------------------------*)
 
-dim_offset: 
+dim_offset:
  | expr? { $1 }
  | "..." { Some (Ellipsis $1) }
 

--- a/lang_php/parsing/parser_php.mly
+++ b/lang_php/parsing/parser_php.mly
@@ -1256,7 +1256,9 @@ lambda_body:
 (* auxillary bis *)
 (*----------------------------*)
 
-dim_offset: expr? { $1 }
+dim_offset: 
+ | expr? { $1 }
+ | "..." { Some (Ellipsis $1) }
 
 exit_expr:
  | (*empty*)    { None }


### PR DESCRIPTION
Add ellipsis case to ArrayGet

Test plan:

semgrep-core -dump_pattern [file] -lang php

with

```
$foo[...]
```