### PR TITLE
Allow any character to be used in semgrep strings

### DIFF
--- a/lang_go/parsing/lexer_go.mll
+++ b/lang_go/parsing/lexer_go.mll
@@ -123,7 +123,10 @@ let octal_byte_value = '\\' octal_digit octal_digit octal_digit
 let hex_byte_value = '\\' 'x' hex_digit hex_digit
 let byte_value = octal_byte_value | hex_byte_value
 
-let escapeseq = '\\' _
+(* semgrep: we can use regexp in semgrep in strings and we want to
+ * support any escape characters there, e.g. eval("=~/.*dev\.corp/")
+ *)
+let semgrep_escapeseq = '\\' _
 
 (*****************************************************************************)
 (* Rule initial *)
@@ -299,6 +302,8 @@ rule token = parse
       { LSTR (s, tokinfo lexbuf) }
   | '"' ((unicode_value_no_double_quote | byte_value)* as s) '"'
       { LSTR (s, tokinfo lexbuf) }
+  | '"' ((unicode_value_no_double_quote | byte_value | semgrep_escapeseq)* as s) '"'
+      { Flag.sgrep_guard (LSTR (s, tokinfo lexbuf)) }
 
   (* ----------------------------------------------------------------------- *)
   (* eof *)


### PR DESCRIPTION
Since regexes can be used in semgrep strings, allow any character when parsing a pattern.

Test plan: semgrep-core -dump_pattern tests/go/regexp_caret.sgrep -lang go
See https://github.com/returntocorp/semgrep/pull/2898