### PR TITLE
Add SwitchE construct to Java

### DIFF
--- a/lang_java/analyze/graph_code_java.ml
+++ b/lang_java/analyze/graph_code_java.ml
@@ -787,6 +787,7 @@ and expr env = function
   | Postfix (e, _) | Prefix (_, e) | Unary (_, e) -> expr env e
   | Infix (e1, _op, e2) -> exprs env [e1;e2]
   | Conditional (e1, e2, e3) -> exprs env [e1;e2;e3]
+  | SwitchE (_tok, e, _cases) -> expr env e
   | AssignOp (e1, _op, e2) -> exprs env [e1;e2]
   | Assign (e1, _tok, e2) -> exprs env [e1;e2]
   | TypedMetavar (_ident, _typ) -> ()

--- a/lang_java/parsing/ast_java.ml
+++ b/lang_java/parsing/ast_java.ml
@@ -212,6 +212,8 @@ and expr =
   | Prefix of AST_generic_.incr_decr wrap * expr
   | Infix of expr * AST_generic_.operator wrap * expr
 
+  | SwitchE of tok * expr * (cases * stmts) list (* TODO bracket *)
+
   (* usually just a single typ, but can also have intersection type t1 & t2 *)
   | Cast of typ list1 bracket * expr
 

--- a/lang_java/parsing/visitor_java.ml
+++ b/lang_java/parsing/visitor_java.ml
@@ -230,6 +230,13 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
       | InstanceOf (v1, v2) -> let v1 = v_expr v1 and v2 = v_ref_type v2 in ()
       | Conditional (v1, v2, v3) ->
           let v1 = v_expr v1 and v2 = v_expr v2 and v3 = v_expr v3 in ()
+      | SwitchE (v0, v1, v2) ->
+          let v0 = v_info v0 in
+          let v1 = v_expr v1
+          and v2 =
+            v_list
+              (fun (v1, v2) -> let v1 = v_cases v1 and v2 = v_stmts v2 in ()) v2
+          in ()
       | AssignOp (v1, v2, v3) ->
           let v1 = v_expr v1 and v2 = v_wrap v_arith_op v2 and v3 = v_expr v3 in ()
       | Assign (v1, v2, v3) ->


### PR DESCRIPTION
Java allows switch expressions as well as switch statements. In the Java AST, to keep the AST clean, we separate this out as SwitchE vs Switch. When this reaches the generic AST, we will instead wrap Switch as an expression.

Test plan: see corresponding semgrep PR https://github.com/returntocorp/semgrep/pull/2975