### PR TITLE
Separate out InterpolatedElements from the rest of the string

### DIFF
--- a/lang_ruby/analyze/il_ruby_build.ml
+++ b/lang_ruby/analyze/il_ruby_build.ml
@@ -800,7 +800,7 @@ and construct_explicit_regexp acc pos re_interp mods : stmt acc * expr =
 and refactor_interp_string acc istr pos =
   let refactor_contents acc : Ast.interp -> stmt acc * expr = function
     | Ast.StrChars (s, _t) -> acc, ELit (String s)
-    | Ast.StrExpr ast_e ->
+    | Ast.StrExpr (_l, ast_e, _r) ->
         let acc, e = refactor_expr acc ast_e in
         make_call_expr acc (Some e) (ID_MethodName "to_s") [] None pos
   in

--- a/lang_ruby/parsing/ast_ruby.ml
+++ b/lang_ruby/parsing/ast_ruby.ml
@@ -264,7 +264,7 @@ and string_kind =
 (* interpolated strings (a.k.a encapsulated/template strings) *)
 and interp =
   | StrChars of string wrap
-  | StrExpr of expr
+  | StrExpr of expr bracket
 
 (* ------------------------------------------------------------------------- *)
 (* Method name *)

--- a/lang_ruby/parsing/parser_ruby.dyp
+++ b/lang_ruby/parsing/parser_ruby.dyp
@@ -614,7 +614,7 @@ interp_code:
         in
           match ss with
           | [] -> tl
-          | x::_ -> StrExpr (mk_block ss)::tl
+          | x::_ -> StrExpr (fake "#{", mk_block ss, fake "}")::tl
       }
 
   | T_INTERP_END<s,pos>


### PR DESCRIPTION
Adding this to ruby to pass a test, though we should probably clean up our interpolated concat generally