### PR TITLE
Show exact termination status in Parallel.invoke.

### DIFF
--- a/commons_core/dune
+++ b/commons_core/dune
@@ -4,5 +4,6 @@
  (libraries
    ANSITerminal
    commons
+   ounit2
  )
 )

--- a/commons_core/signal.ml
+++ b/commons_core/signal.ml
@@ -1,0 +1,57 @@
+(*
+   Utilities to deal with signal numbers.
+*)
+
+let known_signals = [
+  Sys.sigabrt, "sigabrt", "Abnormal termination";
+  Sys.sigalrm, "sigalrm", "Timeout";
+  Sys.sigfpe, "sigfpe", "Arithmetic exception";
+  Sys.sighup, "sighup", "Hangup on controlling terminal";
+  Sys.sigill, "sigill", "Invalid hardware instruction";
+  Sys.sigint, "sigint", "Interactive interrupt (ctrl-C)";
+  Sys.sigkill, "sigkill", "Termination (cannot be ignored)";
+  Sys.sigpipe, "sigpipe", "Broken pipe";
+  Sys.sigquit, "sigquit", "Interactive termination";
+  Sys.sigsegv, "sigsegv", "Invalid memory reference";
+  Sys.sigterm, "sigterm", "Termination";
+  Sys.sigusr1, "sigusr1", "Application-defined signal 1";
+  Sys.sigusr2, "sigusr2", "Application-defined signal 2";
+  Sys.sigchld, "sigchld", "Child process terminated";
+  Sys.sigcont, "sigcont", "Continue";
+  Sys.sigstop, "sigstop", "Stop";
+  Sys.sigtstp, "sigtstp", "Interactive stop";
+  Sys.sigttin, "sigttin", "Terminal read from background process";
+  Sys.sigttou, "sigttou", "Terminal write from background process";
+  Sys.sigvtalrm, "sigvtalrm", "Timeout in virtual time";
+  Sys.sigprof, "sigprof", "Profiling interrupt";
+  Sys.sigbus, "sigbus", "Bus error";
+
+  (* Since OCaml 4.03 *)
+  Sys.sigpoll, "sigpoll", "Pollable event";
+  Sys.sigsys, "sigsys", "Bad argument to routine";
+  Sys.sigtrap, "sigtrap", "Trace/breakpoint trap";
+  Sys.sigurg, "sigurg", "Urgent condition on socket";
+  Sys.sigxcpu, "sigxcpu", "Timeout in cpu time";
+  Sys.sigxfsz, "sigxfsz", "File size limit exceeded";
+]
+
+let signal_tbl = lazy (
+  let tbl = Hashtbl.create 100 in
+  List.iter (fun (id, name, descr) ->
+    Hashtbl.replace tbl id (name, descr)
+  ) known_signals;
+  tbl
+)
+
+let get_info id =
+  Hashtbl.find_opt (Lazy.force signal_tbl) id
+
+let get_name id =
+  match get_info id with
+  | None -> None
+  | Some (name, _) -> Some name
+
+let get_descr id =
+  match get_info id with
+  | None -> None
+  | Some (_, descr) -> Some descr

--- a/commons_core/signal.mli
+++ b/commons_core/signal.mli
@@ -1,0 +1,12 @@
+(*
+   Utilities to deal with signal numbers.
+*)
+
+(* Return the name and description of a signal, if known. *)
+val get_info : int -> (string * string) option
+
+(* Return the name of a signal, if known. *)
+val get_name : int -> string option
+
+(* Return the name of a signal, if known. *)
+val get_descr : int -> string option

--- a/commons_core/unit_commons_core.ml
+++ b/commons_core/unit_commons_core.ml
@@ -1,0 +1,57 @@
+(*
+   Test suite for this folder.
+*)
+
+open Printf
+open OUnit
+
+let test_parallel_invoke_res () =
+  assert_equal true ((Parallel.invoke (fun x -> x + x) 1) () = 2)
+
+let test_parallel_invoke_exn () =
+  try
+    (Parallel.invoke (fun _ -> if true then raise Exit) ()) ();
+    assert false
+  with _unmatchable_exception ->
+    ()
+
+let test_parallel_invoke_crash () =
+  assert_equal true (
+    try
+      (Parallel.invoke
+         (fun _ ->
+            (*
+               Killing self with sigsegv appears to not work in native code,
+               but other signals cause process termination as expected.
+               See discussion started at
+               https://discuss.ocaml.org/t/delivering-sigsegv-to-self-in-native-code/7837
+            *)
+            Unix.kill (Unix.getpid ()) Sys.sigterm
+         ) ()) ();
+      eprintf "Parallel.invoke should have raised an exception.\n%!";
+      false
+    with
+    | Failure errmsg ->
+        (try
+           Scanf.sscanf errmsg
+             "process %i was killed by signal sigterm: Termination"
+             (fun _pid -> ());
+           true
+         with _ ->
+           eprintf "Unexpected error message: %s\n%!" errmsg;
+           false
+        )
+    | e ->
+        eprintf "Not the exception we were expecting: %s\n%!"
+          (Printexc.to_string e);
+        false
+  )
+
+let unittest =
+  "commons_core" >::: [
+    "parallel" >::: [
+      "invoke res" >:: test_parallel_invoke_res;
+      "invoke exn" >:: test_parallel_invoke_exn;
+      "invoke crash" >:: test_parallel_invoke_crash;
+    ]
+  ]

--- a/commons_core/unit_commons_core.mli
+++ b/commons_core/unit_commons_core.mli
@@ -1,0 +1,6 @@
+(*
+   Testsuite for this directory.
+   This is modeled after other test suites in pfff. See for example
+   Unit_program_lang.
+*)
+val unittest: OUnit.test

--- a/dune
+++ b/dune
@@ -2,7 +2,7 @@
  (dev
   ; TODO :standard is
   ; -w @1..3@5..28@30..39@43@46..47@49..57@61..62-40 -strict-sequence -strict-formats -short-paths -keep-locs
-  (flags (-w +a-4-6-7-29-41-44-45-48-52-67-58 -warn-error +a)))
+  (flags (-w +a-4-6-7-29-40-41-42-44-45-48-52-67-58 -warn-error +a)))
  )
 
 

--- a/tests/Test.ml
+++ b/tests/Test.ml
@@ -52,6 +52,7 @@ let test regexp =
     "all" >::: [
 
       (* general tests *)
+      Unit_commons_core.unittest;
       Unit_program_lang.unittest;
       Unit_graph_code.unittest ~graph_of_string;
 


### PR DESCRIPTION
I was observing segfaults in some subprocesses of semgrep-core but eventually found out semgrep was calling an old version in `semgrep/semgrep/semgrep/bin/semgrep-core`. The recent version doesn't have those segfaults.

Anyway, this lead me to checking the process status in `Parallel.invoke`. I didn't find an easy way to print signal names, so I added that too. It's strange that it's not part of the `Sys` module of the standard library. Maybe I missed something, maybe we should suggest it.

I haven't tested this stuff yet. I should add something like a unit test in which a child process dies with a segfault on purpose.

I also disabled warnings 40 and 42 in the pfff build because it's been working well without them in the rest of semgrep:
```
    40   Constructor or label name used out of scope.
    42   Disambiguated constructor or label name.
```
