### PR TITLE
Parse arrays containing ellipses

### DIFF
--- a/lang_php/parsing/parser_php.mly
+++ b/lang_php/parsing/parser_php.mly
@@ -1119,7 +1119,7 @@ assignment_list_element:
 
 array_pair_list: array_pair_list_rev { List.rev $1 }
 array_pair:
- | expr                    { (ArrayExpr $1) }
+ | expr_or_dots                    { (ArrayExpr $1) }
  | TAND expr               { (ArrayRef ($1,$2)) }
  | expr "=>" expr          { (ArrayArrowExpr($1,$2,$3)) }
  | expr "=>" TAND expr { (ArrayArrowRef($1,$2,$3,$4)) }


### PR DESCRIPTION
Test plan: `semgrep-core -dump_pattern tests/php/dots_array.sgrep -lang php` (see semgrep PR: https://github.com/returntocorp/semgrep/pull/3069)