### PR TITLE
tests: Fix hardcoded "/tmp"

### DIFF
--- a/lang_python/parsing/Parsing_hacks_python.ml
+++ b/lang_python/parsing/Parsing_hacks_python.ml
@@ -13,7 +13,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
  * license.txt for more details.
- *)
+*)
 (*e: pad/r2c copyright *)
 
 module T = Parser_python

--- a/tests/Test.ml
+++ b/tests/Test.ml
@@ -30,9 +30,10 @@ let action = ref ""
 (*****************************************************************************)
 
 let graph_of_string str =
+  let tmpdir = Filename.get_temp_dir_name () in
   let tmpfile = Parse_php.tmp_php_file_from_string str in
   let (g, _stat) = Graph_code_php.build
-      ~verbose:false ~logfile:"/dev/null" "/tmp" [tmpfile] in
+      ~verbose:false ~logfile:"/dev/null" tmpdir [tmpfile] in
   g
 
 (*****************************************************************************)


### PR DESCRIPTION
This fixes Pfff tests on MacOS 11.