### PR TITLE
Add helpers for js/typescript AST

### DIFF
--- a/lang_python/parsing/Parsing_hacks_python.ml
+++ b/lang_python/parsing/Parsing_hacks_python.ml
@@ -13,7 +13,7 @@
  * WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
  * license.txt for more details.
- *)
+*)
 (*e: pad/r2c copyright *)
 
 module T = Parser_python


### PR DESCRIPTION
This adds a hack to convert a `parameter` to a `pattern`. They use the same syntax but their types don't match exactly.