### PR TITLE
commons: Add dbe_of_filename_many_ext_opt

### DIFF
--- a/commons/common2.ml
+++ b/commons/common2.ml
@@ -2133,6 +2133,16 @@ let dbe_of_filename_noext_ok file =
   let base = Filename.basename file in
   dir, fileprefix base, filesuffix base
 
+let dbe_of_filename_many_ext_opt file =
+  let re_be = Str.regexp "\\([^.]*\\)\\.\\(.*\\)" in
+  let dir = Filename.dirname file in
+  let base = Filename.basename file in
+  if Str.string_match re_be base 0
+  then
+    let (b, e) = matched2 base in
+    Some (dir, b, e)
+  else
+    None
 
 let replace_ext file oldext newext =
   let (d,b,e) = dbe_of_filename file in

--- a/commons/common2.mli
+++ b/commons/common2.mli
@@ -853,6 +853,15 @@ val dbe_of_filename_nodot : filename -> string * string * string
 val dbe_of_filename_safe :
   filename -> (string * string * string,  string * string) either
 val dbe_of_filename_noext_ok : filename -> string * string * string
+(** [dbe_of_filename_many_ext_opt filename] returns [Some (d,b,e)], where
+ * [d] is the directory path, and [b ^ "." ^ e] is the base name, where
+ * [b] contains no period '.' characters. If this split is not possible,
+ * the result is [None].
+ * E.g.:
+ *     dbe_of_filename_many_ext_opt "foo.test.yaml" = Some (".", "foo", "test.yaml")
+ *     dbe_of_filename_many_ext_opt "foo"           = None
+*)
+val dbe_of_filename_many_ext_opt : filename -> (dirname * string * string) option
 
 val filename_of_dbe : string * string * string -> filename
 


### PR DESCRIPTION
Similar to dbe_of_filename_noext_ok but returns all the extensions in the file name instead of just the last one. It is to be used for semgrep-core -test_rules.