### PR TITLE
[Scala] support for scala 2 symbol literals, e.g., 'foo

### DIFF
--- a/lang_scala/parsing/AST_scala.ml
+++ b/lang_scala/parsing/AST_scala.ml
@@ -157,6 +157,8 @@ type literal =
   | Char   of string wrap
   | String of string wrap
   | Bool of bool wrap
+  (* the string does not contain the ' *)
+  | Symbol of string wrap
   (* scala3: not in simple_literal *)
   | Null of tok
   (* this forces to define type_ and pattern and expr as mutually recursive*)

--- a/lang_scala/parsing/Lexer_scala.mll
+++ b/lang_scala/parsing/Lexer_scala.mll
@@ -258,7 +258,7 @@ rule token = parse
   (* ----------------------------------------------------------------------- *)
   (* Keywords and ident *)
   (* ----------------------------------------------------------------------- *)
-  | "'" (idrest as s) { SymbolLiteral(s, tokinfo lexbuf) }
+  | "'" (plainid as s) { SymbolLiteral(s, tokinfo lexbuf) }
 
   (* keywords *)
   | id_lower as s

--- a/lang_scala/parsing/Lexer_scala.mll
+++ b/lang_scala/parsing/Lexer_scala.mll
@@ -258,6 +258,7 @@ rule token = parse
   (* ----------------------------------------------------------------------- *)
   (* Keywords and ident *)
   (* ----------------------------------------------------------------------- *)
+  | "'" (idrest as s) { SymbolLiteral(s, tokinfo lexbuf) }
 
   (* keywords *)
   | id_lower as s

--- a/lang_scala/parsing/Lexer_scala.mll
+++ b/lang_scala/parsing/Lexer_scala.mll
@@ -406,6 +406,7 @@ and string buf = parse
 (*****************************************************************************)
 (* String interpolation *)
 (*****************************************************************************)
+(* coupling: mostly same code in in_interpolated_triple below *)
 and in_interpolated_double = parse
   | '"'  { pop_mode(); T_INTERPOLATED_END (tokinfo lexbuf) }
 

--- a/lang_scala/parsing/Parser_scala_recursive_descent.ml
+++ b/lang_scala/parsing/Parser_scala_recursive_descent.ml
@@ -881,10 +881,8 @@ let literal ?(isNegated=None) ?(inPattern=false) in_ : literal  =
         (Interpolated ((s, ii), xs, endt))
     (* scala3: unsupported, deprecated in 2.13.0 *)
     (* ast: Apply(scalaDot(Symbol, List(finish(in.strVal)) *)
-    | SymbolLiteral(_, _) ->
-        (* not even generated in the Lexer_scala.mll for now and
-         * deprecated construct anyway. *)
-        raise Impossible
+    | SymbolLiteral(s, ii) ->
+        finish (Symbol (s, ii))
 
     | CharacterLiteral(x, ii) ->
         (* ast: incharVal *)

--- a/tests/scala/parsing/symbol.scala
+++ b/tests/scala/parsing/symbol.scala
@@ -1,0 +1,20 @@
+// symbols are actually not supported in Scala 3 and deprecated
+// in Scala 2.13. You have to use Symbol("foo") instead of 'foo
+
+
+package com.test.scala.http
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+
+object TestRoute {
+  val testRoute: Route =
+    path("login") {
+      get {
+        parameters('test.as[String], 'redirPATH.?) {(test, redirPATH) =>
+          complete(StatusCodes.OK)
+        }
+      }
+    }
+}


### PR DESCRIPTION
This will help https://github.com/returntocorp/semgrep/issues/3261

test plan:
test file included