### PR TITLE
[Scala] parsing correctly ids in interpolated strings after a dollar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ graph: index
 # for really small changes, just push directly!
 pr:
 	git push origin `git rev-parse --abbrev-ref HEAD`
-	hub pull-request -b develop -r mjambon
+	hub pull-request -b develop -r mjambon -r IagoAbal -r emjin
 
 push:
 	git push origin `git rev-parse --abbrev-ref HEAD`

--- a/tests/scala/parsing/dollar_dollar.scala
+++ b/tests/scala/parsing/dollar_dollar.scala
@@ -1,0 +1,9 @@
+object Test {
+  def print(): String = {
+    var XXX = 1
+    s"$$XXX"
+  }
+    def main(args: Array[String]): Unit = {
+      println(print())
+   }
+}

--- a/tests/scala/parsing/dollar_id_dollar.scala
+++ b/tests/scala/parsing/dollar_id_dollar.scala
@@ -1,0 +1,16 @@
+import scala.util.{Try,Success,Failure}
+object Test {
+    def divideXByY(x: Int, y: Int): Try[Int] = {
+      Try(x / y)
+    }
+  def print(): String = {
+      val UsdSymbol = "$"
+    // According to official grammar, this should be a parse error
+    // because UsdSymbol$ is a valid identifier ($ is ok in id)
+    // but the Scala compilers seems to parse it correctly ...
+      s" $UsdSymbol${divideXByY(1,0).getOrElse("")}"
+    }
+    def main(args: Array[String]): Unit = {
+      println(print())
+   }
+}

--- a/tests/scala/parsing/dollar_upper.scala
+++ b/tests/scala/parsing/dollar_upper.scala
@@ -1,0 +1,7 @@
+object Foo {
+  def visitExpr(expr: Expr)
+               (implicit scope: ValScope, fileScope: FileScope): Val = try expr match{
+    case $(offset) => foo
+  }
+
+}


### PR DESCRIPTION
This closes https://github.com/returntocorp/semgrep/issues/3270

test plan:
test file included