### PR TITLE
When -sgrep_mode is used in Java, parse sgrep files

### DIFF
--- a/lang_java/parsing/test_parsing_java.ml
+++ b/lang_java/parsing/test_parsing_java.ml
@@ -68,8 +68,15 @@ let test_lexer file =
   done
 
 let test_dump file =
-  let ast = Parse_java.parse_program file in
-  let s = Ast_java.show_program ast in
+  let s =
+    if !Flag_parsing.sgrep_mode 
+    then 
+       let ast = Parse_java.any_of_string (Common.read_file file) in
+       Ast_java.show_any ast
+    else
+       let ast = Parse_java.parse_program file in
+       Ast_java.show_program ast
+  in
   pr s
 
 let test_visitor file =

--- a/lang_java/parsing/test_parsing_java.ml
+++ b/lang_java/parsing/test_parsing_java.ml
@@ -69,13 +69,13 @@ let test_lexer file =
 
 let test_dump file =
   let s =
-    if !Flag_parsing.sgrep_mode 
-    then 
-       let ast = Parse_java.any_of_string (Common.read_file file) in
-       Ast_java.show_any ast
+    if !Flag_parsing.sgrep_mode
+    then
+      let ast = Parse_java.any_of_string (Common.read_file file) in
+      Ast_java.show_any ast
     else
-       let ast = Parse_java.parse_program file in
-       Ast_java.show_program ast
+      let ast = Parse_java.parse_program file in
+      Ast_java.show_program ast
   in
   pr s
 


### PR DESCRIPTION
Use any_of_string instead of parse_program when running with -sgrep_mode

Test plan:

pfff -dump_java tests/java/$X.sgrep -lang java -sgrep_mode