### PR TITLE
Refactor atom type in Ruby and Scala

### DIFF
--- a/h_program-lang/Parse_info.mli
+++ b/h_program-lang/Parse_info.mli
@@ -124,7 +124,7 @@ val lexical_error: string -> Lexing.lexbuf -> unit
 (*e: signature [[Parse_info.lexical_error]] *)
 
 (*****************************************************************************)
-(* Info accessors *)
+(* Info accessors and builders *)
 (*****************************************************************************)
 
 (*s: signature [[Parse_info.fake_token_location]] *)
@@ -139,6 +139,7 @@ val fake_bracket: 'a -> t * 'a * t
 val unbracket: t * 'a * t -> 'a
 val sc: t
 
+val mk_info_of_loc: token_location -> t
 
 val is_fake: t -> bool
 (*s: signature [[Parse_info.first_loc_of_file]] *)
@@ -266,6 +267,9 @@ val tok_add_s: string -> t -> t
 (*e: signature [[Parse_info.tok_add_s]] *)
 (* used mainly by tree-sitter based parsers in semgrep *)
 val combine_infos: t -> t list -> t
+(* this function assumes the full content of the token is on the same
+ * line, otherwise the line/col of the result might be wrong *)
+val split_info_at_pos: int -> t -> t * t
 
 (*s: signature [[Parse_info.tokenize_all_and_adjust_pos]] *)
 (* to be used by the lexer *)

--- a/lang_ruby/analyze/highlight_ruby.ml
+++ b/lang_ruby/analyze/highlight_ruby.ml
@@ -96,7 +96,9 @@ let visit_program ~tag_hook _prefs (_program, toks) =
         tag ii Number
     | T.K_NIL ii ->
         tag ii Null
-    | T.T_ATOM (_, ii) | T.T_ATOM_BEG ii ->
+    | T.T_ATOM (ii1, (_, ii2)) ->
+        tag ii1 Atom; tag ii2 Atom
+    | T.T_ATOM_BEG ii ->
         tag ii Atom
     | T.T_SINGLE_STRING (_, ii)
     | T.T_INTERP_STR (_, ii)

--- a/lang_ruby/parsing/ast_ruby.ml
+++ b/lang_ruby/parsing/ast_ruby.ml
@@ -251,11 +251,10 @@ and literal =
 
   | Nil of tok
 
-and atom =
-  (* the atom string includes the ':' prefix *)
+and atom = tok (* ':' *) * atom_kind
+and atom_kind =
   | AtomSimple of string wrap
-  (* less: tok for ':' ? *)
-  | AtomFromString of interp list bracket (* '' or "" *)
+  | AtomFromString of interp list bracket (* '' or "" or %i() *)
 
 and string_kind =
   | Single of string wrap
@@ -482,4 +481,4 @@ let opt_stmts_to_stmts = function
 (* x: v  <=>  :x => v  in Ruby in hash and calls *)
 let keyword_arg_to_expr id tk arg =
   let (s, t) = id in
-  Binop (((Atom (AtomSimple ((":"^s), t)))), (Op_ASSOC, tk), arg)
+  Binop (((Atom (tk, AtomSimple ((s), t)))), (Op_ASSOC, tk), arg)

--- a/lang_ruby/parsing/lexer_ruby.mll
+++ b/lang_ruby/parsing/lexer_ruby.mll
@@ -716,7 +716,7 @@ and atom t state = parse
   | '[' ']' ('='?) (* these can only appear together like this (I think) *)
   | '`'
     { end_state_unless_afterdef state;
-      T_ATOM((contents_of_str (":" ^ str lexbuf)), (add_to_tok lexbuf t)) }
+      T_ATOM(t, (str lexbuf, tk lexbuf)) }
 
   | '$'
      { let str =
@@ -726,12 +726,12 @@ and atom t state = parse
           | _ -> assert false
         in
         end_state_unless_afterdef state;
-        T_ATOM(contents_of_str (":" ^ str), (add_to_tok lexbuf t)) }
+        T_ATOM(t, (str, tk lexbuf)) }
 
   (* regular atom (e.g., :foo), possibly prefixed with @ and suffixed with = *)
   | ('@'* id) '='?
       { end_state_unless_afterdef state;
-        T_ATOM((contents_of_str (":" ^ str lexbuf)), (add_to_tok lexbuf t)) }
+        T_ATOM(t, (str lexbuf, tk lexbuf)) }
   | '"'
       { end_state_unless_afterdef state;
         let _newt = tk lexbuf in

--- a/lang_ruby/parsing/parser_ruby.dyp
+++ b/lang_ruby/parsing/parser_ruby.dyp
@@ -192,7 +192,7 @@ and params_to_pattern xs =
 %token <string * Parse_info.t>  T_NUM
 %token <string * Parse_info.t>  T_FLOAT
 
-%token <string * Parse_info.t> T_ATOM
+%token <Parse_info.t * (string * Parse_info.t)> T_ATOM
 %token <Parse_info.t> T_ATOM_BEG
 
 %token <string * Parse_info.t> T_SINGLE_STRING
@@ -568,8 +568,10 @@ constant:
 
   | string<s>        { s }
 
-  | T_ATOM    { Atom (AtomSimple $1) }
-  | T_ATOM_BEG<pos> interp_str<istr> { Atom (AtomFromString (pos, istr, fake"\"")) }
+  | T_ATOM
+      { Atom (fst $1, AtomSimple (snd $1)) }
+  | T_ATOM_BEG<pos> interp_str<istr>
+      { Atom (pos, AtomFromString (pos, istr, fake"\"")) }
 
   | T_REGEXP<s,m,pos> { Literal(Regexp ((s,m),pos)) }
   | T_REGEXP_BEG<pos> interp_str<istr> T_REGEXP_MOD<mods, _posTODO>
@@ -1073,7 +1075,7 @@ method_kind:
 
 meth_or_atom:
     | method_name  { $1 }
-    | T_ATOM       { MethodAtom (AtomSimple $1) }
+    | T_ATOM       { MethodAtom (fst $1, AtomSimple (snd $1)) }
 
 /*(* TODO: split in scoped_id *)*/
 var_or_scoped_id:

--- a/lang_ruby/parsing/parser_ruby.mli
+++ b/lang_ruby/parsing/parser_ruby.mli
@@ -95,7 +95,7 @@ type token =
   | T_DOUBLE_BEG of Parse_info.t
   | T_SINGLE_STRING of (string * Parse_info.t)
   | T_ATOM_BEG of Parse_info.t
-  | T_ATOM of (string * Parse_info.t)
+  | T_ATOM of (Parse_info.t * (string * Parse_info.t))
   | T_FLOAT of (string * Parse_info.t)
   | T_NUM of (string * Parse_info.t)
   | T_CLASS_VAR of (string * Parse_info.t)
@@ -152,7 +152,7 @@ val pp :
    | `Obj_T_ANDOP of Parse_info.t
    | `Obj_T_ASSIGN of Parse_info.t
    | `Obj_T_ASSOC of Parse_info.t
-   | `Obj_T_ATOM of string * Parse_info.t
+   | `Obj_T_ATOM of Parse_info.t * (string * Parse_info.t)
    | `Obj_T_ATOM_BEG of Parse_info.t
    | `Obj_T_BANG of Parse_info.t
    | `Obj_T_CARROT of Parse_info.t

--- a/lang_ruby/parsing/parser_ruby_helpers.ml
+++ b/lang_ruby/parsing/parser_ruby_helpers.ml
@@ -331,7 +331,7 @@ let fix_broken_assoc l op r =
       let l' = replace_end l (Id((s,p),ik)) in
         l', Op_ASSOC, r
 *)
-    | Atom(AtomFromString(lt, sc, rt)) ->
+    | Atom(tk, AtomFromString(lt, sc, rt)) ->
         let (astr, t), rest = match List.rev sc with
           | (Ast_ruby.StrChars (s, t))::tl -> (s,t),tl
           | _ -> ("a", Parse_info.fake_info "a"),[]
@@ -341,7 +341,7 @@ let fix_broken_assoc l op r =
         then
           let s' = String.sub astr 0 (len-1) in
           let sc' = List.rev ((Ast_ruby.StrChars (s',t))::rest) in
-          let l' = replace_end l ((Atom(AtomFromString(lt, sc', rt)))) in
+          let l' = replace_end l ((Atom(tk, AtomFromString(lt, sc', rt)))) in
           l', Op_ASSOC, r
         else default
     | _ -> default

--- a/lang_ruby/parsing/token_helpers_ruby.ml
+++ b/lang_ruby/parsing/token_helpers_ruby.ml
@@ -145,7 +145,10 @@ let visitor_info_of_tok f = function
   | T_REGEXP (a,b, ii) -> T_REGEXP (a,b, f ii)
   | T_FLOAT (a, ii) -> T_FLOAT (a, f ii)
   | T_NUM (s, ii) -> T_NUM (s, f ii)
-  | T_ATOM (s, ii) -> T_ATOM (s, f ii)
+  | T_ATOM (ii1, (s, ii2)) ->
+      let ii1' = f ii1 in
+      let ii2' = f ii2 in
+      T_ATOM (ii1', (s, ii2'))
 
 
 let info_of_tok tok =

--- a/lang_scala/parsing/AST_scala.ml
+++ b/lang_scala/parsing/AST_scala.ml
@@ -157,8 +157,7 @@ type literal =
   | Char   of string wrap
   | String of string wrap
   | Bool of bool wrap
-  (* the string does not contain the ' *)
-  | Symbol of string wrap
+  | Symbol of tok (* "'" *) * string wrap
   (* scala3: not in simple_literal *)
   | Null of tok
   (* this forces to define type_ and pattern and expr as mutually recursive*)

--- a/lang_scala/parsing/Lexer_scala.mll
+++ b/lang_scala/parsing/Lexer_scala.mll
@@ -265,7 +265,11 @@ rule token = parse
   (* ----------------------------------------------------------------------- *)
   (* Keywords and ident *)
   (* ----------------------------------------------------------------------- *)
-  | "'" (plainid as s) { SymbolLiteral(s, tokinfo lexbuf) }
+  | "'" (plainid as s) {
+      let t = tokinfo lexbuf in
+      let (tcolon, trest) = PI.split_info_at_pos 1 t in
+      SymbolLiteral(tcolon, (s, trest))
+    }
 
   (* keywords *)
   | id_lower as s

--- a/lang_scala/parsing/Parser_scala_recursive_descent.ml
+++ b/lang_scala/parsing/Parser_scala_recursive_descent.ml
@@ -885,8 +885,8 @@ let literal ?(isNegated=None) ?(inPattern=false) in_ : literal  =
         (Interpolated ((s, ii), xs, endt))
     (* scala3: unsupported, deprecated in 2.13.0 *)
     (* ast: Apply(scalaDot(Symbol, List(finish(in.strVal)) *)
-    | SymbolLiteral(s, ii) ->
-        finish (Symbol (s, ii))
+    | SymbolLiteral(tcolon, id) ->
+        finish (Symbol (tcolon, id))
 
     | CharacterLiteral(x, ii) ->
         (* ast: incharVal *)

--- a/lang_scala/parsing/Token_helpers_scala.ml
+++ b/lang_scala/parsing/Token_helpers_scala.ml
@@ -70,7 +70,10 @@ let visitor_info_of_tok f = function
   | FloatingPointLiteral(x, ii) -> FloatingPointLiteral(x, f ii)
   | CharacterLiteral(x, ii) -> CharacterLiteral(x, f ii)
   | BooleanLiteral(x, ii) -> BooleanLiteral(x, f ii)
-  | SymbolLiteral(s, ii) -> SymbolLiteral(s, f ii)
+  | SymbolLiteral(ii1, (s, ii2)) ->
+      let ii1' = f ii1 in
+      let ii2' = f ii2 in
+      SymbolLiteral(ii1', (s, ii2'))
   | StringLiteral(x, ii) -> StringLiteral(x, f ii)
 
   (* tokens without values *)

--- a/lang_scala/parsing/Token_scala.ml
+++ b/lang_scala/parsing/Token_scala.ml
@@ -7,7 +7,7 @@ type token =
   | T_INTERPOLATED_END of (Parse_info.t)
   | T_DOLLAR_LBRACE of (Parse_info.t)
   | TILDE of (Parse_info.t)
-  | SymbolLiteral of (string * Parse_info.t)
+  | SymbolLiteral of (Parse_info.t * (string * Parse_info.t))
   | StringLiteral of (string * Parse_info.t)
   | Space of (Parse_info.t)
   | SUPERTYPE of (Parse_info.t)


### PR DESCRIPTION
Separate the leading special token from the symbol itself.
This will help semgrep metavariable matching on symbols.

test plan:
see related PR in semgrep