### PR TITLE
update to ppxlib 0.20.0

### DIFF
--- a/pfff.opam
+++ b/pfff.opam
@@ -38,7 +38,7 @@ depends: [
   "grain_dypgen"
   "ppx_deriving"
   "ppx_hash"
-  "ppxlib" {= "0.15.0" }
+  "ppxlib" {= "0.20.0" }
   "uutf"
   "uucp"
   "ounit2"

--- a/ppx/ppx_profiling.ml
+++ b/ppx/ppx_profiling.ml
@@ -134,7 +134,7 @@ let impl xs =
               m ^ "." ^ fname
           | [{pstr_desc =
                 Pstr_eval
-                  ({pexp_desc = Pexp_constant (Pconst_string (name, None));_},
+                  ({pexp_desc = Pexp_constant (Pconst_string (name, _loc, None));_},
                    _); _}] -> name
           | _ ->
               Location.raise_errorf ~loc
@@ -151,7 +151,7 @@ let impl xs =
                  (Exp.apply
                     (Exp.ident
                        {txt = Ldot (Lident "Common", "profile_code" ); loc})
-                    [Nolabel, Exp.constant (Pconst_string (action_name, None));
+                    [Nolabel, Exp.constant (Pconst_string (action_name, loc, None));
                      Nolabel, Exp.fun_ Nolabel None (Pat.any ())
                        (Exp.apply (Exp.ident {txt = Lident fname; loc})
                           (mk_args loc nbparams))


### PR DESCRIPTION
This is needed to be able to compile pfff (and so semgrep) with
OCaml 4.12.0 (which itself is needed to compile correctly on Homebrew
and recent macOS)

test plan:
make test