### PR TITLE
Add support for optional 'as' to re-export constructs in javascript

### DIFF
--- a/lang_js/analyze/graph_code_js.ml
+++ b/lang_js/analyze/graph_code_js.ml
@@ -362,7 +362,8 @@ and module_directive env x =
           Hashtbl.replace env.imports str2 (mk_qualified_name readable str1)
         )
       end
-  | Export (_t, name) ->
+  | Export (_t, name)
+  | ReExportNamespace (_t, _, Some name, _, _) ->
       if env.phase = Defs then begin
         let exports =
           try
@@ -372,13 +373,13 @@ and module_directive env x =
         let str = s_of_n name in
         Hashtbl.replace env.exports env.file_readable (str::exports)
       end
+  | ReExportNamespace (_t, _, None, _, _file) -> ()
   | ModuleAlias (_, name, _fileTODO) ->
       (* for now just add name as a local; anyway we do not
        * generate dependencies for fields yet
       *)
       let s = s_of_n name in
       Hashtbl.replace env.vars s true;
-  | ReExportNamespace (_t, _, _, _file) -> ()
   | ImportFile (_t, _file) -> ()
 
 and toplevels env xs = List.iter (toplevel env) xs

--- a/lang_js/parsing/ast_js.ml
+++ b/lang_js/parsing/ast_js.ml
@@ -539,8 +539,9 @@ and module_directive =
   *)
   | Import of tok * a_ident * a_ident option (* 'name1 as name2' *) * a_filename
   | Export of tok * a_ident
-  (* export * from 'foo' *)
-  | ReExportNamespace of tok * tok * tok * a_filename
+  (* export * from 'foo'
+     export * as bar from 'foo' *)
+  | ReExportNamespace of tok * tok * a_ident option * tok * a_filename
 
   (* hard to unsugar in Import because we do not have the list of names *)
   | ModuleAlias of tok * a_ident * a_filename (* import * as 'name' from 'file' *)

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -530,7 +530,7 @@ export_decl:
 
 export_names:
  | "*"           from_clause sc
-    { (fun t -> [M (ReExportNamespace (t, $1, fst $2, snd $2))]) }
+    { (fun t -> [M (ReExportNamespace (t, $1, None, fst $2, snd $2))]) }
  | export_clause from_clause sc
     { (fun _t -> []) (*TODO ReExportNames ($1, $2, $3)*) }
  | export_clause sc

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -404,8 +404,12 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
 
   and v_module_directive x =
     match x with
-    | ReExportNamespace (v1, v2, v3, v4) ->
-        v_tok v1; v_tok v2; v_tok v3; v_filename v4
+    | ReExportNamespace (v1, v2, opt_as, v4, v5) ->
+        v_tok v1; v_tok v2;
+        (match opt_as with
+         | Some name -> v_name name
+         | None -> ());
+        v_tok v4; v_filename v5
     | Import (t, v1, v2, v3) ->
         let t = v_tok t in
         let v1 = v_name v1 and v2 = v_option v_name v2 and v3 = v_filename v3 in ()


### PR DESCRIPTION
Adds support for `as foo` in
```js
export * as foo from 'bar';
```
The pfff parser wasn't updated to support this, only the tree-sitter parser.

This is part of the ecmascript 2021 draft (maybe not a draft anymore?).
https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export