### PR TITLE
parse_info: Add function to fix the location of a token

### DIFF
--- a/h_program-lang/Parse_info.ml
+++ b/h_program-lang/Parse_info.ml
@@ -706,17 +706,20 @@ let adjust_pinfo_wrt_base base_loc loc =
         loc.column;
     file    = base_loc.file; }
 
-let adjust_info_wrt_base base_loc ii =
+let fix_token_location fix ii =
   { ii with token =
               match ii.token with
               | OriginTok pi ->
-                  OriginTok(adjust_pinfo_wrt_base base_loc pi)
+                  OriginTok(fix pi)
               | ExpandedTok (pi, vpi, off) ->
-                  ExpandedTok(adjust_pinfo_wrt_base base_loc pi, vpi, off)
+                  ExpandedTok(fix pi, vpi, off)
               | FakeTokStr (s, vpi_opt) ->
                   FakeTokStr (s, vpi_opt)
               | Ab -> Ab
   }
+
+let adjust_info_wrt_base base_loc ii =
+  fix_token_location (adjust_pinfo_wrt_base base_loc) ii
 
 (*****************************************************************************)
 (* Error location report *)

--- a/h_program-lang/Parse_info.mli
+++ b/h_program-lang/Parse_info.mli
@@ -303,6 +303,12 @@ val complete_token_location_large :
   Common.filename -> (int -> (int * int))  -> token_location -> token_location
 (*e: signature [[Parse_info.complete_token_location_large]] *)
 
+(** Fix the location info in a token. *)
+val fix_token_location : (token_location -> token_location) -> token_mutable -> token_mutable
+
+(** See [adjust_info_wrt_base]. *)
+val adjust_pinfo_wrt_base : token_location -> token_location -> token_location
+
 (** [adjust_info_wrt_base base_loc tok], where [tok] represents a location
   * relative to [base_loc], returns the same [tok] but with an absolute
   * {! token_location}. This is useful for fixing parse info after


### PR DESCRIPTION
Plus, export `adjust_pinfo_wrt_base`.