### PR TITLE
[C/C++] Prevent stack overflows with tailrec functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install pfff
       run: |
         opam init
-        ./scripts/install-opam-deps --ocaml-version 4.09.1
+        ./scripts/install-opam-deps --ocaml-version 4.10.2
         opam install -y pfff
     - name: Run Tests
       run: eval $(opam env); dune build && dune runtest -f

--- a/commons/Common.ml
+++ b/commons/Common.ml
@@ -747,6 +747,7 @@ let rec filter_some = function
   | None :: l -> filter_some l
   | Some e :: l -> e :: filter_some l
 
+(* Tail-recursive to prevent stack overflows. *)
 let map_filter f xs =
   List.fold_left (fun acc x ->
     match f x with
@@ -1148,9 +1149,10 @@ let erase_this_temp_file f =
 (* List *)
 (*****************************************************************************)
 
+(* Safe implementation that prevents stack overflows. *)
 let map f xs =
   (* Since map is such a frequently used function we try to make it fast for
-   * small/medium-sized lists too. Inspired by Jane Street's Base library. *)
+   * small/medium-sized lists. Inspired by Jane Street's Base library. *)
   let max_rec_count = 1000 in
   let rec count_map i = function
     | [] -> []
@@ -1260,6 +1262,7 @@ let sort_by_key_highfirst xs =
 let sort_by_key_lowfirst xs =
   sort_prof (fun (k1,_v1) (k2,_v2) -> compare k1 k2) xs
 
+(* Tail-recursive to prevent stack overflows. *)
 let flatten xss =
   xss
   |> List.fold_left (fun acc xs ->

--- a/commons/Common.mli
+++ b/commons/Common.mli
@@ -148,6 +148,10 @@ val cmd_to_list_and_status:
 (*s: signature [[Common.null]] *)
 val null : 'a list -> bool
 (*e: signature [[Common.null]] *)
+
+(** Same as [List.map] but tail recursive. *)
+val map : ('a -> 'b) -> 'a list -> 'b list
+
 (*s: signature [[Common.exclude]] *)
 val exclude : ('a -> bool) -> 'a list -> 'a list
 (*e: signature [[Common.exclude]] *)
@@ -158,6 +162,7 @@ val sort : 'a list -> 'a list
 val uniq_by: ('a -> 'a -> bool) -> 'a list -> 'a list
 
 (*s: signature [[Common.map_filter]] *)
+(** Same as [List.filter_map] but tail recursive. *)
 val map_filter : ('a -> 'b option) -> 'a list -> 'b list
 (*e: signature [[Common.map_filter]] *)
 (*s: signature [[Common.find_opt]] *)
@@ -226,6 +231,9 @@ val group_by_mapped_key: ('a -> 'b) -> 'a list -> ('b * 'a list) list
 (*s: signature [[Common.group_by_multi]] *)
 val group_by_multi: ('a -> 'b list) -> 'a list -> ('b * 'a list) list
 (*e: signature [[Common.group_by_multi]] *)
+
+(** Same as [List.flatten] but tail recursive. *)
+val flatten : 'a list list -> 'a list
 
 (*s: type [[Common.stack]] *)
 type 'a stack = 'a list

--- a/commons/OCaml.ml
+++ b/commons/OCaml.ml
@@ -263,7 +263,7 @@ let vof_string x =
 let vof_bool b =
   VBool b
 let vof_list ofa x =
-  VList (List.map ofa x)
+  VList (Common.map ofa x)
 let vof_option ofa x =
   match x with
   | None -> VNone
@@ -314,7 +314,7 @@ let option_ofv a__of_sexp sexp = match sexp with
 (* Format pretty printers *)
 (*****************************************************************************)
 let add_sep xs =
-  xs |> List.map (fun x -> Right x) |> Common2.join_gen (Left ())
+  xs |> Common.map (fun x -> Right x) |> Common2.join_gen (Left ())
 
 (*
  * OCaml value pretty printer. A similar functionnality is provided by

--- a/commons/common2.ml
+++ b/commons/common2.ml
@@ -3819,6 +3819,7 @@ let rec list_init = function
  *   let last l = List.hd (last_n 1 l)
 *)
 
+(* Tail-recursive to prevent stack overflows. *)
 let join_gen a xs =
   let rec aux acc = function
     | [] -> List.rev acc

--- a/commons/common2.ml
+++ b/commons/common2.ml
@@ -3819,11 +3819,13 @@ let rec list_init = function
  *   let last l = List.hd (last_n 1 l)
 *)
 
-let rec join_gen a = function
-  | [] -> []
-  | [x] -> [x]
-  | x::xs -> x::a::(join_gen a xs)
-
+let join_gen a xs =
+  let rec aux acc = function
+    | [] -> List.rev acc
+    | [x] -> List.rev (x::acc)
+    | x::xs -> aux (a::x::acc) xs
+  in
+  aux [] xs
 
 (* todo: foldl, foldr (a more consistent foldr) *)
 

--- a/lang_c/parsing/ast_c_build.ml
+++ b/lang_c/parsing/ast_c_build.ml
@@ -316,7 +316,7 @@ and initialiser env x =
              )) xs)
        | _ ->
            A.ArrayInit (bracket_keep (fun xs ->
-             xs |> uncomma |> List.map (function
+             xs |> uncomma |> Common.map (function
                (* less: todo? *)
                | InitIndexOld ((_, idx, _), ini) ->
                    Some (expr env idx), initialiser env ini

--- a/lang_c/parsing/parse_c.ml
+++ b/lang_c/parsing/parse_c.ml
@@ -28,7 +28,7 @@ let logger = Logging.get_logger [__MODULE__]
 let parse file =
   let (ast2, stat) = Parse_cpp.parse_with_lang ~lang:Flag_parsing_cpp.C file in
   let ast = ast2 |> List.map fst in
-  let toks = ast2 |> List.map snd |> List.flatten in
+  let toks = ast2 |> List.concat_map snd in
   let ast, stat =
     try (Ast_c_build.program ast), stat
     with exn ->

--- a/lang_cpp/parsing/cst_cpp.ml
+++ b/lang_cpp/parsing/cst_cpp.ml
@@ -833,7 +833,7 @@ let noQscope = []
 (* Wrappers *)
 (*****************************************************************************)
 let unwrap x = fst x
-let uncomma xs = List.map fst xs
+let uncomma xs = Common.map fst xs
 let unparen (_, x, _) = x
 let unbrace (_, x, _) = x
 

--- a/lang_cpp/parsing/parsing_hacks.ml
+++ b/lang_cpp/parsing/parsing_hacks.ml
@@ -83,7 +83,8 @@ let filter_comment_stuff xs =
 let insert_virtual_positions l =
   let strlen x = String.length (Parse_info.str_of_info x) in
   let rec loop acc prev offset = function
-      [] -> List.rev acc
+    (* Tail-recursive to prevent stack overflows. *)
+    | [] -> List.rev acc
     | x::xs ->
         let ii = TH.info_of_tok x in
         let inject pi =
@@ -100,7 +101,8 @@ let insert_virtual_positions l =
             (loop acc' prev (offset + (strlen ii)) xs)
         | Parse_info.Ab -> failwith "abstract not expected" in
   let rec skip_fake acc = function
-      [] -> List.rev acc
+    (* Tail-recursive to prevent stack overflows. *)
+    | [] -> List.rev acc
     | x::xs ->
         let ii = TH.info_of_tok x in
         match ii.Parse_info.token with

--- a/lang_cpp/parsing/parsing_hacks_define.ml
+++ b/lang_cpp/parsing/parsing_hacks_define.ml
@@ -98,6 +98,7 @@ let pos ii = Parse_info.string_of_info ii
  * and replace \ with TCommentSpace
 *)
 let rec define_line_1 acc xs =
+  (* Tail-recursive to prevent stack overflows. *)
   match xs with
   | [] -> List.rev acc
   | (TDefine ii as x)::xs ->
@@ -110,6 +111,7 @@ let rec define_line_1 acc xs =
       define_line_1 (x::acc) xs
 
 and define_line_2 acc line lastinfo xs =
+  (* Tail-recursive to prevent stack overflows. *)
   match xs with
   | [] ->
       (* should not happened, should meet EOF before *)
@@ -137,6 +139,7 @@ let define_line xs = define_line_1 [] xs
 
 (* put the TIdent_Define and TOPar_Define *)
 let define_ident xs =
+  (* Tail-recursive to prevent stack overflows. *)
   let rec aux acc xs =
     match xs with
     | [] -> List.rev acc

--- a/lang_cpp/parsing/parsing_hacks_define.ml
+++ b/lang_cpp/parsing/parsing_hacks_define.ml
@@ -97,76 +97,88 @@ let pos ii = Parse_info.string_of_info ii
 (* put the TCommentNewline_DefineEndOfMacro at the good place
  * and replace \ with TCommentSpace
 *)
-let rec define_line_1 xs =
+let rec define_line_1 acc xs =
   match xs with
-  | [] -> []
+  | [] -> List.rev acc
   | (TDefine ii as x)::xs ->
       let line = PI.line_of_info ii in
-      x::define_line_2 line ii xs
+      define_line_2 (x::acc) line ii xs
   | TCppEscapedNewline ii::xs ->
       pr2 (spf "WEIRD: a \\ outside a #define at %s" (pos ii));
-      (* fresh_tok*) TCommentSpace ii::define_line_1 xs
+      define_line_1 ((* fresh_tok*) TCommentSpace ii::acc) xs
   | x::xs ->
-      x::define_line_1 xs
+      define_line_1 (x::acc) xs
 
-and define_line_2 line lastinfo xs =
+and define_line_2 acc line lastinfo xs =
   match xs with
   | [] ->
       (* should not happened, should meet EOF before *)
       pr2 "PB: WEIRD in Parsing_hack_define.define_line_2";
-      mark_end_define lastinfo::[]
+      List.rev (mark_end_define lastinfo::acc)
   | x::xs ->
       let line' = TH.line_of_tok x in
       let info = TH.info_of_tok x in
 
       (match x with
        | EOF ii ->
-           mark_end_define lastinfo::EOF ii::define_line_1 xs
+           define_line_1 (EOF ii::mark_end_define lastinfo::acc) xs
        | TCppEscapedNewline ii ->
            if (line' <> line)
            then pr2 "PB: WEIRD: not same line number";
-           (* fresh_tok*) TCommentSpace ii::define_line_2 (line+1) info xs
+           define_line_2 ((* fresh_tok*) TCommentSpace ii::acc) (line+1) info xs
        | x ->
            if line' = line
-           then x::define_line_2 line info xs
+           then define_line_2 (x::acc) line info xs
            else
-             mark_end_define lastinfo::define_line_1 (x::xs)
+             define_line_1 (mark_end_define lastinfo::acc) (x::xs)
       )
+
+let define_line xs = define_line_1 [] xs
 
 (* put the TIdent_Define and TOPar_Define *)
-let rec define_ident xs =
-  match xs with
-  | [] -> []
-  | (TDefine ii as x)::xs ->
-      x::
-      (match xs with
-       | (TCommentSpace _ as x)::TIdent (s,i2)::(* no space *)TOPar (i3)::xs ->
-           (* if TOPar_Define is just next to the ident (no space), then
-            * it's a macro-function. We change the token to avoid
-            * ambiguity between '#define foo(x)'  and   '#define foo   (x)'
-           *)
-           x
-           ::Hack.fresh_tok (TIdent_Define (s,i2))
-           ::Hack.fresh_tok (TOPar_Define i3)
-           ::define_ident xs
+let define_ident xs =
+  let rec aux acc xs =
+    match xs with
+    | [] -> List.rev acc
+    | (TDefine ii as x)::xs ->
+        (match xs with
+         | (TCommentSpace _ as x1)::TIdent (s,i2)::(* no space *)TOPar (i3)::xs ->
+             (* if TOPar_Define is just next to the ident (no space), then
+              * it's a macro-function. We change the token to avoid
+              * ambiguity between '#define foo(x)'  and   '#define foo   (x)'
+             *)
+             let acc' =
+               Hack.fresh_tok (TOPar_Define i3)
+               ::Hack.fresh_tok (TIdent_Define (s,i2))
+               ::x1
+               ::x
+               ::acc
+             in
+             aux acc' xs
 
-       | (TCommentSpace _ as x)::TIdent (s,i2)::xs ->
-           x
-           ::Hack.fresh_tok (TIdent_Define (s,i2))
-           ::define_ident xs
-       | _ ->
-           pr2 (spf "WEIRD #define body, at %s" (pos ii));
-           define_ident xs
-      )
-  | x::xs ->
-      x::define_ident xs
+         | (TCommentSpace _ as x1)::TIdent (s,i2)::xs ->
+             let acc' =
+               Hack.fresh_tok (TIdent_Define (s,i2))
+               ::x1
+               ::x
+               ::acc
+             in
+             aux acc' xs
+         | _ ->
+             pr2 (spf "WEIRD #define body, at %s" (pos ii));
+             aux (x::acc) xs
+        )
+    | x::xs ->
+        aux (x::acc) xs
+  in
+  aux [] xs
 
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
 let fix_tokens_define2 xs =
-  define_ident (define_line_1 xs)
+  define_ident (define_line xs)
 
 let fix_tokens_define a =
   Common.profile_code "Hack.fix_define" (fun () -> fix_tokens_define2 a)

--- a/lang_cpp/parsing/parsing_hacks_pp.ml
+++ b/lang_cpp/parsing/parsing_hacks_pp.ml
@@ -89,13 +89,13 @@ let is_really_foreach xs =
 (* TODO: set_ifdef_parenthize_info ?? from parsing_c/ *)
 
 let filter_pp_or_comment_stuff xs =
-  let rec aux xs =
+  let rec aux acc xs =
     match xs with
-    | [] -> []
+    | [] -> List.rev acc
     | x::xs ->
         (match x.TV.t with
          | tok when TH.is_comment tok ->
-             aux xs
+             aux acc xs
          (* don't want drop the define, or if drop, have to drop
           * also its body otherwise the line heuristics may be lost
           * by not finding the TDefine in column 0 but by finding
@@ -104,14 +104,14 @@ let filter_pp_or_comment_stuff xs =
           * todo? but define often contain some unbalanced {
          *)
          | Parser.TDefine _ ->
-             x::aux xs
+             aux (x::acc) xs
          | tok when TH.is_pp_instruction tok ->
-             aux xs
+             aux acc xs
          | _ ->
-             x::aux xs
+             aux (x::acc) xs
         )
   in
-  aux xs
+  aux [] xs
 
 (*****************************************************************************)
 (* Ifdef keeping/passing *)

--- a/lang_cpp/parsing/parsing_hacks_pp.ml
+++ b/lang_cpp/parsing/parsing_hacks_pp.ml
@@ -89,6 +89,7 @@ let is_really_foreach xs =
 (* TODO: set_ifdef_parenthize_info ?? from parsing_c/ *)
 
 let filter_pp_or_comment_stuff xs =
+  (* Tail-recursive to prevent stack overflows. *)
   let rec aux acc xs =
     match xs with
     | [] -> List.rev acc

--- a/lang_cpp/parsing/parsing_hacks_typedef.ml
+++ b/lang_cpp/parsing/parsing_hacks_typedef.ml
@@ -87,7 +87,7 @@ let look_like_declaration_context tok_before =
 (* Better View *)
 (*****************************************************************************)
 
-let  filter_for_typedef multi_groups =
+let filter_for_typedef multi_groups =
 
   (* a sentinel, which helps a few typedef heuristics which look
    * for a token before which would not work for the first toplevel

--- a/lang_cpp/parsing/token_views_cpp.ml
+++ b/lang_cpp/parsing/token_views_cpp.ml
@@ -208,6 +208,7 @@ let rec mk_parameters extras acc_before_sep  xs =
  * pre: have done the TInf->TInf_Template translation.
 *)
 let mk_parenthised xs =
+  (* Tail-recursive to prevent stack overflows. *)
   let rec aux acc xs =
     match xs with
     | [] -> List.rev acc


### PR DESCRIPTION
test plan:
1. make test
2. pfff -parse_cpp semgrep/parsing-stats/lang/c/tmp/coolsnowwolf-lede//package/lean/mt/drivers/mt7603e/src/mt7603_wifi/ap/ap_cfg.c
  #^ no longer segfaults
3. pfff -parse_cpp semgrep/parsing-stats/lang/c/tmp/coolsnowwolf-lede/package/lean/mt/drivers/mt7603e/src/mt7603_wifi/include/mcu/mt7636_firmware.h
  #^ no longer segfaults
4. pfff -parse_cpp semgrep/parsing-stats/lang/c/tmp/coolsnowwolf-lede/package/lean/mt/drivers/mt7615d/src/mt_wifi/embedded/include/mcu/mt7615_firmware.h
  #^ no longer segfaults

Helps returntocorp/semgrep#3538