### PR TITLE
[JS] Prevent stack overflows with tailrec functions

### DIFF
--- a/lang_js/parsing/parsing_hacks_js.ml
+++ b/lang_js/parsing/parsing_hacks_js.ml
@@ -116,7 +116,7 @@ let fix_tokens toks =
                                          kind = TH.token_kind_of_tok;
                                        } toks
     in
-    let horigin = toks |> List.map (fun t -> TH.info_of_tok t, t)
+    let horigin = toks |> Common.map (fun t -> TH.info_of_tok t, t)
                   |> Common.hash_of_list in
     let retag_lparen_arrow = Hashtbl.create 101 in
     let retag_lparen_method = Hashtbl.create 101 in
@@ -154,7 +154,7 @@ let fix_tokens toks =
     visitor trees;
 
     (* use the tagged information and transform tokens *)
-    toks |> List.map (function
+    toks |> Common.map (function
       | T.T_LPAREN info when Hashtbl.mem retag_lparen_arrow info ->
           T.T_LPAREN_ARROW info
       | T.T_LPAREN info when Hashtbl.mem retag_lparen_method info ->


### PR DESCRIPTION
test plan:
1. make test
2. pfff -parse_js perf/so/three.js
  #^ no longer segfaults

Helps returntocorp/semgrep#3538