### PR TITLE
[JS] Normalize representation of numeric keys

### DIFF
--- a/commons/common2.ml
+++ b/commons/common2.ml
@@ -1440,6 +1440,17 @@ let int_of_all s =
   if String.length s >= 2 && (String.get s 0 =<= '0') && is_digit (String.get s 1)
   then int_of_octal s else int_of_string s
 
+let int_of_string_c_octal_opt s =
+  let open Common in
+  if s =~ "^0\\([0-7]+\\)$" then
+    let s = Common.matched1 s in
+    int_of_string_opt ("0o" ^ s)
+  else int_of_string_opt s
+
+let float_of_string_opt s =
+  match int_of_string_c_octal_opt s with
+  | Some i -> Some (float_of_int i)
+  | None -> float_of_string_opt s
 
 let (+=) ref v = ref := !ref + v
 let (-=) ref v = ref := !ref - v

--- a/commons/common2.mli
+++ b/commons/common2.mli
@@ -589,6 +589,13 @@ val int_of_base : string -> int -> int
 val int_of_stringbits : string -> int
 val int_of_octal : string -> int
 val int_of_all : string -> int
+(* like int_of_string_opt, but also converts C octals like 0400 in
+ * the right value. *)
+val int_of_string_c_octal_opt : string -> int option
+(* like float_of_string_opt, but also converts C octals like 0400 in
+ * the right value. *)
+val float_of_string_opt : string -> float option
+
 
 (* useful but sometimes when want grep for all places where do modif,
  * easier to have just code using ':=' and '<-' to do some modifications.

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -1374,7 +1374,13 @@ numeric_literal:
   | T_FLOAT { $1 }
 numeric_literal_as_string: numeric_literal
     { let t = snd $1 in
-      (Parse_info.str_of_info t, t)
+      let s = Parse_info.str_of_info t in
+      let s' =
+        match Common2.float_of_string_opt s with
+        | None -> s
+        | Some n -> string_of_float n
+      in
+      (s', t)
     }
 
 regex_literal: T_REGEX { $1 }


### PR DESCRIPTION
In JS, `{1:"a"}` and `{0x1:"a"}` are equal objects, that is, numeric keys
`1` and `0x1` are equivalent.

Helps returntocorp/semgrep#3579

test plan:
Run `pfff -dump_js` on both `var x = {1:"a"};` and `var x = {0x1:"a"};`
and check that in both cases the key is represented by `PN ("1.", ())`.