### PR TITLE
Add safeguards around the 'set_timeout' function (formerly 'timeout_function_float')

### DIFF
--- a/commons/Common.ml
+++ b/commons/Common.ml
@@ -48,7 +48,15 @@ let logger = Logging.get_logger [__MODULE__]
 
 let spf = Printf.sprintf
 
-exception Timeout
+(* A timeout exception with accompanying debug information:
+   - a descriptive name
+   - the time limit
+     The mli interface makes this type private to help prevent unsafe uses of
+     the exception.
+*)
+type timeout_info = string * float
+exception Timeout of timeout_info
+
 exception UnixExit of int
 
 let rec drop n xs =
@@ -335,8 +343,8 @@ let profile_code category f =
     if !show_trace_profile then pr2 (spf "> %s" category);
     let t = Unix.gettimeofday () in
     let res, prefix =
-      try Some (f ()), ""
-      with Timeout -> None, "*"
+      try Ok (f ()), ""
+      with Timeout _ as e -> Error e, "*"
     in
     let category = prefix ^ category in (* add a '*' to indicate timeout func *)
     let t' = Unix.gettimeofday () in
@@ -345,8 +353,8 @@ let profile_code category f =
 
     adjust_profile_entry category (t' -. t);
     (match res with
-     | Some res -> res
-     | None -> raise Timeout
+     | Ok res -> res
+     | Error e -> raise e
     );
   end
 
@@ -1035,9 +1043,10 @@ let (with_open_infile: filename -> ((in_channel) -> 'a) -> 'a) = fun file f ->
     res)
     (fun _e -> close_in chan)
 
-(* now in prelude:
- * exception Timeout
-*)
+let string_of_timeout_info (name, time_limit) =
+  spf "%s:%g" name time_limit
+
+let current_timer = ref None
 
 (* it seems that the toplevel block such signals, even with this explicit
  *  command :(
@@ -1046,67 +1055,68 @@ let (with_open_infile: filename -> ((in_channel) -> 'a) -> 'a) = fun file f ->
 
 (* could be in Control section *)
 
-(* subtil: have to make sure that timeout is not intercepted before here, so
- * avoid exn handle such as try (...) with _ -> cos timeout will not bubble up
- * enough. In such case, add a case before such as
- * with Timeout -> raise Timeout | _ -> ...
- *
- * question: can we have a signal and so exn when in a exn handler ?
-*)
-let timeout_function ?(verbose=false) timeoutval = fun f ->
-  try
-    begin
-      Sys.set_signal Sys.sigalrm (Sys.Signal_handle (fun _ -> raise Timeout ));
-      ignore(Unix.alarm timeoutval);
-      let x = f () in
-      ignore(Unix.alarm 0);
-      x
-    end
-  with Timeout ->
-    begin
-      if verbose then pr2 "timeout (we abort)";
-      raise Timeout;
-    end
-     | e ->
-         (* subtil: important to disable the alarm before relaunching the exn,
-          * otherwise the alarm is still running.
-          *
-          * robust?: and if alarm launched after the log (...) ?
-          * Maybe signals are disabled when process an exception handler ?
-         *)
-         begin
-           ignore(Unix.alarm 0);
-           (* log ("exn while in transaction (we abort too, even if ...) = " ^
-              Printexc.to_string e);
-           *)
-           if verbose then pr2 "exn while in timeout_function";
-           raise e
-         end
+(*
+   This is tricky stuff.
 
-(* coupling: very similar to timeout_function above *)
-let timeout_function_float ?(verbose=false) timeoutval = fun f ->
-  try
-    Sys.set_signal Sys.sigalrm (Sys.Signal_handle (fun _ -> raise Timeout ));
+   We have to make sure that timeout is not intercepted before here, so
+   avoid exn handle such as try (...) with _ -> cos timeout will not bubble up
+   enough. In such case, add a case before such as
+   with Timeout -> raise Timeout | _ -> ...
+
+  question: can we have a signal and so exn when in a exn handler ?
+*)
+let set_timeout ?(verbose=false) ~name time_limit = fun f ->
+  (match !current_timer with
+   | None -> ()
+   | Some (running_name, running_val) ->
+       invalid_arg (
+         spf
+           "Common.set_timeout: cannot set a timeout %S of %g seconds. \
+            A timer for %S of %g seconds is still running."
+           name time_limit
+           running_name running_val
+       )
+  );
+  let info (* private *) = (name, time_limit) in
+  let timeout_exn = Timeout info in
+  let clear_timer () =
+    current_timer := None;
     Unix.setitimer Unix.ITIMER_REAL
-      { Unix.it_value = timeoutval; it_interval = 0. } |> ignore;
+      { Unix.it_value = 0.; it_interval = 0. }
+    |> ignore
+  in
+  let set_timer () =
+    current_timer := Some (name, time_limit);
+    Unix.setitimer Unix.ITIMER_REAL
+      { Unix.it_value = time_limit; it_interval = 0. }
+    |> ignore
+  in
+  try
+    Sys.set_signal Sys.sigalrm (Sys.Signal_handle (fun _ -> raise timeout_exn));
+    set_timer ();
     let x = f () in
-    Unix.setitimer Unix.ITIMER_REAL { Unix.it_value = 0.; it_interval = 0. }
-    |> ignore;
-    x
-  with Timeout ->
-    if verbose then pr2 "timeout (we abort)";
-    raise Timeout;
-     | e ->
-         (* subtil: important to disable the alarm before relaunching the exn,
-          * otherwise the alarm is still running.
-          *
-          * robust?: and if alarm launched after the log (...) ?
-          * Maybe signals are disabled when process an exception handler ?
-         *)
-         Unix.setitimer Unix.ITIMER_REAL { Unix.it_value = 0.; it_interval = 0. }
-         |> ignore;
-         if verbose then pr2 "exn while in timeout_function";
-         raise e
+    clear_timer ();
+    Some x
+  with
+  | Timeout (name, time_limit) ->
+      clear_timer ();
+      if verbose then pr2 (spf "%S timeout at %g s (we abort)" name time_limit);
+      None
+  | e ->
+      (* It's important to disable the alarm before relaunching the exn,
+         otherwise the alarm is still running.
+
+         robust?: and if alarm launched after the log (...) ?
+         Maybe signals are disabled when process an exception handler ?
+      *)
+      clear_timer ();
+      if verbose then pr2 "exn while in set_timeout";
+      raise e
+
+let set_timeout_opt ?verbose ~name time_limit f =
+  match time_limit with
+  | None -> Some (f ())
+  | Some x -> set_timeout ?verbose ~name x f
 
 (* creation of tmp files, a la gcc *)
 

--- a/commons/Common.mli
+++ b/commons/Common.mli
@@ -446,13 +446,39 @@ val memoized :
 exception UnixExit of int
 (*e: exception [[Common.UnixExit]] *)
 
+(* Contains the name given by the user to the timer and the time limit *)
+type timeout_info
+
 (*s: exception [[Common.Timeout]] *)
-exception Timeout
+(*
+   If ever caught, this exception must be re-raised immediately so as
+   to not interfere with the timeout handler. See function 'set_timeout'.
+*)
+exception Timeout of timeout_info
 (*e: exception [[Common.Timeout]] *)
+
+(* Show name and time limit in a compact format for debugging purposes. *)
+val string_of_timeout_info : timeout_info -> string
+
 (*s: signature [[Common.timeout_function]] *)
-val timeout_function: ?verbose:bool -> int -> (unit -> 'a) -> 'a
+(*
+   Launch the specified computation and abort if it takes longer than
+   specified (in seconds).
+
+   This uses a global timer. An Invalid_argument exception will be raised
+   if the timer is already running.
+
+   tl;dr nesting will fail
+*)
+val set_timeout:
+  ?verbose:bool -> name:string -> float -> (unit -> 'a) -> 'a option
 (*e: signature [[Common.timeout_function]] *)
-val timeout_function_float :?verbose:bool -> float -> (unit -> 'a) -> 'a
+
+(*
+   Only set a timer if a time limit is specified. Uses 'set_timeout'.
+*)
+val set_timeout_opt:
+  ?verbose:bool -> name:string -> float option -> (unit -> 'a) -> 'a option
 
 (*
    Measure how long it takes for a function to run, returning the result

--- a/commons/common2.mli
+++ b/commons/common2.mli
@@ -1153,21 +1153,13 @@ val with_open_outfile_append :
 val with_open_stringbuf :
   (((string -> unit) * Buffer.t) -> unit) -> string
 
-exception Timeout
+(* Same as Common.set_timeout *)
+val set_timeout:
+  ?verbose:bool -> name:string -> float -> (unit -> 'a) -> 'a option
 
-(* subtil: have to make sure that Timeout is not intercepted before here. So
- * avoid exn handler such as try (...) with _ -> cos Timeout will not bubble up
- * enough. In such case, add a case before such as
- * with Timeout -> raise Timeout | _ -> ...
- *
- * The same is true for UnixExit (see below).
-*)
-val timeout_function :
-  ?verbose:bool ->
-  int -> (unit -> 'a) -> 'a
-
-val timeout_function_opt : int option -> (unit -> 'a) -> 'a
-
+(* Same as Common.set_timeout_opt *)
+val set_timeout_opt :
+  ?verbose:bool -> name:string -> float option -> (unit -> 'a) -> 'a option
 
 val with_tmp_file: str:string -> ext:string -> (filename -> 'a) -> 'a
 val with_tmp_dir: (dirname -> 'a) -> 'a

--- a/h_program-lang/Error_code.ml
+++ b/h_program-lang/Error_code.ml
@@ -376,9 +376,11 @@ let exn_to_error file exn =
       (* this should never be captured *)
       (* in theory we should also avoid to capture those *)
 *)
-  | Common.Timeout ->
+  | Common.Timeout timeout_info ->
+      (* This exception should always be reraised. *)
       let loc = Parse_info.first_loc_of_file file in
-      mk_error_loc loc (Timeout None)
+      let msg = Common.string_of_timeout_info timeout_info in
+      mk_error_loc loc (Timeout (Some msg))
   | Out_of_memory ->
       let loc = Parse_info.first_loc_of_file file in
       mk_error_loc loc (OutOfMemory None)

--- a/lang_c/analyze/graph_code_c.ml
+++ b/lang_c/analyze/graph_code_c.ml
@@ -160,7 +160,7 @@ let parse ~show_parse_error file =
           Parse_c.parse_program file
         )))
   with
-  | Timeout -> raise Timeout
+  | Timeout _ as e -> raise e
   | exn ->
       pr2_once (spf "PARSE ERROR with %s, exn = %s" file (Common.exn_to_s exn));
       raise exn

--- a/lang_java/analyze/graph_code_java.ml
+++ b/lang_java/analyze/graph_code_java.ml
@@ -109,7 +109,7 @@ let parse ~show_parse_error file =
   try
     Parse_java.parse_program file
   with
-  | Timeout -> raise Timeout
+  | Timeout _ as e -> raise e
   | exn ->
       if show_parse_error
       then pr2_once (spf "PARSE ERROR with %s, exn = %s" file

--- a/lang_js/analyze/graph_code_js.ml
+++ b/lang_js/analyze/graph_code_js.ml
@@ -108,7 +108,7 @@ let parse file =
     try
       Parse_js.parse_program file
     with
-    | Timeout -> raise Timeout
+    | Timeout _ as e -> raise e
     | exn ->
         pr2 (spf "PARSE ERROR with %s, exn = %s" file (Common.exn_to_s exn));
         if !error_recovery

--- a/lang_js/parsing/parse_js.mli
+++ b/lang_js/parsing/parse_js.mli
@@ -4,7 +4,7 @@
  *  - Parse_info.Lexical_error if Flag_parsing.exn_when_lexical_error is true.
 *)
 val parse:
-  ?timeout: int ->
+  ?timeout: float ->
   Common.filename ->
   (Ast_js.a_program, Parser_js.token) Parse_info.parsing_result
 

--- a/lang_js/parsing/test_parsing_js.ml
+++ b/lang_js/parsing/test_parsing_js.ml
@@ -47,7 +47,7 @@ let test_parse_common xs fullxs ext  =
       try (
         Common.save_excursion Flag.error_recovery true (fun () ->
           Common.save_excursion Flag.exn_when_lexical_error false (fun () ->
-            Parse_js.parse ~timeout:5 file
+            Parse_js.parse ~timeout:5.0 file
 
            (* to have a better comparison with semgrep -lang js -test_parse_lang: *)
            (* let _gen = Js_to_generic.program ast in *)

--- a/lang_lisp/analyze/graph_code_lisp.ml
+++ b/lang_lisp/analyze/graph_code_lisp.ml
@@ -67,7 +67,7 @@ let parse file =
     try
       Parse_lisp.parse_program file
     with
-    | Timeout -> raise Timeout
+    | Timeout _ as e -> raise e
     | exn ->
         pr2_once (spf "PARSE ERROR with %s, exn = %s" file (Common.exn_to_s exn));
         []

--- a/lang_php/analyze/graph_code_php.ml
+++ b/lang_php/analyze/graph_code_php.ml
@@ -154,7 +154,7 @@ let parse env file =
       ast
     )
   with
-  | Timeout -> raise Timeout
+  | Timeout _ as e -> raise e
   | exn ->
       env.stats.G.parse_errors |> Common.push file;
       env.pr2_and_log (spf "PARSE ERROR with %s, exn = %s" (env.path file)


### PR DESCRIPTION
The difficulty is that the timeout mechanism relies of a single signal with a single signal handler so we can't have nested functions with a timeout. The new implementation helps protect against such bugs and will report misuses. Here's what changed:

- there's now just a function that works with a float timeout, eliminating the one that works with ints.
- all code uses the same function `Common.set_timeout` to deal with timeouts.
- nesting is a bug and will be reported instead of causing mysterious behavior. For example, an accidental `set_timeout ... (fun () -> set_timeout ...))` will be reported at runtime.
- the `set_timeout` function returns an option rather than raising an exception. It was previously re-raising the same exception that was raised by the signal handler, creating confusion.
- the `Timeout` exception that's raised by the signal handler should still be re-raised by user code. It now carries a name for the timer and time limit, which is useful for debugging purposes and for generating error messages in case of conflict between timers.
