### PR TITLE
Use 'open_in_bin', 'open_out_bin' instead of 'open_in', 'open_out'

### DIFF
--- a/commons/Common.ml
+++ b/commons/Common.ml
@@ -451,7 +451,7 @@ let get_value filename =
   (close_in chan; x)
 
 let write_value valu filename =
-  let chan = open_out filename in
+  let chan = open_out_bin filename in
   (output_value chan valu;  (* <=> Marshal.to_channel *)
    (* Marshal.to_channel chan valu [Marshal.Closures]; *)
    close_out chan)
@@ -932,7 +932,7 @@ let read_file a =
   profile_code "Common.read_file" (fun () -> read_file2 a)
 
 let write_file ~file s =
-  let chan = open_out file in
+  let chan = open_out_bin file in
   (output_string chan s; close_out chan)
 
 (* could be in control section too *)
@@ -1031,7 +1031,7 @@ let cache_computation ?verbose ?use_cache a b c =
 (* emacs/lisp inspiration (eric cooper and yaron minsky use that too) *)
 let (with_open_outfile: filename -> (((string -> unit) * out_channel) -> 'a) -> 'a) =
   fun file f ->
-  let chan = open_out file in
+  let chan = open_out_bin file in
   let pr s = output_string chan s in
   unwind_protect (fun () ->
     let res = f (pr, chan) in

--- a/commons/Common.ml
+++ b/commons/Common.ml
@@ -968,18 +968,17 @@ let input_text_line ic =
   else
     s
 
-(* tail recursive efficient version *)
 let cat file =
+  let acc = ref [] in
   let chan = open_in_bin file in
-  let rec cat_aux acc ()  =
-    (* cant do input_line chan::aux() cos ocaml eval from right to left ! *)
-    let (b, l) =
-      try (true, input_text_line chan) with End_of_file -> (false, "") in
-    if b
-    then cat_aux (l::acc) ()
-    else acc
-  in
-  cat_aux [] () |> List.rev |> (fun x -> close_in chan; x)
+  try
+    while true do
+      acc := input_text_line chan :: !acc
+    done;
+    assert false
+  with End_of_file ->
+    close_in chan;
+    List.rev !acc
 
 let read_file2 file =
   let ic = open_in_bin file  in

--- a/commons/Common.ml
+++ b/commons/Common.ml
@@ -446,7 +446,7 @@ let profile_code2 category f =
 (*****************************************************************************)
 
 let get_value filename =
-  let chan = open_in filename in
+  let chan = open_in_bin filename in
   let x = input_value chan in (* <=> Marshal.from_channel  *)
   (close_in chan; x)
 
@@ -911,7 +911,7 @@ let cmd_to_list_and_status = process_output_to_list2
 
 (* tail recursive efficient version *)
 let cat file =
-  let chan = open_in file in
+  let chan = open_in_bin file in
   let rec cat_aux acc ()  =
     (* cant do input_line chan::aux() cos ocaml eval from right to left ! *)
     let (b, l) = try (true, input_line chan) with End_of_file -> (false, "") in
@@ -922,7 +922,7 @@ let cat file =
   cat_aux [] () |> List.rev |> (fun x -> close_in chan; x)
 
 let read_file2 file =
-  let ic = open_in file  in
+  let ic = open_in_bin file  in
   let size = in_channel_length ic in
   let buf = Bytes.create size in
   really_input ic buf 0 size;
@@ -1040,7 +1040,7 @@ let (with_open_outfile: filename -> (((string -> unit) * out_channel) -> 'a) -> 
     (fun _e -> close_out chan)
 
 let (with_open_infile: filename -> ((in_channel) -> 'a) -> 'a) = fun file f ->
-  let chan = open_in file in
+  let chan = open_in_bin file in
   unwind_protect (fun () ->
     let res = f chan in
     close_in chan;

--- a/commons/Common.mli
+++ b/commons/Common.mli
@@ -111,6 +111,10 @@ type dirname = string
 type path = string
 (*e: type [[Common.path]] *)
 
+(*
+   Return the lines of a file. Both Windows-style and Unix-style line endings
+   are recognized and removed from the end of the line.
+*)
 (*s: signature [[Common.cat]] *)
 val cat :      filename -> string list
 (*e: signature [[Common.cat]] *)

--- a/commons/Unit_commons.ml
+++ b/commons/Unit_commons.ml
@@ -47,9 +47,32 @@ let test_common_map =
   in
   tests
 
+(*
+   Check that both Windows (CRLF) and Unix line endings (LF) are removed
+   when reading a line. This is a problem with Stdlib.input_line, which
+   leaves a trailing '\r' when reading a file from Windows.
+*)
+let test_cat () =
+  let contents = "\
+hello\r\n\
+world\n\
+!"
+  in
+  let file = Filename.temp_file "test_cat_" ".txt" in
+  let oc = open_out_bin file in
+  output_string oc contents;
+  close_out oc;
+  match Common.cat file with
+  | ["hello"; "world"; "!"] -> ()
+  | lines ->
+      List.iteri (fun i line -> eprintf "line %i: %S\n" i line) lines;
+      flush stderr;
+      assert false
+
 let unittest =
   "commons" >::: [
     "common" >::: [
       "map" >::: test_common_map;
+      "cat" >:: test_cat;
     ]
   ]

--- a/commons/common2.ml
+++ b/commons/common2.ml
@@ -373,7 +373,7 @@ let mk_pr2_wrappers aref =
 
 let redirect_stdout file f =
   begin
-    let chan = open_out file in
+    let chan = open_out_bin file in
     let descr = Unix.descr_of_out_channel chan in
 
     let saveout = Unix.dup Unix.stdout in
@@ -393,7 +393,7 @@ let redirect_stdout_opt optfile f =
 
 let redirect_stdout_stderr file f =
   begin
-    let chan = open_out file in
+    let chan = open_out_bin file in
     let descr = Unix.descr_of_out_channel chan in
 
     let saveout = Unix.dup Unix.stdout in
@@ -453,7 +453,7 @@ let _chan = ref stderr
 let start_log_file () =
   let filename = (spf "/tmp/debugml%d:%d" (Unix.getuid()) (Unix.getpid())) in
   pr2 (spf "now using %s for logging" filename);
-  _chan := open_out filename
+  _chan := open_out_bin filename
 
 
 let dolog s = output_string !_chan (s ^ "\n"); flush !_chan
@@ -768,7 +768,7 @@ let get_value filename =
   (close_in chan; x)
 
 let write_value valu filename =
-  let chan = open_out filename in
+  let chan = open_out_bin filename in
   (output_value chan valu;  (* <=> Marshal.to_channel *)
    (* Marshal.to_channel chan valu [Marshal.Closures]; *)
    close_out chan)
@@ -925,7 +925,7 @@ let mk_str_func_of_assoc_conv xs =
 
 (* put your macro in macro.ml4, and you can test it interactivly as in lisp *)
 let macro_expand s =
-  let c = open_out "/tmp/ttttt.ml" in
+  let c = open_out_bin "/tmp/ttttt.ml" in
   begin
     output_string c s; close_out c;
     command2 ("ocamlc -c -pp 'camlp4o pa_extend.cmo q_MLast.cmo -impl' " ^
@@ -3047,7 +3047,7 @@ let read_file file =
 
 
 let write_file ~file s =
-  let chan = open_out file in
+  let chan = open_out_bin file in
   (output_string chan s; close_out chan)
 
 let unix_stat file =
@@ -3391,7 +3391,7 @@ let has_env _var =
 
 let (with_open_outfile_append: filename -> (((string -> unit) * out_channel) -> 'a) -> 'a) =
   fun file f ->
-  let chan = open_out_gen [Open_creat;Open_append] 0o666 file in
+  let chan = open_out_gen [Open_creat;Open_append;Open_binary] 0o666 file in
   let pr s = output_string chan s in
   Common.unwind_protect (fun () ->
     let res = f (pr, chan) in
@@ -5215,7 +5215,7 @@ let (display: 'a graph -> ('a -> unit) -> unit) = fun g display_func ->
   in aux 0 1
 
 let (display_dot: 'a graph -> ('a -> string) -> unit)= fun (nodes,arcs) func ->
-  let file = open_out "test.dot" in
+  let file = open_out_bin "test.dot" in
   output_string file "digraph misc {\n" ;
   List.iter (fun (n, node) ->
     output_int file n; output_string file " [label=\"";
@@ -5233,7 +5233,7 @@ let (display_dot: 'a graph -> ('a -> string) -> unit)= fun (nodes,arcs) func ->
 (* todo: mettre diff(modulo = !!) en rouge *)
 let (display_dot2: 'a graph -> 'a graph -> ('a -> string) -> unit) =
   fun (nodes1, arcs1) (nodes2, arcs2) func ->
-  let file = open_out "test.dot" in
+  let file = open_out_bin "test.dot" in
   output_string file "digraph misc {\n" ;
   output_string file "rotate = 90;\n";
   List.iter (fun (n, node) ->
@@ -5328,7 +5328,7 @@ type pixel = (int * int * int) (* RGB *)
 (* required pixel list in row major order, line after line *)
 let (write_ppm: int -> int -> (pixel list) -> string -> unit) = fun
   width height xs filename ->
-  let chan = open_out filename in
+  let chan = open_out_bin filename in
   begin
     output_string chan "P6\n";
     output_string chan ((string_of_int width)  ^ "\n");

--- a/commons/common2.ml
+++ b/commons/common2.ml
@@ -410,7 +410,7 @@ let redirect_stdout_stderr file f =
 
 let redirect_stdin file f =
   begin
-    let chan = open_in file in
+    let chan = open_in_bin file in
     let descr = Unix.descr_of_in_channel chan in
 
     let savein = Unix.dup Unix.stdin in
@@ -763,7 +763,7 @@ let take_one xs =
 (*****************************************************************************)
 
 let get_value filename =
-  let chan = open_in filename in
+  let chan = open_in_bin filename in
   let x = input_value chan in (* <=> Marshal.from_channel  *)
   (close_in chan; x)
 
@@ -2834,7 +2834,7 @@ let _ = example (nblines "toto\ntata\n" =|= 2)
 let nblines_eff2 file =
   let res = ref 0 in
   let finished = ref false in
-  let ch = open_in file in
+  let ch = open_in_bin file in
   while not !finished do
     try
       let _ = input_line ch in
@@ -2869,7 +2869,7 @@ let _ = example (lines_with_nl_either "ab\n\nc" =*=
 (* Process/Files *)
 (*****************************************************************************)
 let cat_orig file =
-  let chan = open_in file in
+  let chan = open_in_bin file in
   let rec cat_orig_aux ()  =
     try
       (* cant do input_line chan::aux() cos ocaml eval from right to left ! *)
@@ -2880,7 +2880,7 @@ let cat_orig file =
 
 (* tail recursive efficient version *)
 let cat file =
-  let chan = open_in file in
+  let chan = open_in_bin file in
   let rec cat_aux acc ()  =
     (* cant do input_line chan::aux() cos ocaml eval from right to left ! *)
     let (b, l) = try (true, input_line chan) with End_of_file -> (false, "") in
@@ -3038,7 +3038,7 @@ let mkdir ?(mode=0o770) file =
   Unix.mkdir file mode
 
 let read_file file =
-  let ic = open_in file  in
+  let ic = open_in_bin file  in
   let size = in_channel_length ic in
   let buf = Bytes.create size in
   really_input ic buf 0 size;
@@ -3061,7 +3061,7 @@ let filesize file =
   then (unix_stat file).Unix.st_size
   (* src: https://rosettacode.org/wiki/File_size#OCaml *)
   else begin
-    let ic = open_in file in
+    let ic = open_in_bin file in
     let i = in_channel_length ic in
     close_in ic;
     i
@@ -5446,7 +5446,7 @@ let parserCommon lexbuf parserer lexer =
 (*
 let getDoubleParser parserer lexer string =
   let lexbuf1 = Lexing.from_string string in
-  let chan = open_in string in
+  let chan = open_in_bin string in
   let lexbuf2 = Lexing.from_channel chan in
   (parserCommon lexbuf1 parserer lexer  , parserCommon lexbuf2 parserer lexer )
 *)
@@ -5458,7 +5458,7 @@ let getDoubleParser parserer lexer =
        parserCommon lexbuf1 parserer lexer
     ),
     (function string ->
-       let chan = open_in string in
+       let chan = open_in_bin string in
        let lexbuf2 = Lexing.from_channel chan in
        parserCommon lexbuf2 parserer lexer
     ))
@@ -5952,7 +5952,7 @@ let format_to_string f =
   Format.print_flush();
   Format.set_formatter_out_channel stdout;
   close_out o;
-  let i = open_in nm in
+  let i = open_in_bin nm in
   let lines = ref [] in
   let rec loop _ =
     let cur = input_line i in

--- a/commons_core/docs/common.ml.nw
+++ b/commons_core/docs/common.ml.nw
@@ -437,7 +437,7 @@ let redirect_stdout_stderr file f =
 
 let redirect_stdin file f =
   begin
-    let chan = open_in file in
+    let chan = open_in_bin file in
     let descr = Unix.descr_of_in_channel chan in
 
     let savein = Unix.dup Unix.stdin in
@@ -926,7 +926,7 @@ let take_one xs =
 (*****************************************************************************)
 
 let get_value filename =
-  let chan = open_in filename in
+  let chan = open_in_bin filename in
   let x = input_value chan in (* <=> Marshal.from_channel  *)
   (close_in chan; x)
 
@@ -3045,7 +3045,7 @@ let _ = example (nblines "toto\ntata\n" =|= 2)
 let nblines_eff2 file =
   let res = ref 0 in
   let finished = ref false in
-  let ch = open_in file in
+  let ch = open_in_bin file in
   while not !finished do
     try
       let _ = input_line ch in
@@ -3078,7 +3078,7 @@ let _ = example (lines_with_nl_either "ab\n\nc" =*=
 (* Process/Files *)
 (*****************************************************************************)
 let cat_orig file =
-  let chan = open_in file in
+  let chan = open_in_bin file in
   let rec cat_orig_aux ()  =
     try
       (* cant do input_line chan::aux() cos ocaml eval from right to left ! *)
@@ -3089,7 +3089,7 @@ let cat_orig file =
 
 (* tail recursive efficient version *)
 let cat file =
-  let chan = open_in file in
+  let chan = open_in_bin file in
   let rec cat_aux acc ()  =
       (* cant do input_line chan::aux() cos ocaml eval from right to left ! *)
     let (b, l) = try (true, input_line chan) with End_of_file -> (false, "") in
@@ -3224,7 +3224,7 @@ let mkdir ?(mode=0o770) file =
 
 let read_file_orig file = cat file +> unlines
 let read_file file =
-  let ic = open_in file  in
+  let ic = open_in_bin file  in
   let size = in_channel_length ic in
   let buf = String.create size in
   really_input ic buf 0 size;
@@ -3545,7 +3545,7 @@ let (with_open_outfile: filename -> (((string -> unit) * out_channel) -> 'a) -> 
     (fun e -> close_out chan)
 
 let (with_open_infile: filename -> ((in_channel) -> 'a) -> 'a) = fun file f ->
-  let chan = open_in file in
+  let chan = open_in_bin file in
   unwind_protect (fun () ->
     let res = f chan in
     close_in chan;
@@ -5622,7 +5622,7 @@ let parserCommon lexbuf parserer lexer =
 (*
 let getDoubleParser parserer lexer string =
   let lexbuf1 = Lexing.from_string string in
-  let chan = open_in string in
+  let chan = open_in_bin string in
   let lexbuf2 = Lexing.from_channel chan in
   (parserCommon lexbuf1 parserer lexer  , parserCommon lexbuf2 parserer lexer )
 *)
@@ -5634,7 +5634,7 @@ let getDoubleParser parserer lexer =
      parserCommon lexbuf1 parserer lexer
    ),
    (function string ->
-     let chan = open_in string in
+     let chan = open_in_bin string in
      let lexbuf2 = Lexing.from_channel chan in
      parserCommon lexbuf2 parserer lexer
    ))
@@ -6097,7 +6097,7 @@ let format_to_string f =
   Format.print_flush();
   Format.set_formatter_out_channel stdout;
   close_out o;
-  let i = open_in nm in
+  let i = open_in_bin nm in
   let lines = ref [] in
   let rec loop _ =
     let cur = input_line i in

--- a/commons_core/docs/common.ml.nw
+++ b/commons_core/docs/common.ml.nw
@@ -400,7 +400,7 @@ let mk_pr2_wrappers aref =
 
 let redirect_stdout file f =
   begin
-    let chan = open_out file in
+    let chan = open_out_bin file in
     let descr = Unix.descr_of_out_channel chan in
 
     let saveout = Unix.dup Unix.stdout in
@@ -420,7 +420,7 @@ let redirect_stdout_opt optfile f =
 
 let redirect_stdout_stderr file f =
   begin
-    let chan = open_out file in
+    let chan = open_out_bin file in
     let descr = Unix.descr_of_out_channel chan in
 
     let saveout = Unix.dup Unix.stdout in
@@ -481,7 +481,7 @@ let _chan = ref stderr
 let start_log_file () =
   let filename = (spf "/tmp/debugml%d:%d" (Unix.getuid()) (Unix.getpid())) in
   pr2 (spf "now using %s for logging" filename);
-  _chan := open_out filename
+  _chan := open_out_bin filename
 
 
 let dolog s = output_string !_chan (s ^ "\n"); flush !_chan
@@ -931,7 +931,7 @@ let get_value filename =
   (close_in chan; x)
 
 let write_value valu filename =
-  let chan = open_out filename in
+  let chan = open_out_bin filename in
   (output_value chan valu;  (* <=> Marshal.to_channel *)
    (* Marshal.to_channel chan valu [Marshal.Closures]; *)
    close_out chan)
@@ -1088,7 +1088,7 @@ let format_to_string f =
 
 (* put your macro in macro.ml4, and you can test it interactivly as in lisp *)
 let macro_expand s =
-  let c = open_out "/tmp/ttttt.ml" in
+  let c = open_out_bin "/tmp/ttttt.ml" in
   begin
     output_string c s; close_out c;
     command2 ("ocamlc -c -pp 'camlp4o pa_extend.cmo q_MLast.cmo -impl' " ^
@@ -3233,7 +3233,7 @@ let read_file file =
 
 
 let write_file ~file s =
-  let chan = open_out file in
+  let chan = open_out_bin file in
   (output_string chan s; close_out chan)
 
 let unix_stat file =
@@ -3536,7 +3536,7 @@ let has_env var =
 (* emacs/lisp inspiration (eric cooper and yaron minsky use that too) *)
 let (with_open_outfile: filename -> (((string -> unit) * out_channel) -> 'a) -> 'a) =
  fun file f ->
-  let chan = open_out file in
+  let chan = open_out_bin file in
   let pr s = output_string chan s in
   unwind_protect (fun () ->
     let res = f (pr, chan) in
@@ -3555,7 +3555,7 @@ let (with_open_infile: filename -> ((in_channel) -> 'a) -> 'a) = fun file f ->
 
 let (with_open_outfile_append: filename -> (((string -> unit) * out_channel) -> 'a) -> 'a) =
  fun file f ->
-  let chan = open_out_gen [Open_creat;Open_append] 0o666 file in
+  let chan = open_out_gen [Open_creat;Open_append;Open_binary] 0o666 file in
   let pr s = output_string chan s in
   unwind_protect (fun () ->
     let res = f (pr, chan) in
@@ -5388,7 +5388,7 @@ let (display: 'a graph -> ('a -> unit) -> unit) = fun g display_func ->
   in aux 0 1
 
 let (display_dot: 'a graph -> ('a -> string) -> unit)= fun (nodes,arcs) func ->
-  let file = open_out "test.dot" in
+  let file = open_out_bin "test.dot" in
   output_string file "digraph misc {\n" ;
   List.iter (fun (n, node) ->
     output_int file n; output_string file " [label=\"";
@@ -5406,7 +5406,7 @@ let (display_dot: 'a graph -> ('a -> string) -> unit)= fun (nodes,arcs) func ->
 (* todo: mettre diff(modulo = !!) en rouge *)
 let (display_dot2: 'a graph -> 'a graph -> ('a -> string) -> unit) =
   fun (nodes1, arcs1) (nodes2, arcs2) func ->
-  let file = open_out "test.dot" in
+  let file = open_out_bin "test.dot" in
   output_string file "digraph misc {\n" ;
   output_string file "rotate = 90;\n";
   List.iter (fun (n, node) ->
@@ -5504,7 +5504,7 @@ type pixel = (int * int * int) (* RGB *)
 (* required pixel list in row major order, line after line *)
 let (write_ppm: int -> int -> (pixel list) -> string -> unit) = fun
   width height xs filename ->
-    let chan = open_out filename in
+    let chan = open_out_bin filename in
     begin
      output_string chan "P6\n";
      output_string chan ((string_of_int width)  ^ "\n");

--- a/h_program-lang/Parse_info.ml
+++ b/h_program-lang/Parse_info.ml
@@ -531,7 +531,7 @@ let split_info_at_pos pos ii =
 
 let full_charpos_to_pos_large2 = fun file ->
 
-  let chan = open_in file in
+  let chan = open_in_bin file in
   let size = Common2.filesize file + 2 in
 
   (* old: let arr = Array.create size  (0,0) in *)
@@ -747,7 +747,7 @@ let (info_from_charpos2: int -> filename -> (int * int * string)) =
    *      (pos.pos_cnum - pos.pos_bol) in
    * Hence this function to overcome the previous limitation.
   *)
-  let chan = open_in filename in
+  let chan = open_in_bin filename in
   let linen  = ref 0 in
   let posl   = ref 0 in
   let rec charpos_to_pos_aux last_valid =

--- a/lang_c/analyze/graph_code_c.ml
+++ b/lang_c/analyze/graph_code_c.ml
@@ -1025,7 +1025,7 @@ let build ?(verbose=true) root files =
   let g = G.create () in
   G.create_initial_hierarchy g;
 
-  let chan = open_out (Filename.concat root "pfff.log") in
+  let chan = open_out_bin (Filename.concat root "pfff.log") in
 
   (* less: we could also have a local_typedefs_of_files to avoid conflicts *)
 

--- a/lang_java/parsing/test_parsing_java.ml
+++ b/lang_java/parsing/test_parsing_java.ml
@@ -59,7 +59,7 @@ let test_parse xs  =
   ()
 
 let test_lexer file =
-  let lexbuf = Lexing.from_channel (open_in file) in
+  let lexbuf = Lexing.from_channel (open_in_bin file) in
   while true do
     let result = Lexer_java.token lexbuf in
     pr2_gen result;

--- a/lang_js/analyze/graph_code_js.ml
+++ b/lang_js/analyze/graph_code_js.ml
@@ -681,7 +681,7 @@ let build_gen ?(verbose=false) root files =
   (* use Hashtbl.find_all property *)
   let hstat_lookup_failures = Hashtbl.create 101 in
 
-  let chan = open_out (Filename.concat root "pfff.log") in
+  let chan = open_out_bin (Filename.concat root "pfff.log") in
 
   let env = {
     g;

--- a/lang_js/analyze/utils_js.ml
+++ b/lang_js/analyze/utils_js.ml
@@ -10,7 +10,7 @@ let load db gen =
     data
   with _ ->
     let data = gen() in
-    let out_channel = open_out db in
+    let out_channel = open_out_bin db in
     Marshal.to_channel out_channel data [];
     close_out out_channel;
     data

--- a/lang_js/analyze/utils_js.ml
+++ b/lang_js/analyze/utils_js.ml
@@ -4,7 +4,7 @@ let string_of_any ast =
 
 let load db gen =
   try
-    let in_channel = open_in db in
+    let in_channel = open_in_bin db in
     let data = Marshal.from_channel in_channel in
     close_in in_channel;
     data

--- a/lang_lisp/analyze/graph_code_lisp.ml
+++ b/lang_lisp/analyze/graph_code_lisp.ml
@@ -235,7 +235,7 @@ let build ?(verbose=true) root files =
   let g = G.create () in
   G.create_initial_hierarchy g;
 
-  let chan = open_out (Filename.concat root "pfff.log") in
+  let chan = open_out_bin (Filename.concat root "pfff.log") in
 
   let env = {
     g;

--- a/lang_php/analyze/graph_code_php.ml
+++ b/lang_php/analyze/graph_code_php.ml
@@ -1073,7 +1073,7 @@ let build
   let g = G.create () in
   G.create_initial_hierarchy g;
 
-  let chan = open_out logfile in
+  let chan = open_out_bin logfile in
   let env = {
     g;
 

--- a/lang_ruby/parsing/test_parsing_ruby.ml
+++ b/lang_ruby/parsing/test_parsing_ruby.ml
@@ -17,7 +17,7 @@ let test_tokens file =
   Flag.exn_when_lexical_error := true;
 *)
 
-  let ic = open_in file in
+  let ic = open_in_bin file in
   let lexbuf = Lexing.from_channel ic in
   let state = Lexer_parser_ruby.create ("top_lexer", Lexer_ruby.top_lexer) in
 


### PR DESCRIPTION
I replaced `open_in` by `open_in_bin` everywhere so as to avoid contents mangling on Windows. This will avoid crashing in some cases (e.g. when reading marshaled data) and will avoid invalid locations or `End_of_file` errors in other cases. Parsers are already capable of interpreting both CRLF and LF as line terminators anyway.

This is most of the work for https://github.com/returntocorp/semgrep/issues/3061
Might fix (?) https://github.com/returntocorp/semgrep/issues/2991
