### PR TITLE
Rewrite Common.read_file to support input from '<(echo contents)' (process substitution)

### DIFF
--- a/commons/Common.ml
+++ b/commons/Common.ml
@@ -1203,13 +1203,31 @@ let cat file =
     close_in chan;
     List.rev !acc
 
-let read_file2 file =
-  let ic = open_in_bin file  in
-  let size = in_channel_length ic in
-  let buf = Bytes.create size in
-  really_input ic buf 0 size;
-  close_in ic;
-  buf |> Bytes.to_string
+(*
+   This implementation works even with Linux files like /dev/fd/63
+   created by bash's process substitution e.g.
+
+     my-ocaml-program <(echo contents)
+
+   See https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html
+*)
+let read_file2 path =
+  let buf_len = 4096 in
+  let extbuf = Buffer.create 4096 in
+  let buf = Bytes.create buf_len in
+  let rec loop fd =
+    match Unix.read fd buf 0 buf_len with
+    | 0 -> Buffer.contents extbuf
+    | num_bytes ->
+        assert (num_bytes > 0);
+        assert (num_bytes <= buf_len);
+        Buffer.add_subbytes extbuf buf 0 num_bytes;
+        loop fd
+  in
+  let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
+  Fun.protect
+    ~finally:(fun () -> Unix.close fd)
+    (fun () -> loop fd)
 
 let read_file a =
   profile_code "Common.read_file" (fun () -> read_file2 a)

--- a/commons/Common.ml
+++ b/commons/Common.ml
@@ -1210,6 +1210,16 @@ let cat file =
      my-ocaml-program <(echo contents)
 
    See https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html
+
+   In bash, '<(echo contents)' is replaced by something like
+   '/dev/fd/63' which is a special file of apparent size 0 (as
+   reported by `Unix.stat`) but contains data (here,
+   "contents\n"). So we can't use 'Unix.stat' or 'in_channel_length'
+   to obtain the length of the file contents. Instead, we read the file
+   chunk by chunk until there's nothing left to read.
+
+   Why such a function is not provided by the ocaml standard library is
+   unclear.
 *)
 let read_file2 path =
   let buf_len = 4096 in

--- a/commons/Common.mli
+++ b/commons/Common.mli
@@ -123,13 +123,14 @@ val cat :      filename -> string list
 val write_file : file:filename -> string -> unit
 (*e: signature [[Common.write_file]] *)
 (*s: signature [[Common.read_file]] *)
-(*
-   Read the contents of file.
+(* Read the contents of file.
 
    This implementation works even with Linux files like /dev/fd/63
-   created by bash when using e.g.
+   created by bash when using "process substitution"* e.g.
 
      my-ocaml-program <(echo contents)
+
+   * https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html
 *)
 val read_file : filename -> string
 (*e: signature [[Common.read_file]] *)

--- a/commons/Common.mli
+++ b/commons/Common.mli
@@ -123,6 +123,14 @@ val cat :      filename -> string list
 val write_file : file:filename -> string -> unit
 (*e: signature [[Common.write_file]] *)
 (*s: signature [[Common.read_file]] *)
+(*
+   Read the contents of file.
+
+   This implementation works even with Linux files like /dev/fd/63
+   created by bash when using e.g.
+
+     my-ocaml-program <(echo contents)
+*)
 val read_file : filename -> string
 (*e: signature [[Common.read_file]] *)
 


### PR DESCRIPTION
In bash, `<(echo contents)` is replaced by something like `/dev/fd/63` which is a special file of _apparent_ size 0 (as reported by `Unix.stat`) but contains data (here, `"contents\n"`). So we can't use `Unix.stat` or `in_channel_length` to obtain the size of such file.

In semgrep-core, this new implementation of `Common.read_file` directly allows reading from a pattern file without creating the file manually, using `semgrep-core -f <(echo 'alert(...)')` if needed, which behaves like `semgrep-core -e 'alert(...)'`. The goal is to make this work for target files as well, but this will take changes in semgrep-core.

See also [the bash manual for process substitution](https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html).
