### PR TITLE
Add max_depth option to the pretty-printer.

### DIFF
--- a/commons/OCaml.mli
+++ b/commons/OCaml.mli
@@ -69,8 +69,13 @@ val string_ofv: v -> string
 val list_ofv: (v -> 'a) -> v -> 'a list
 val option_ofv: (v -> 'a) -> v -> 'a option
 
-(* regular pretty printer (not via sexp, but using Format) *)
-val string_of_v: v -> string
+(*
+   Regular pretty printer (not via sexp, but using Format).
+
+   Use max_depth=1 to show only the root construct, use max_depth=2 to
+   show two levels deep, etc. The default is to show the whole tree.
+*)
+val string_of_v: ?max_depth:int -> v -> string
 
 (* sexp converters *)
 (*


### PR DESCRIPTION
I'm using this to print subtrees during matching in semgrep:
```
----- m_stmt -----
stmt pattern 2:
ExprStmt(Call(..., ...), ())
~~~~~
stmt target 4:
If((), Call(..., ...), ExprStmt(..., ...), None)
```

### Security

- [x] Change has no security implications (otherwise, ping the security team)
