### PR TITLE
[C++] remove TBase

### DIFF
--- a/lang_cpp/analyze/highlight_cpp.ml
+++ b/lang_cpp/analyze/highlight_cpp.ml
@@ -446,9 +446,9 @@ let visit_toplevel ~tag_hook _prefs (*db_opt *) (ast, toks) =
            | _ -> tag ii Comment
           )
 
-    | T.TInt (_,ii) | T.TFloat ((_,ii), _) ->
+    | T.TInt (_,ii) | T.TFloat (_,ii) ->
         tag ii Number
-    | T.TString ((_s,ii), _) | T.TChar ((_s,ii), _) ->
+    | T.TString (_s,ii) | T.TChar (_s,ii) ->
         tag ii String
     | T.Tfalse ii | T.Ttrue ii  ->
         tag ii Boolean

--- a/lang_cpp/parsing/lexer_cpp.mll
+++ b/lang_cpp/parsing/lexer_cpp.mll
@@ -512,26 +512,26 @@ rule token = parse
       { let info = tokinfo lexbuf in
         let s = char lexbuf   in
         let t = info |> tok_add_s (s ^ "'") in
-        TChar     ((s, t),   IsChar)
+        TChar (s, t)
       }
   | '"'
       { let info = tokinfo lexbuf in
         let s = string lexbuf in
         let t = info |> tok_add_s (s ^ "\"") in
-        TString   ((s, t),   IsChar)
+        TString (s, t)
       }
   (* wide character encoding, TODO L'toto' valid ? what is allowed ? *)
   | 'L' "'"
       { let info = tokinfo lexbuf in
         let s = char lexbuf   in
         let t = info |> tok_add_s (s ^ "'") in
-        TChar     ((s,t),   IsWchar)
+        TChar (s,t)
       }
   | 'L' '"'
       { let info = tokinfo lexbuf in
         let s = string lexbuf in
         let t = info |> tok_add_s (s ^ "\"") in
-        TString   ((s,t),   IsWchar)
+        TString (s,t)
       }
 
   (* Take care of the order ? No because lex try the longest match. The
@@ -553,9 +553,9 @@ rule token = parse
         )?
     ) as x { TInt (int_of_string_opt x, tokinfo lexbuf) }
 
-  | (real ['f' 'F']) as x { TFloat ((float_of_string_opt x, tokinfo lexbuf), CFloat) }
-  | (real ['l' 'L']) as x { TFloat ((float_of_string_opt x, tokinfo lexbuf), CLongDouble) }
-  | (real as x)           { TFloat ((float_of_string_opt x, tokinfo lexbuf), CDouble) }
+  | (real ['f' 'F']) as x { TFloat ((float_of_string_opt x, tokinfo lexbuf)) }
+  | (real ['l' 'L']) as x { TFloat ((float_of_string_opt x, tokinfo lexbuf)) }
+  | real as x             { TFloat ((float_of_string_opt x, tokinfo lexbuf)) }
 
   | ['0'] ['0'-'9']+
       { error (error_radix "octal" ^ tok lexbuf) lexbuf;

--- a/lang_cpp/parsing/parse_cpp.ml
+++ b/lang_cpp/parsing/parse_cpp.ml
@@ -23,7 +23,6 @@ module Flag_cpp = Flag_parsing_cpp
 module T = Parser_cpp
 module TH = Token_helpers_cpp
 module Lexer = Lexer_cpp
-module Semantic = Parser_cpp_mly_helper
 
 let logger = Logging.get_logger [__MODULE__]
 
@@ -368,7 +367,7 @@ let parse_with_lang ?(lang=Flag_parsing_cpp.Cplusplus) file : (Ast.program, T.to
             (* menhir *)
             | Parser_cpp.Error ->
                 pr2 ("parse error \n = " ^ error_msg_tok tr.PI.current)
-            | Semantic.Semantic (s, _i) ->
+            | Parse_info.Other_error (s, _i) ->
                 pr2 ("semantic error " ^s^ "\n ="^ error_msg_tok tr.PI.current)
             | e -> raise e
            );

--- a/lang_cpp/parsing/parser_cpp.mly
+++ b/lang_cpp/parsing/parser_cpp.mly
@@ -922,35 +922,35 @@ exception_decl:
 type_spec:
  | simple_type_specifier { $1 }
  | elaborated_type_specifier { $1 }
- | enum_specifier  { Right3 $1, noii }
- | class_specifier { Right3 (ClassDef $1), noii }
+ | enum_specifier  { Right3 $1 }
+ | class_specifier { Right3 (ClassDef $1) }
 
 simple_type_specifier:
- | Tvoid                { Right3 (TPrimitive (TVoid, $1)), noii }
- | Tchar                { Right3 (TPrimitive (TChar, $1)), noii }
- | Tint                 { Right3 (TPrimitive (TInt, $1)), noii }
- | Tfloat               { Right3 (TPrimitive (TFloat, $1)),  noii }
- | Tdouble              { Right3 (TPrimitive (TDouble, $1)), noii }
- | Tshort               { Middle3 (Short $1),  noii}
- | Tlong                { Middle3 (Long $1),   noii}
- | Tsigned              { Left3 (Signed $1),   noii}
- | Tunsigned            { Left3 (UnSigned $1), noii}
+ | Tvoid                { Right3 (TPrimitive (TVoid, $1)) }
+ | Tchar                { Right3 (TPrimitive (TChar, $1)) }
+ | Tint                 { Right3 (TPrimitive (TInt, $1)) }
+ | Tfloat               { Right3 (TPrimitive (TFloat, $1)) }
+ | Tdouble              { Right3 (TPrimitive (TDouble, $1)) }
+ | Tshort               { Middle3 (Short $1)}
+ | Tlong                { Middle3 (Long $1)}
+ | Tsigned              { Left3 (Signed $1)}
+ | Tunsigned            { Left3 (UnSigned $1)}
  (*c++ext: *)
- | Tbool                { Right3 (TPrimitive (TBool, $1)), noii }
- | Twchar_t             { Right3 (TypeName (name_of_id ("wchar_t", $1))), noii}
+ | Tbool                { Right3 (TPrimitive (TBool, $1)) }
+ | Twchar_t             { Right3 (TypeName (name_of_id ("wchar_t", $1)))}
 
  (* gccext: *)
- | Ttypeof "(" assign_expr ")" { Right3(TypeOf ($1,($2,Right $3,$4))), noii}
- | Ttypeof "(" type_id     ")" { Right3(TypeOf ($1,($2,Left $3,$4))), noii}
+ | Ttypeof "(" assign_expr ")" { Right3(TypeOf ($1,($2,Right $3,$4)))}
+ | Ttypeof "(" type_id     ")" { Right3(TypeOf ($1,($2,Left $3,$4)))}
 
  (* history: cant put TIdent {} cos it makes the grammar ambiguous and
   * generates lots of conflicts => we must use some tricks.
   * See parsing_hacks_typedef.ml. See also conflicts.txt
   *)
- | type_cplusplus_id { Right3 (TypeName $1), noii }
+ | type_cplusplus_id { Right3 (TypeName $1) }
 
  (* c++0x: *)
- | decltype_specifier { Middle3 (Long $1), [$1] }
+ | decltype_specifier { Middle3 (Long $1) }
 
 decltype_specifier:
  (* c++0x: TODO *)
@@ -960,10 +960,10 @@ decltype_specifier:
 
 (*todo: can have a ::opt optl(nested_name_specifier) before ident*)
 elaborated_type_specifier:
- | Tenum ident                  { Right3 (EnumName ($1, name_of_id $2)), noii }
- | class_key ident              { Right3 (ClassName ($1, name_of_id $2)), noii }
+ | Tenum ident                  { Right3 (EnumName ($1, name_of_id $2)) }
+ | class_key ident              { Right3 (ClassName ($1, name_of_id $2)) }
  (* c++ext:  *)
- | Ttypename type_cplusplus_id  { Right3 (TypenameKwd ($1, (nQ, TypeName $2))), noii }
+ | Ttypename type_cplusplus_id  { Right3 (TypenameKwd ($1, (nQ, TypeName $2)))}
 
 (*----------------------------*)
 (* c++ext:  *)

--- a/lang_cpp/parsing/parsing_hacks_pp.ml
+++ b/lang_cpp/parsing/parsing_hacks_pp.ml
@@ -370,7 +370,7 @@ let rec find_macro_paren xs =
   *)
 
   (* string macro variable, before case *)
-  | PToken ({t=TString ((str,_),_)})::PToken ({t=TIdent (_s,_)} as id)
+  | PToken ({t=TString (str,_)})::PToken ({t=TIdent (_s,_)} as id)
     ::xs ->
 
       (* c++ext: *)

--- a/lang_cpp/parsing/token_helpers_cpp.ml
+++ b/lang_cpp/parsing/token_helpers_cpp.ml
@@ -303,9 +303,9 @@ let visitor_info_of_tok f = function
   | Tthread_local i -> Tthread_local (f i)
   | Tnullptr i -> Tnullptr (f i)
   | Tconstexpr i -> Tconstexpr (f i)
-  | TString ((s, i), isWchar)  -> TString ((s, f i),isWchar)
-  | TChar  ((s, i), isWchar)   -> TChar  ((s, f i), isWchar)
-  | TFloat ((s, i), floatType) -> TFloat ((s, f i), floatType)
+  | TString (s, i)  -> TString (s, f i)
+  | TChar  (s, i)   -> TChar  (s, f i)
+  | TFloat (s, i) -> TFloat (s, f i)
   | TAssign  ((x, i)) -> TAssign ((x, f i))
 
   | TIdent  (s, i)       -> TIdent  (s, f i)


### PR DESCRIPTION
TBase has been deprecated in favor of TPrimitive and the
more general TSized

test plan:
make


### Security

- [x] Change has no security implications (otherwise, ping the security team)