### PR TITLE
Don't raise an exception when printing a location that's not available.

### DIFF
--- a/h_program-lang/Parse_info.ml
+++ b/h_program-lang/Parse_info.ml
@@ -347,7 +347,9 @@ let string_of_token_location x =
   spf "%s:%d:%d" x.file x.line x.column
 
 let string_of_info x =
-  string_of_token_location (unsafe_token_location_of_info x)
+  match token_location_of_info x with
+  | Ok loc -> string_of_token_location loc
+  | Error msg -> spf "unknown location (%s)" msg
 
 let str_of_info  ii =
   match ii.token  with


### PR DESCRIPTION
I was getting this exception:
```
$ semgrep-core -lang bash -e 'x' <(echo '$X$Y')
/tmp/semgrep-core-2e673b-63:1:0: Fatal error: Parse_info.NoTokenLocation("FakeTokStr")
Raised at Parse_info.unsafe_token_location_of_info in file "src/pfff/h_program-lang/Parse_info.ml", line 139, characters 17-44
Called from Parse_info.string_of_info in file "src/pfff/h_program-lang/Parse_info.ml", line 350, characters 27-60
```
I was getting this error because I mistakenly called `Parse_info.string_of_info` (location string) instead of `Parse_info.str_of_info` (string contents of the token). Maybe these functions should be renamed but it's a minor issue.

As far as I can tell, `string_of_info` is used in pfff and in semgrep-core to print locations in log messages and shouldn't raise an exception. This PR avoids the exception.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
