### PR TITLE
Provide exception printer for the Parse_info module

### DIFF
--- a/h_program-lang/Parse_info.mli
+++ b/h_program-lang/Parse_info.mli
@@ -92,6 +92,15 @@ exception NoTokenLocation of string
 
 val lexical_error: string -> Lexing.lexbuf -> unit
 
+(*
+   Register printers for the exceptions defined in this module.
+
+   This makes 'Printexc.to_string' print the exceptions in a more complete
+   fashion than the default printer, which only prints ints and strings
+   and doesn't descend any deeper.
+*)
+val register_exception_printer : unit -> unit
+
 (*****************************************************************************)
 (* Info accessors and builders *)
 (*****************************************************************************)


### PR DESCRIPTION
This allows showing location and token instead of `Parse_info.Parsing_error (_)` when printing the exception with `Printexc.to_string`.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
