### PR TITLE
Scala: parse nullary constructors with no arguments in more locations

### DIFF
--- a/lang_scala/parsing/Parser_scala_recursive_descent.ml
+++ b/lang_scala/parsing/Parser_scala_recursive_descent.ml
@@ -605,7 +605,7 @@ let inBracesOrNil = inBraces
 (** {{{ { `sep` part } }}}. *)
 let separatedToken sep part in_ =
   (* CHECK: "separator cannot be a comma" *)
-  in_ |> with_logging (spf "separatedTopen(%s)" (T.show sep)) (fun () ->
+  in_ |> with_logging (spf "separatedToken(%s)" (T.show sep)) (fun () ->
     let ts = ref [] in
     while in_.token =~= sep do
       let ii = TH.info_of_tok in_.token in
@@ -1952,8 +1952,8 @@ and argumentExprs in_ : arguments =
           | _ -> args in_
         ) in_
         |> (fun x -> Args x)
-    (* stricter: *)
-    | _ -> error "was expecting a ( or { for an argumentExprs" in_
+    (* TODO: is using this token a good idea? Would unsafe_fake_bracket be better or worse? *)
+    | _ -> Args (fb (TH.info_of_tok in_.token) [])
   )
 
 (* ------------------------------------------------------------------------- *)

--- a/tests/scala/parsing/constructor_annots.scala
+++ b/tests/scala/parsing/constructor_annots.scala
@@ -1,0 +1,3 @@
+class A @Annot private[B] {
+  val x = 0
+}


### PR DESCRIPTION
Details in:
https://github.com/returntocorp/semgrep/pull/4225

### Security

- [x] Change has no security implications (otherwise, ping the security team)
