### PR TITLE
Scala: parse infix type operators with tuple arguments

### DIFF
--- a/lang_scala/parsing/Parser_scala_recursive_descent.ml
+++ b/lang_scala/parsing/Parser_scala_recursive_descent.ml
@@ -1055,8 +1055,10 @@ and tupleInfixType in_ : type_ =
          (* CHECK: ts foreach checkNotByNameOrVarargs *)
          (* ast: makeSafeTupleType(ts) *)
          let tuple =  TyTuple ts in
-         warning "tupleInfixType:STILL? infixTypeRest(compoundTypeRest(...))";
-         tuple
+         let str = simpleTypeRest tuple in_ in
+         let atr = !annotTypeRest_ str in_ in
+         let ctr = compoundTypeRest (Some atr) in_ in
+         infixTypeRest ctr FirstOp in_
     )
   )
 

--- a/tests/scala/parsing/tuple_infix_type.scala
+++ b/tests/scala/parsing/tuple_infix_type.scala
@@ -1,0 +1,7 @@
+object Foo {
+  implicit def curryUncurryAdjunction[S]: (S, *) -| (S => *) =
+      new Adjunction[(S, *), (S => *)] {
+        override def leftAdjunct[A, B](a: => A)(f: ((S, A)) => B): S => B = s => f((s, a))
+        override def rightAdjunct[A, B](a: (S, A))(f: A => S => B): B = f(a._2)(a._1)
+      }
+}


### PR DESCRIPTION
Details in https://github.com/returntocorp/semgrep/pull/4236.

test plan: make test (see added test)
### Security

- [x] Change has no security implications (otherwise, ping the security team)
