### PR TITLE
Go: Allow newline after ellipsis standing for key-value pair list

### DIFF
--- a/lang_go/parsing/parser_go.mly
+++ b/lang_go/parsing/parser_go.mly
@@ -758,6 +758,16 @@ complitexpr:
 |   "{" braced_keyval_list "}" { InitBraces ($1, $2, $3) }
 
 bare_complitexpr:
+(* Special case to deal with automatic semicolon insertion. We want to parse
+   &http.Transport{
+     ...
+   }
+   but ASI turns this into
+   &http.Transport{
+     ...;
+   }
+*)
+|   "..." ";" { InitExpr (Ellipsis $1)}
 |   expr { InitExpr $1 }
 |   "{" braced_keyval_list "}" { InitBraces ($1, $2, $3) }
 


### PR DESCRIPTION
Details in: https://github.com/returntocorp/semgrep/pull/4404

### Security

- [x] Change has no security implications (otherwise, ping the security team)
