### PR TITLE
Scala: Add PatEllipsis to AST

### DIFF
--- a/lang_scala/parsing/AST_scala.ml
+++ b/lang_scala/parsing/AST_scala.ml
@@ -236,6 +236,7 @@ and pattern =
   | PatUnderscoreStar of tok (* '_' *) * tok (* '*' *)
 
   | PatDisj of pattern * tok (* | *) * pattern
+  | PatEllipsis of tok
 
 (*****************************************************************************)
 (* Expressions *)

--- a/lang_scala/parsing/Parser_scala_recursive_descent.ml
+++ b/lang_scala/parsing/Parser_scala_recursive_descent.ml
@@ -1535,6 +1535,9 @@ and simplePattern in_ : pattern =
     | x when TH.isLiteral x ->
         let x = literal ~inPattern:true in_ in
         PatLiteral x
+    | Ellipsis t ->
+        nextToken in_;
+        PatEllipsis t
     (* scala3: deprecated XMLSTART *)
     | _ ->
         error "illegal start of simple pattern" in_


### PR DESCRIPTION
Details in: https://github.com/returntocorp/semgrep/pull/4409
This PR adds `PatEllipsis` to the Scala AST

### Security

- [x] Change has no security implications (otherwise, ping the security team)
