### PR TITLE
Expose the character used by the Unicode hack

### DIFF
--- a/h_program-lang/Parse_info.ml
+++ b/h_program-lang/Parse_info.ml
@@ -637,6 +637,8 @@ let complete_token_location_large filename table x =
     column = snd (table (x.charpos));
   }
 
+let unicode_hack_replacement_byte = 'Z'
+
 (* Why is it better to first get all the tokens?
  * Why not lex on-demand as yacc requires more tokens?
  * There are a few reasons:
@@ -654,13 +656,22 @@ let tokenize_all_and_adjust_pos ?(unicode_hack=false)
         let string =
           Common.profile_code "Unicode.input_and_replace_non_ascii" (fun () ->
           (*
+             We replace all unicode characters by Zs as a hack to avoid
+             invalid locations due to assumptions that one byte = character.
+             This causes any non-ascii character to be represented by a
+             sequence of Zs, resulting in false positives such
+             as '"😀"' matching '"🚀"'.
+             See https://github.com/returntocorp/semgrep/issues/2111
+             TODO: get rid of this hack and fix location problems properly
+
              This breaks java (and perhaps other) characters constants.
              UTF-8 characters become something invalid like this:
                char c = 'ZZZ'
              There's a hack in the java lexer to support such invalid
              character literals.
           *)
-            Unicode.input_and_replace_non_ascii ~replacement_byte:'Z' chan
+            Unicode.input_and_replace_non_ascii
+              ~replacement_byte:unicode_hack_replacement_byte chan
           ) in
         Lexing.from_string string
       else

--- a/h_program-lang/Parse_info.mli
+++ b/h_program-lang/Parse_info.mli
@@ -229,6 +229,14 @@ val combine_infos: t -> t list -> t
  * line, otherwise the line/col of the result might be wrong *)
 val split_info_at_pos: int -> t -> t * t
 
+(*
+   Any non-ascii byte is replaced by this ascii character as a hack to
+   work around our lack of support for Unicode-aware code locations.
+   This character is 'Z'.
+   Any sequence of one of more Zs may be the result of such replacement.
+*)
+val unicode_hack_replacement_byte : char
+
 (* to be used by the lexer *)
 val tokenize_all_and_adjust_pos:
   ?unicode_hack:bool ->

--- a/h_program-lang/Unicode.mli
+++ b/h_program-lang/Unicode.mli
@@ -1,5 +1,13 @@
 (*
    Utilities for dealing with Unicode issues.
+
+   Notes for later:
+
+   Eventually, we want to support Unicode properly! At a minimum, we want:
+   - comparing raw UTF-8 data is done correctly i.e. the pattern
+     '"😀"' matches the target code '"😀"' and not '"🚀"'.
+   - positions in source code (number of lines, position within the line)
+     must be interpreted identically in javascript, python, and ocaml.
 *)
 
 (*

--- a/testutil/Testutil.ml
+++ b/testutil/Testutil.ml
@@ -86,6 +86,11 @@ let to_alcotest ?(speed_level = `Quick) tests : unit Alcotest.test list =
   tests
   |> list_map (fun (path, func) ->
     let category, name = split_path path in
+    let category =
+      match category with
+      | "" -> name
+      | s -> s
+    in
     let pretty_category = use_pretty_path_separator category in
     (pretty_category, (name, speed_level, func)))
   |> group_by_key


### PR DESCRIPTION
\+ assign a category name to the tests that don't have one so that we can filter them by name on the command line.

Used by https://github.com/returntocorp/semgrep/pull/4415

### Security

- [x] Change has no security implications (otherwise, ping the security team)
