### PR TITLE
Remove Unicode hack from Go/Java/JavaScript/Python parsers

### DIFF
--- a/h_program-lang/Parse_info.mli
+++ b/h_program-lang/Parse_info.mli
@@ -235,17 +235,8 @@ val combine_infos: t -> t list -> t
  * line, otherwise the line/col of the result might be wrong *)
 val split_info_at_pos: int -> t -> t * t
 
-(*
-   Any non-ascii byte is replaced by this ascii character as a hack to
-   work around our lack of support for Unicode-aware code locations.
-   This character is 'Z'.
-   Any sequence of one of more Zs may be the result of such replacement.
-*)
-val unicode_hack_replacement_byte : char
-
 (* to be used by the lexer *)
 val tokenize_all_and_adjust_pos:
-  ?unicode_hack:bool ->
   Common.filename ->
   (Lexing.lexbuf -> 'tok) (* tokenizer *) ->
   ((t -> t) -> 'tok -> 'tok) (* token visitor *) ->

--- a/lang_cpp/parsing/parse_cpp.ml
+++ b/lang_cpp/parsing/parse_cpp.ml
@@ -109,7 +109,7 @@ let is_same_line_or_close line tok =
 
 (* called by parse below *)
 let tokens file =
-  Parse_info.tokenize_all_and_adjust_pos ~unicode_hack:false
+  Parse_info.tokenize_all_and_adjust_pos
     file Lexer.token TH.visitor_info_of_tok TH.is_eof
 [@@profiling]
 

--- a/lang_go/parsing/parse_go.ml
+++ b/lang_go/parsing/parse_go.ml
@@ -43,7 +43,7 @@ let tokens2 file =
   let token lexbuf =
     Lexer.token lexbuf
   in
-  Parse_info.tokenize_all_and_adjust_pos ~unicode_hack:true
+  Parse_info.tokenize_all_and_adjust_pos
     file token TH.visitor_info_of_tok TH.is_eof
 
 let tokens a =

--- a/lang_go/parsing/unit_parsing_go.ml
+++ b/lang_go/parsing/unit_parsing_go.ml
@@ -11,11 +11,7 @@ let tests =
       let dir = Config_pfff.tests_path "go/parsing" in
       let files = Common2.glob (spf "%s/*.go" dir)in
       files |> List.iter (fun file ->
-        try
-          let _ = Parse_go.parse_program file in
-          ()
-        with Parse_info.Parsing_error _ ->
-          Alcotest.failf "it should correctly parse %s" file
+        Testutil.run file (fun () -> Parse_go.parse_program file |> ignore)
       )
     );
   ]

--- a/lang_java/parsing/parse_java.ml
+++ b/lang_java/parsing/parse_java.ml
@@ -38,7 +38,7 @@ let error_msg_tok tok =
 
 let tokens2 file =
   let token = Lexer_java.token in
-  Parse_info.tokenize_all_and_adjust_pos ~unicode_hack:true
+  Parse_info.tokenize_all_and_adjust_pos
     file token TH.visitor_info_of_tok TH.is_eof
 let tokens a =
   Common.profile_code "Java parsing.tokens" (fun () -> tokens2 a)

--- a/lang_java/parsing/unit_parsing_java.ml
+++ b/lang_java/parsing/unit_parsing_java.ml
@@ -15,11 +15,7 @@ let tests =
       let dir = Config_pfff.tests_path "java/parsing" in
       let files = Common2.glob (spf "%s/*.java" dir) in
       files |> List.iter (fun file ->
-        try
-          let _ = Parse_java.parse file in
-          ()
-        with Parse_info.Parsing_error _ ->
-          Alcotest.failf "it should correctly parse %s" file
+        Testutil.run file (fun () -> Parse_java.parse file |> ignore)
       )
     );
 

--- a/lang_js/parsing/lexer_js.mll
+++ b/lang_js/parsing/lexer_js.mll
@@ -273,8 +273,6 @@ rule initial = parse
    * The right solution would be to switch to a unicode-aware lexer generator,
    * like ulex or sedlex.
    * todo: https://en.wikipedia.org/wiki/Whitespace_character#Unicode
-   * update: with Parse_info.tokenize_all_and_adjust_pos ~unicode_hack:true
-   * the hack below is redundant.
    *)
   | "\xc2\xa0" (* non-breaking-space \u{00A0} *)
   | "\xef\xbb\xbf" (* byte-order-mark \u{FEFF} *)

--- a/lang_js/parsing/parse_js.ml
+++ b/lang_js/parsing/parse_js.ml
@@ -182,7 +182,7 @@ let tokens file =
     then Lexer_js._last_non_whitespace_like_token := Some tok;
     tok
   in
-  Parse_info.tokenize_all_and_adjust_pos ~unicode_hack:true
+  Parse_info.tokenize_all_and_adjust_pos
     file token TH.visitor_info_of_tok TH.is_eof
 [@@profiling]
 

--- a/lang_python/parsing/Parse_python.ml
+++ b/lang_python/parsing/Parse_python.ml
@@ -90,7 +90,7 @@ let tokens parsing_mode file =
         Parse_info.lexical_error s lexbuf;
         T.EOF (Parse_info.tokinfo lexbuf)
   in
-  Parse_info.tokenize_all_and_adjust_pos ~unicode_hack:true
+  Parse_info.tokenize_all_and_adjust_pos
     file token TH.visitor_info_of_tok TH.is_eof
 [@@profiling]
 

--- a/lang_python/parsing/Unit_parsing_python.ml
+++ b/lang_python/parsing/Unit_parsing_python.ml
@@ -11,11 +11,7 @@ let tests =
       let dir = Config_pfff.tests_path "python/parsing" in
       let files = Common2.glob (spf "%s/*.py" dir)in
       files |> List.iter (fun file ->
-        try
-          let _ = Parse_python.parse_program file in
-          ()
-        with Parse_info.Parsing_error _ ->
-          Alcotest.failf "it should correctly parse %s" file
+        Testutil.run file (fun () -> Parse_python.parse_program file |> ignore)
       )
     );
   ]

--- a/lang_scala/parsing/Parse_scala.ml
+++ b/lang_scala/parsing/Parse_scala.ml
@@ -48,7 +48,7 @@ let tokens file =
     tok
   in
   (* set to false to parse correctly arrows *)
-  Parse_info.tokenize_all_and_adjust_pos ~unicode_hack:false
+  Parse_info.tokenize_all_and_adjust_pos
     file token TH.visitor_info_of_tok TH.is_eof
 [@@profiling]
 

--- a/tests/go/parsing/rune.go
+++ b/tests/go/parsing/rune.go
@@ -6,6 +6,7 @@ func main() {
      r = '\u00FF'
      r = '\u00B7'
      a = '\''
+     gbp = '£'
      // this is not allowed by 'go run', but valid according to grammar rules
      //a = '''
 

--- a/testutil/Testutil.ml
+++ b/testutil/Testutil.ml
@@ -2,6 +2,8 @@
    Utilities for writing test suites for Alcotest.
 *)
 
+open Printf
+
 type test = string * (unit -> unit)
 
 (*
@@ -128,3 +130,11 @@ let filter ?substring ?pcre tests =
     && (matches_pcre path
         || matches_pcre pretty_path)
   )
+
+let run what f =
+  printf "running %s...\n%!" what;
+  Fun.protect
+    ~finally:(fun () ->
+      printf "done with %s.\n%!" what
+    )
+    f

--- a/testutil/Testutil.mli
+++ b/testutil/Testutil.mli
@@ -107,3 +107,13 @@ val filter : ?substring:string -> ?pcre:string -> test list -> test list
 *)
 val to_alcotest :
   ?speed_level:Alcotest.speed_level -> test list -> unit Alcotest.test list
+
+(*
+   Log a function call. e.g.
+
+     Testutil.run file (fun () -> Parse_java.parse file)
+
+   will log the file name instead of letting us guess which file was being
+   parsed.
+*)
+val run : string -> (unit -> 'a) -> 'a


### PR DESCRIPTION

### Security

- [x] Change has no security implications (otherwise, ping the security team)
