### PR TITLE
Use r2c's docker image with opam packages pre-installed.

### DIFF
--- a/.github/post-checkout
+++ b/.github/post-checkout
@@ -1,0 +1,77 @@
+#! /usr/bin/env bash
+#
+# Recover from changes made to our container by GitHub Actions.
+#
+# The problem is: We specify our own base image in the job config
+# but the first thing GHA does is change the working directory and
+# the HOME variable for the user. This script is an attempt to recover
+# data from the original working directory.
+#
+set -eu
+
+# The original user of the container (USER line in the dockerfile)
+# before GitHub changes it.
+#
+user="user"
+
+cat <<EOF
+Current directory: $(pwd)
+Current HOME: $HOME
+Current user: $(whoami)
+EOF
+
+# GHA sets the new HOME to something like '/github/home' (sic).
+# Let's not fight it, but we'll import files from the old home.
+#
+if [[ "$HOME" != "$(pwd)" ]]; then
+  cat <<EOF
+Switching current directory from $(pwd) to $HOME (HOME)."
+EOF
+  cd
+fi
+
+if [[ "$(whoami)" != "$user" ]]; then
+  cat <<EOF
+Original/desired user: $user"
+Current user: $(whoami)
+OMG, we're a different user.
+EOF
+fi
+
+if [[ -d .opam ]]; then
+  cat <<EOF
+.opam exists in the current directory. Let's assume everything is fine.
+EOF
+else
+  user_home=$(eval "echo ~$user")
+  cat <<EOF
+.opam doesn't exist in the current directory.
+Let's try importing files from the old home '$user_home'.
+EOF
+  (
+    # The following may be as simple as creating a symlink to the old .opam
+    # and to .bashrc. There could be other config files, so we try to deal
+    # with them gracefully.
+    #
+    shopt -s dotglob nullglob
+    for orig in "$user_home"/*; do
+      echo "Create symlink to '$orig'."
+      if ! ln -s "$orig" . ; then
+        echo "Symlink to '$orig' failed."
+        local=$(basename "$orig")
+        if [[ -f "$orig" && -f "$local" ]]; then
+          echo "Inserting contents of '$orig' at the beginning of '$local'."
+          (cat "$orig"; echo; cat "$local") >> "$local".tmp
+          mv -f "$local".tmp "$local"
+        else
+          echo "Warning: Failed to import some file '$orig' into '$(pwd)'."
+        fi
+      fi
+    done
+  )
+fi
+
+cat <<EOF
+Here's what we got in $(pwd):
+EOF
+ls -al

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,16 +10,28 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # Use our own image with opam dependencies pre-installed to speed
+    # things up.
+    container: returntocorp/ocaml:ubuntu
+
     steps:
-    - uses: actions/checkout@v1
+    - name: Pre-checkout fixes
+      run: |
+        sudo chmod -R 777 /github
+        github_cache_dir="/__w"
+        sudo mkdir -p "$github_cache_dir"
+        sudo chmod -R 777 "$github_cache_dir"
+    - uses: actions/checkout@v2
+
+    # Move /home/user/.opam to the new HOME imposed by GHA
+    - name: Post-checkout fixes
+      run: ./.github/post-checkout
+
     - name: Install System Deps
       run: sudo apt update && sudo apt-get install -y --no-install-recommends wget swi-prolog mercurial ocaml opam
     - name: debugging
       run: opam --version
     - name: Install pfff
-      run: |
-        opam init
-        ./scripts/install-opam-deps --ocaml-version 4.10.2
-        opam install -y pfff
+      run: opam install -y pfff
     - name: Run Tests
       run: eval $(opam env); dune build && dune runtest -f

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,11 +34,12 @@ jobs:
         set -x
         echo "$HOME"
         echo "$PATH"
-        pwd
-        ocamlc -v
+        opam exec -- ocamlc -v
         opam --version
         opam switch list
         opam switch
+        pwd
+        ls -a
     - name: Install pfff
       run: opam install -y pfff
     - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,14 @@ jobs:
       run: sudo apt update && sudo apt-get install -y --no-install-recommends wget swi-prolog mercurial
     - name: debugging
       run: |
-        echo "HOME: $HOME"
-        echo "PATH: $PATH"
-        echo "current directory: $(pwd)"
-        echo "ocaml version: $(ocamlc -v)"
-        echo "opam version: $(opam --version)"
+        set -x
+        echo "$HOME"
+        echo "$PATH"
+        pwd
+        ocamlc -v
+        opam --version
+        opam switch list
+        opam switch
     - name: Install pfff
       run: opam install -y pfff
     - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       run: ./.github/post-checkout
 
     - name: Install System Deps
-      run: sudo apt update && sudo apt-get install -y --no-install-recommends wget swi-prolog mercurial ocaml opam
+      run: sudo apt update && sudo apt-get install -y --no-install-recommends wget swi-prolog mercurial
     - name: debugging
       run: |
         echo "HOME: $HOME"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,6 @@ jobs:
         pwd
         ls -a
     - name: Install pfff
-      run: opam install -y pfff
+      run: opam install -y .
     - name: Run Tests
       run: eval $(opam env); dune build && dune runtest -f

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,10 @@ jobs:
     - name: Install System Deps
       run: sudo apt update && sudo apt-get install -y --no-install-recommends wget swi-prolog mercurial ocaml opam
     - name: debugging
-      run: opam --version
+      run: |
+        echo "current directory: $(pwd)"
+        echo "ocaml version: $(ocamlc -v)"
+        echo "opam version: $(opam --version)"
     - name: Install pfff
       run: opam install -y pfff
     - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
       run: sudo apt update && sudo apt-get install -y --no-install-recommends wget swi-prolog mercurial ocaml opam
     - name: debugging
       run: |
+        echo "HOME: $HOME"
+        echo "PATH: $PATH"
         echo "current directory: $(pwd)"
         echo "ocaml version: $(ocamlc -v)"
         echo "opam version: $(opam --version)"


### PR DESCRIPTION
This upgrades ocaml from 4.10.2 to 4.12.0.

* makes the GHA job faster: 13 min -> 3 min
* fixes the build issue I ran into: https://github.com/returntocorp/pfff/pull/502#issuecomment-1011734210 (I don't know what the problem was but now it's working)

test plan: GitHub Actions job should succeed.

Implementation notes: the long `post-checkout` script was copied from the semgrep project. I wish we didn't have to resort to this.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
