### PR TITLE
commons: Fix filename_without_leading_path and readable

### DIFF
--- a/commons/Common.ml
+++ b/commons/Common.ml
@@ -1085,7 +1085,8 @@ let filename_without_leading_path prj_path s =
   if s =$= prj_path
   then "."
   else
-  if s =~ ("^" ^ prj_path ^ "/\\(.*\\)$")
+    (* Note that we should handle multiple consecutive '/' as in 'path/to//file' *)
+  if s =~ ("^" ^ prj_path ^ "/+\\(.*\\)$")
   then matched1 s
   else
     failwith

--- a/commons/Unit_commons.ml
+++ b/commons/Unit_commons.ml
@@ -77,6 +77,8 @@ let test_readable () =
     (Common.readable ~root:"." "a/b/Bar.java");
   Alcotest.(check string) "same string" "Bar.java"
     (Common.readable ~root:"/a/b/" "/a/b/Bar.java");
+  Alcotest.(check string) "same string" "Bar.java"
+    (Common.readable ~root:"/a/b/" "/a/b//Bar.java");
   ()
 
 


### PR DESCRIPTION
The filename of 'path/to//file' is 'file' and not '/file'.

test plan:
make file # test included

### Security

- [x] Change has no security implications (otherwise, ping the security team)
