### PR TITLE
Pin Menhir to a version that doesn't cause massive slowdowns

### DIFF
--- a/pfff.opam
+++ b/pfff.opam
@@ -34,7 +34,7 @@ depends: [
   "dune"
   "ocamlgraph"
   "yojson"
-  "menhir" {= "20211128"}
+  "menhir" {= "20211128"} (* Newer versions cause massive build slowdowns *)
   "grain_dypgen"
   "ppx_deriving"
   "ppx_hash"

--- a/pfff.opam
+++ b/pfff.opam
@@ -34,7 +34,7 @@ depends: [
   "dune"
   "ocamlgraph"
   "yojson"
-  "menhir"
+  "menhir" {= "20211128"}
   "grain_dypgen"
   "ppx_deriving"
   "ppx_hash"


### PR DESCRIPTION
The latest version of Menhir generates code that takes too much memory to compile.

Semgrep PR: https://github.com/returntocorp/semgrep/pull/4937
### Security

- [x] Change has no security implications (otherwise, ping the security team)
