### PR TITLE
[ruby] Allow 'unless' used as keyword argument or hash key

### DIFF
--- a/lang_ruby/parsing/parser_ruby.dyp
+++ b/lang_ruby/parsing/parser_ruby.dyp
@@ -724,6 +724,15 @@ pair:
     { token_immediate_check (snd $1) $2;
       $1, $2, $3
      }
+  /* HACK: 'unless' is a valid name for a keyword argument or a hash key!
+   * Tree-sitter's Ruby parser doesn't even treat 'unless' as a keyword.
+   * This is just a quick-fix until we use tree-sitter's parser also for
+   * parsing Semgrep patterns. */
+  | K_UNLESS T_COLON arg
+    {
+      token_immediate_check $1 $2;
+      ("unless", $1), $2, $3
+    }
 
 /*(*************************************************************************)*/
 /*(*1 Call *)*/


### PR DESCRIPTION
Helps returntocorp/semgrep#4948
Helps #PA-1094

test plan:          
```
% cat 4948.rb 
after_update $ARG, unless: ...
% pfff -dump_ruby 4948.rb
[(Call ((Id (("after_update", ()), ID_Lowercase)),
    ((),            
     [(Arg (Id (("$ARG", ()), ID_Global))); 
       (ArgKwd (("unless", ()), (), (Ellipsis ())))],
     ()),
    None))          
  ]                 
```
                          
Note that we interpret `unless: ...` as a keyword argument... but it
could also be interpreted as a "hash" (map). AFAICT the correct 
interpretation depends on how the called method is declared!

### Security

- [x] Change has no security implications (otherwise, ping the security team)
