### PR TITLE
[ruby] Add basic support for lambdas

### DIFF
--- a/lang_ruby/analyze/highlight_ruby.ml
+++ b/lang_ruby/analyze/highlight_ruby.ml
@@ -195,6 +195,7 @@ let visit_program ~tag_hook _prefs (_program, toks) =
     | T.T_LPAREN ii | T.T_LPAREN_ARG ii
       -> tag ii Punctuation
 
+    | T.T_RARROW ii
     | T.T_ASSOC ii
     | T.T_COMMA ii
     | T.T_DOT ii

--- a/lang_ruby/analyze/il_ruby_build.ml
+++ b/lang_ruby/analyze/il_ruby_build.ml
@@ -524,7 +524,8 @@ let rec refactor_expr (acc:stmt acc) (e : Ast.expr) : stmt acc * Il_ruby.expr =
 
   | Ast.S Ast.Case _ | Ast.S Ast.ExnBlock _
   | Ast.D Ast.EndBlock _ | Ast.D Ast.BeginBlock _
-  | Ast.CodeBlock _ | Ast.D Ast.MethodDef _
+  | Ast.CodeBlock _ | Ast.Lambda _
+  | Ast.D Ast.MethodDef _
   | Ast.S Ast.For _
   | Ast.S Ast.Unless _ | Ast.S Ast.Until _
   | Ast.S Ast.While _
@@ -1630,7 +1631,8 @@ and refactor_stmt (acc: stmt acc) (e:Ast.expr) : stmt acc =
       let pos = raise Todo in
       refactor_body acc body pos
 
-  | Ast.CodeBlock _ as s ->
+  | Ast.CodeBlock _
+  | Ast.Lambda _ as s ->
       Log.fatal (Log.of_tok (tok_of s))
         "refactor_stmt: unknown stmt to refactor: %s\n"
         (Ast_ruby.show_expr s)

--- a/lang_ruby/parsing/ast_ruby.ml
+++ b/lang_ruby/parsing/ast_ruby.ml
@@ -216,6 +216,7 @@ type expr =
 
   (* true = {}, false = do/end *)
   | CodeBlock of bool bracket * formal_param list option * stmts
+  | Lambda of tok * formal_param list option * stmts
 
   | S of stmt
   | D of definition

--- a/lang_ruby/parsing/lexer_ruby.mll
+++ b/lang_ruby/parsing/lexer_ruby.mll
@@ -344,6 +344,11 @@ and top_lexer state = parse
   | ws* "&&"
       { S.beg_state state;T_ANDOP (tk lexbuf) }
 
+  (* HACK: need precedence over `ws+ '-'` otherwise " ->" is tokenized as
+   * "-" followed by ">", instead of as "->". *)
+  | ws+ "->"
+    {S.beg_state state;T_RARROW (tk lexbuf)}
+
   (* the following lexemes may represent various tokens depending on
      the expression state and surrounding spaces.  Space before and
      after is typically the binop form, while a space before but not
@@ -445,6 +450,7 @@ and top_lexer state = parse
   | "!~"  {S.beg_state state;T_NMATCH (tk lexbuf) }
   | ">>"  {S.beg_state state;T_RSHFT (tk lexbuf)}
   | "=>"  {S.beg_state state;T_ASSOC (tk lexbuf)}
+  | "->"  {S.beg_state state;T_RARROW (tk lexbuf)}
   | '^'   {S.beg_state state;T_CARROT (tk lexbuf)}
   | '|'   {S.beg_state state;T_VBAR (tk lexbuf)}
 

--- a/lang_ruby/parsing/parser_ruby.dyp
+++ b/lang_ruby/parsing/parser_ruby.dyp
@@ -287,6 +287,7 @@ and params_to_pattern xs =
 %token <Parse_info.t> T_SLASH    /* / */
 %token <Parse_info.t> T_PERCENT  /* % */
 
+%token <Parse_info.t> T_RARROW   /* -> */
 %token <Parse_info.t> T_CARROT       /* ^ */
 %token <Parse_info.t> T_VBAR         /* | */
 %token <Parse_info.t> T_BANG         /* ! */
@@ -488,6 +489,8 @@ primary:
 
   | primary<p> T_LBRACK_ARG<t1> eols arg_comma_list_trail<xs> eols T_RBRACK<t2>
      { M.methodcall (DotAccess(p,(t1), MethodOperator(Op_AREF,t2))) (fb xs) None }
+
+  | lambda { $1 }
 
   | array { $1 }
   | hash { $1 }
@@ -941,6 +944,20 @@ code_block_body:
 do_codeblock:
   | K_DO eols code_block_body<b> K_lEND
       { let args, body = b in CodeBlock(($1,false,$4),args,body) }
+
+/*(*----------------------------*)*/
+/*(*2 Lambda *)*/
+/*(*----------------------------*)*/
+
+lambda:
+  | T_RARROW<pos> lambda_args<opt_args> eols lambda_body<body>
+      { Lambda (pos, opt_args, body) }
+
+lambda_args:
+  | T_LPAREN eols formal_arg_list<args> T_RPAREN  { Some args }
+
+lambda_body:
+  | T_LBRACE_ARG eols stmt_list<body> T_RBRACE    { body }
 
 /*(*----------------------------*)*/
 /*(*2 parameters (not arguments, as the name (wrongly) says) *)*/

--- a/lang_ruby/parsing/parser_ruby.mli
+++ b/lang_ruby/parsing/parser_ruby.mli
@@ -6,6 +6,7 @@ type token =
   | T_BANG of Parse_info.t
   | T_VBAR of Parse_info.t
   | T_CARROT of Parse_info.t
+  | T_RARROW of Parse_info.t
   | T_PERCENT of Parse_info.t
   | T_SLASH of Parse_info.t
   | T_USTAR of Parse_info.t
@@ -196,6 +197,7 @@ val pp :
    | `Obj_T_PLUS of Parse_info.t
    | `Obj_T_POW of Parse_info.t
    | `Obj_T_QUESTION of Parse_info.t
+   | `Obj_T_RARROW of Parse_info.t
    | `Obj_T_RBRACE of Parse_info.t
    | `Obj_T_RBRACK of Parse_info.t
    | `Obj_T_REGEXP_BEG of Parse_info.t
@@ -265,6 +267,9 @@ val pp :
    | `Obj_interp_str of Ast_ruby.interp list
    | `Obj_interp_str_work of Ast_ruby.interp list
    | `Obj_keyword_as_id of Ast_ruby.ident
+   | `Obj_lambda of Ast_ruby.expr
+   | `Obj_lambda_args of Ast_ruby.formal_param list option
+   | `Obj_lambda_body of Ast_ruby.stmts
    | `Obj_lhs of Ast_ruby.expr
    | `Obj_lhs_assign_op of
         Ast_ruby.expr * Ast_ruby.binary_op * Parse_info.t

--- a/lang_ruby/parsing/token_helpers_ruby.ml
+++ b/lang_ruby/parsing/token_helpers_ruby.ml
@@ -45,6 +45,7 @@ let visitor_info_of_tok f = function
   | T_AMPER ii -> T_AMPER (f ii)
   | T_TILDE ii -> T_TILDE (f ii)
   | T_BANG ii -> T_BANG (f ii)
+  | T_RARROW ii -> T_RARROW (f ii)
   | T_VBAR ii -> T_VBAR (f ii)
   | T_CARROT ii -> T_CARROT (f ii)
   | T_PERCENT ii -> T_PERCENT (f ii)


### PR DESCRIPTION
Yet another hack until we extend Ruby's tree-sitter grammar to parse
Semgrep patterns.

Helps returntocorp/semgrep#4950
Helps #PA-1095

test plan:
```
% cat 4950.rb
$FOO = -> (...) {...}
% pfff -dump_ruby 4950.rb
ASSIGN
[(Binop ((Id (("$FOO", ()), ID_Global)), (Op_ASSIGN, ()),
    (Lambda ((), (Some [(ParamEllipsis ())]), [(Ellipsis ())]))))
  ]
```

### Security

- [x] Change has no security implications (otherwise, ping the security team)
