### PR TITLE
fix(python): Allows parens around `with` context exprs

### DIFF
--- a/tests/python/parsing/with_stmt.py
+++ b/tests/python/parsing/with_stmt.py
@@ -18,3 +18,19 @@ def with_stmt_test():
 
     with open("some_file1.txt"), open("some_file2.txt"):
         x += 1
+
+    with (open("some_file1.txt"), open("some_file2.txt")):
+        x = 15112
+
+    with (
+        open("some_file1.txt") as f1,
+        open("some_file2.txt") as f2,
+    ):
+        data1 = f1.read()
+        data2 = f2.read()
+
+    with (open("some_file1.txt") as f1, open("some_file2.txt"), ):
+        data1 = f1.read()
+
+    with (open("some_file1.txt"), open("some_file2.txt") as f2):
+        data2 = f2.read()


### PR DESCRIPTION
This PR adds support for parentheses around with context expressions. Previously, we allowed code like:

```
with open(x) as a, open(y) as b:
    pass
```

but not

```
with (open(x) as a, open(y) as b):
    pass
```
(or with a trailing comma)

After this PR, both would parse correctly.

Helps PA-1218

Test plan: tests included.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
