### PR TITLE
Make throw an expression in PHP

### DIFF
--- a/lang_php/analyze/ast_php.ml
+++ b/lang_php/analyze/ast_php.ml
@@ -209,6 +209,7 @@ type expr =
   | Unpack of expr
 
   | Call of expr * expr list bracket
+  | Throw of tok * expr
 
   (* todo? transform into Call (builtin ...) ? *)
   | Infix of AST_generic_.incr_decr wrap * expr
@@ -303,7 +304,6 @@ and stmt =
   | Label of ident * tok (* : *) * stmt
   | Goto of tok * ident
 
-  | Throw of tok * expr
   | Try of tok * stmt * catch list * finally list
 
   (* only at toplevel in most of our code *)

--- a/lang_php/analyze/ast_php_build.ml
+++ b/lang_php/analyze/ast_php_build.ml
@@ -285,7 +285,7 @@ and stmt env st acc =
   | Label (id,tok,st) -> A.Label (ident env id,tok,stmt1 tok (stmt env st [])) :: acc
   | Goto (tok,id,_) -> A.Goto (tok,ident env id) :: acc
   | Return (tok, eopt, _) -> A.Return (tok, opt expr env eopt) :: acc
-  | Throw (tok, e, _) -> A.Throw (tok, expr env e) :: acc
+  | Throw (tok, e, sc) -> A.Expr (A.Throw (tok, expr env e), sc) :: acc
   | Try (tok, (lb, stl, rb), cl, fl) ->
       let stl = List.fold_right (stmt_and_def env) stl [] in
       let cl = List.map (catch env) cl in

--- a/lang_php/analyze/graph_code_php.ml
+++ b/lang_php/analyze/graph_code_php.ml
@@ -736,7 +736,6 @@ and stmt_bis env x =
   (* TODO: does anything special need to be done for Label and Goto? *)
   | Label (_,_,st) -> stmt env st
   | Goto _ -> ()
-  | Throw (_, e) -> expr env e
   | Try (_, xs, cs, fs) ->
       stmt env xs;
       catches env (cs);
@@ -959,6 +958,7 @@ and expr env x =
            expr env e;
            exprl env es
       )
+  | Throw (_, e) -> expr env e
 
   (* -------------------------------------------------- *)
   (* This should be executed only for access to class constants or static


### PR DESCRIPTION
As of PHP 8.0.0, the throw keyword is an expression and may be used in any expression context. In prior versions it was a statement and was required to be on its own line.

[corresponding semgrep pull request](https://github.com/returntocorp/semgrep/pull/5306)

### Security

- [x] Change has no security implications (otherwise, ping the security team)
