### PR TITLE
feat: Add alternation function for options to `Common`

### DIFF
--- a/commons/Common.ml
+++ b/commons/Common.ml
@@ -920,6 +920,11 @@ let (|||) a b =
   | Some x -> x
   | None -> b
 
+let (<|>) a b =
+  match a with
+  | Some _ -> a
+  | _ -> b
+
 type ('a,'b) either = Left of 'a | Right of 'b
 [@@deriving eq]
 (* with sexp *)

--- a/commons/Common.mli
+++ b/commons/Common.mli
@@ -150,6 +150,7 @@ val optlist_to_list: 'a list option -> 'a list
 (* you should prefer let ( let* ) = Option.bind though *)
 val (>>=): 'a option -> ('a -> 'b option) -> 'b option
 val (|||): 'a option -> 'a -> 'a
+val (<|>): 'a option -> 'a option -> 'a option
 
 
 type ('a, 'b) either = Left of 'a | Right of 'b


### PR DESCRIPTION
Currently we only have a function of type `'a option -> 'a -> 'a`. It's
also useful to have one where both inputs are options.

Helps https://github.com/returntocorp/semgrep/pull/5343

### Security

- [x] Change has no security implications (otherwise, ping the security team)
