### PR TITLE
Work around YAML or JSON parsers that don't distinguish floats from ints

### DIFF
--- a/commons/JSON.ml
+++ b/commons/JSON.ml
@@ -21,6 +21,10 @@ let rec (to_yojson: t -> Y.t) = function
   | String s -> `String s
   | Int i -> `Int i
   | Bool b -> `Bool b
+  | Float x when Float.is_integer x ->
+      (* needed for atdgen readers that reject e.g. '4.0' when expecting
+         an integer *)
+      `Int (int_of_float x)
   | Float f -> `Float f
   | Null -> `Null
 


### PR DESCRIPTION
Atdgen readers that expect an int will reject a number literal containing a decimal point or some other notation normally associated with floats (`42.0`, `1e3`, ...). This caused a parsing error in Semgrep where the `options` section of a YAML rule is translated to the generic AST, then back to JSON, and finally parsed by an atdgen-generated JSON parser.

Perhaps atdgen should be more tolerant and accept float notations for ints as long as the decimal part is zero. Anyway, this PR fixes it.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
