### PR TITLE
Scala: do not parse parenthesized expressions as unary tuples

### DIFF
--- a/lang_scala/parsing/Parser_scala_recursive_descent.ml
+++ b/lang_scala/parsing/Parser_scala_recursive_descent.ml
@@ -1806,8 +1806,12 @@ and simpleExpr in_ : expr =
        * expressions when part of a short lambda (arrow).
       *)
       | LPAREN _ ->
-          let xs = makeParens (commaSeparated expr) in_ in
-          Tuple xs
+          let (_,xs,_) as tuple = makeParens (commaSeparated expr) in_ in
+          begin
+            match xs with
+            | [x] -> x
+            | _ -> Tuple tuple
+          end
       | LBRACE _ ->
           canApply := false;
           let x = blockExpr in_ in


### PR DESCRIPTION
See https://github.com/returntocorp/semgrep/pull/5387

### Security

- [x] Change has no security implications (otherwise, ping the security team)
