### PR TITLE
fix(js): Remove T_NEW variant from new_expr rule

### DIFF
--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -1311,7 +1311,6 @@ call_expr(x):
 
 new_expr(x):
  | member_expr(x)    { $1 }
- | T_NEW new_expr(d1) { special New $1 [$2] }
 
 member_expr(x):
  | primary_expr(x)                   { $1 }


### PR DESCRIPTION
### Security

- [x] Change has no security implications (otherwise, ping the security team)
