### PR TITLE
fix(js): Parse `New` as a separate construct from `Apply`

### DIFF
--- a/lang_js/analyze/graph_code_js.ml
+++ b/lang_js/analyze/graph_code_js.ml
@@ -579,13 +579,14 @@ and expr env e =
            add_use_edge_candidates env (n, E.Function) (*scope*)
        | IdSpecial (special, _tok) ->
            (match special, es with
-            | New, _ -> (* TODO *) ()
             | _ -> ()
            )
        | _ ->
            expr env e
       );
       List.iter (expr env) es
+
+  | New _ ->  (* TODO *) ()
 
   | Conditional (e1, e2, e3) ->
       List.iter (expr env) [e1;e2;e3]

--- a/lang_js/parsing/ast_js.ml
+++ b/lang_js/parsing/ast_js.ml
@@ -124,7 +124,7 @@ type special =
   | Arguments
 
   (* Special apply *)
-  | New | NewTarget
+  | NewTarget
   | Eval (* builtin not in the grammar *)
   | Seq
   (* a kind of cast operator:
@@ -220,6 +220,7 @@ and expr =
   (* ident is a Some when recursive lambda or assigned in module.exports *)
   | Fun of function_definition * a_ident option
   | Apply of expr * a_arguments
+  | New of tok * expr * a_arguments
 
   (* copy-paste of AST_generic.xml (but with different 'expr') *)
   | Xml of xml

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -1311,13 +1311,13 @@ call_expr(x):
 
 new_expr(x):
  | member_expr(x)    { $1 }
- | T_NEW new_expr(d1) { special New $1 [$2] }
+ | T_NEW new_expr(d1) { New ($1, $2, fb $1 []) }
 
 member_expr(x):
  | primary_expr(x)                   { $1 }
  | member_expr(x) "[" expr "]"       { ArrAccess($1, ($2, $3, $4)) }
  | member_expr(x) "." field_name     { ObjAccess($1, $2, PN $3) }
- | T_NEW member_expr(d1) arguments   { Apply(special New $1 [$2], $3) }
+ | T_NEW member_expr(d1) arguments   { New ($1, $2, $3) }
  (* es6: *)
  | member_expr(x) template_literal   { mk_Encaps (Some $1) $2 }
  | T_SUPER "[" expr "]"              { ArrAccess(mk_Super($1),($2,$3,$4))}

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -89,7 +89,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | Module -> ()
     | Define -> ()
     | Arguments -> ()
-    | New -> ()
     | NewTarget -> ()
     | Eval -> ()
     | Seq -> ()
@@ -182,6 +181,9 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           ()
       | Fun (v1, v2) -> let v1 = v_function_definition v1 and v2 = v_option v_name v2 in ()
       | Apply (v1, v2) -> let v1 = v_expr v1 and v2 = v_bracket (v_list v_expr) v2 in ()
+      | New (t, v1, v2) ->
+          let t = v_tok t in
+          let v1 = v_expr v1 and v2 = v_bracket (v_list v_expr) v2 in ()
       | Arr v1 -> let v1 = v_bracket (v_list v_expr) v1 in ()
       | Conditional (v1, v2, v3) ->
           let v1 = v_expr v1 and v2 = v_expr v2 and v3 = v_expr v3 in ()


### PR DESCRIPTION
My end goal is to allow Semgrep to infer the type from this:

```
const x = new Y();
```

In other languages, this works fine: there's some code that looks for a
few common cases on the RHS of a variable definition and pulls out the
type. However, because of some parsing oddities, in JS this ends up
being parsed as a `Call` with some weird arguments.

Changing the pfff parser to separate `New` is the first step towards
addressing this.

Test plan: Automated tests

### Security

- [x] Change has no security implications (otherwise, ping the security team)
