### PR TITLE
Add an 'Exception' module to take care of catching exceptions with a trace

### DIFF
--- a/commons/Exception.ml
+++ b/commons/Exception.ml
@@ -1,0 +1,39 @@
+(*
+   Wrapper around Printexc to ensure or at least encourage uniform
+   exception tracing.
+*)
+
+type t = exn * Printexc.raw_backtrace
+
+let catch exn = (exn, Printexc.get_raw_backtrace ())
+let trace exn = (exn, Printexc.get_callstack 100)
+
+let catch_all f : (_, t) Result.t =
+  try Ok (f ())
+  with exn ->
+    (* Important: no external function calls here. This is to ensure
+       no exception is raised and caught in the mean time since it would
+       replace the backtrace. *)
+    Error (catch exn)
+
+let reraise ((exn, trace) : t) =
+  Printexc.raise_with_backtrace exn trace
+
+let catch_and_reraise exn =
+  reraise (catch exn)
+
+let create exn trace = (exn, trace)
+let get_exn (exn, _trace) = exn
+let get_trace (_exn, trace) = trace
+
+let to_string (exn, trace) =
+  let msg =
+    Printf.sprintf "%s\n%s"
+      (Printexc.to_string exn)
+      (Printexc.raw_backtrace_to_string trace)
+  in
+  (* ensure the output ends with a newline *)
+  if msg = "" || msg.[String.length msg - 1] <> '\n' then
+    msg ^ "\n"
+  else
+    msg

--- a/commons/Exception.mli
+++ b/commons/Exception.mli
@@ -1,0 +1,89 @@
+(*
+   Wrapper around Printexc to ensure or at least encourage uniform
+   exception tracing.
+
+   In some cases, exceptions are caught and passed around as data before
+   being ultimately reraised. When doing this, it's important to keep track
+   of where the exception was originally raised so we can understand what
+   happened and debug the issue.
+
+   To do this, we must capture a stack trace where the exception
+   is first caught. Then, we can reraise this exception later with a proper
+   function that will extend the original backtrace and give us a full trace.
+
+   How to use exceptions for successful error tracking:
+
+   1. Raise fresh exceptions normally using 'raise'.
+   2. Use 'Exception.reraise' to reraise exceptions.
+   3. Right after catching an exception with a try-with,
+      call 'Exception.catch'.
+   4. When defining a new exception, define an exception printer and
+      register it globally with 'Printexc.register_printer'.
+
+   * Do not pass exceptions around without an accompanying trace.
+   * Do not re-raise exceptions using 'raise'.
+*)
+
+(*
+   A traced exception is a pair (exception, stack trace)
+
+   The stack trace is a best effort to track the execution of the program
+   up to the point where the exception was raised. OCaml offers mechanisms
+   to produce the following kinds of traces under the same type:
+
+   - stack backtrace: represents the call stack at the point where the last
+     exception to be raised was raised ('Printexc.get_backtrace ()').
+   - stack trace: represents the current call stack, possibly truncated to
+     some maximum size ('Printexc.get_callstack 100').
+   - extended trace: a trace that was extended by stitching multiple traces
+     together ('Printexc.raise_with_backtrace exn trace').
+
+   This module provides a thin interface to the standard 'Printexc'
+   module with the goal of forcing the programmer to do the right thing
+   and/or understand what they're doing.
+*)
+type t
+
+(* Catch any exception and capture a stack backtrace *)
+val catch_all : (unit -> 'a) -> ('a, t) Result.t
+
+(* Create a traced exception in case we can't use 'catch_all'.
+   This records the stack backtrace which is the state of the call stack
+   where the exception was raised. *)
+val catch : exn -> t
+
+(* Re-raise an exception, extending the previous trace. *)
+val reraise : t -> 'a
+
+(* Re-raise a freshly-caught exception, preserving the stack backtrace
+   that indicates where the exception was originally raised.
+   Must be called immediately after catching the exception with try-with
+   before any other exception could be raised and caught during the
+   execution of other functions. *)
+val catch_and_reraise : exn -> 'a
+
+(* Created a traced exception and record the state of the stack at this point
+   in the program execution. When catching an exception, it's best to
+   use 'catch_exception' instead so as to get the full stack
+   (where the exception was raised rather than the smaller stack where
+   the exception was caught). *)
+val trace : exn -> t
+
+(* Low-level creation of a traced exception. *)
+val create : exn -> Printexc.raw_backtrace -> t
+
+(* Get the original exception without the trace. *)
+val get_exn : t -> exn
+
+(* Get the trace. *)
+val get_trace : t -> Printexc.raw_backtrace
+
+(*
+   Convert the exception and the trace to a string in a multiline format
+   suitable for error messages. It always includes a terminal newline ('\n').
+
+   It uses the standard 'Printexc.to_string' function, which itself will
+   call the custom exception printers registered with
+   'Printexc.register_printer'.
+*)
+val to_string : t -> string

--- a/commons/Exception.mli
+++ b/commons/Exception.mli
@@ -62,9 +62,9 @@ val reraise : t -> 'a
    execution of other functions. *)
 val catch_and_reraise : exn -> 'a
 
-(* Created a traced exception and record the state of the stack at this point
+(* Create a traced exception and record the state of the stack at this point
    in the program execution. When catching an exception, it's best to
-   use 'catch_exception' instead so as to get the full stack
+   use 'catch' instead so as to get the full stack
    (where the exception was raised rather than the smaller stack where
    the exception was caught). *)
 val trace : exn -> t
@@ -79,7 +79,7 @@ val get_exn : t -> exn
 val get_trace : t -> Printexc.raw_backtrace
 
 (*
-   Convert the exception and the trace to a string in a multiline format
+   Convert the exception and the trace into a string in a multiline format
    suitable for error messages. It always includes a terminal newline ('\n').
 
    It uses the standard 'Printexc.to_string' function, which itself will

--- a/h_program-lang/Parse_info.mli
+++ b/h_program-lang/Parse_info.mli
@@ -145,13 +145,16 @@ val mk_info_of_loc: token_location -> t
 val is_fake: t -> bool
 val first_loc_of_file: Common.filename -> token_location
 
+(* Extract the lexeme (token) as a string *)
 val str_of_info   : t -> string
+
+(* Extract position information *)
 val line_of_info  : t -> int
 val col_of_info   : t -> int
 val pos_of_info   : t -> int
 val file_of_info  : t -> Common.filename
 
-(* small error reporting, for longer reports use error_message above *)
+(* Format the location file/line/column into a string *)
 val string_of_info: t -> string
 
 val is_origintok: t -> bool


### PR DESCRIPTION
In semgrep-core, we had a number of places where a stack trace was lost or collected at the wrong time. This is meant to enforce best practices.

See explanations in the new ml/mli files.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
