### PR TITLE
Fix all the bad exception reraises reported by Semgrep

### DIFF
--- a/commons/Common.mli
+++ b/commons/Common.mli
@@ -245,9 +245,9 @@ val action_list:
 val debugger : bool ref
 
 (* emacs spirit *)
-val unwind_protect : (unit -> 'a) -> (exn -> 'b) -> 'a
+val unwind_protect : (unit -> 'a) -> (Exception.t -> 'b) -> 'a
 (* java spirit *)
-val finalize :       (unit -> 'a) -> (unit -> 'b) -> 'a
+val finalize :       (unit -> 'a) -> (unit -> unit) -> 'a
 
 val save_excursion : 'a ref -> 'a -> (unit -> 'b) -> 'b
 

--- a/h_program-lang/Error_code.mli
+++ b/h_program-lang/Error_code.mli
@@ -100,18 +100,11 @@ val filter_maybe_parse_and_fatal_errors: error list -> error list
 val adjust_paths_relative_to_root:
   Common.path -> error list -> error list
 
-val exn_to_error: Common.filename -> exn -> error
+val exn_to_error: Common.filename -> Exception.t -> error
 
 val try_with_exn_to_error : Common.filename -> (unit -> unit) -> unit
 
 val try_with_print_exn_and_reraise:
-  Common.filename -> (unit -> unit) -> unit
-
-(*
-   Print exception and exit with code 2. No stack trace is printed because
-   it takes 2 seconds in some instances.
-*)
-val try_with_print_exn_and_exit_fast:
   Common.filename -> (unit -> unit) -> unit
 
 (* to detect false positives (we use the Hashtbl.find_all property) *)

--- a/lang_c/analyze/graph_code_c.ml
+++ b/lang_c/analyze/graph_code_c.ml
@@ -160,10 +160,12 @@ let parse ~show_parse_error file =
           Parse_c.parse_program file
         )))
   with
-  | Timeout _ as e -> raise e
+  | Timeout _ as exn -> Exception.catch_and_reraise exn
   | exn ->
-      pr2_once (spf "PARSE ERROR with %s, exn = %s" file (Common.exn_to_s exn));
-      raise exn
+      let e = Exception.catch exn in
+      pr2_once (spf "PARSE ERROR with %s, exn = %s"
+                  file (Common.exn_to_s exn));
+      Exception.reraise e
 
 (*****************************************************************************)
 (* Helpers *)

--- a/lang_c/parsing/parse_c.ml
+++ b/lang_c/parsing/parse_c.ml
@@ -34,9 +34,11 @@ let parse file =
   let ast, stat =
     try (Ast_c_build.program ast), stat
     with exn ->
-      logger#error "PB: Ast_c_build, on %s (exn = %s)" file (Common.exn_to_s exn);
+      let e = Exception.catch exn in
+      logger#error "PB: Ast_c_build, on %s (exn = %s)"
+        file (Common.exn_to_s exn);
       (*None, { stat with Stat.bad = stat.Stat.bad + stat.Stat.correct } *)
-      raise exn
+      Exception.reraise e
   in
   { Parse_info. ast; tokens; stat }
 

--- a/lang_cpp/analyze/TODO_more/graph_code_includes.ml
+++ b/lang_cpp/analyze/TODO_more/graph_code_includes.ml
@@ -53,10 +53,11 @@ let parse ~show_parse_error file =
       Parse_cpp.tokens file
     )
   with
-  | Timeout -> raise Timeout
+  | Timeout as exn -> Exception.catch_and_reraise exn
   | exn ->
+      let e = Exception.catch exn in
       pr2_once (spf "PARSE ERROR with %s, exn = %s" file (Common.exn_to_s exn));
-      raise exn
+      Exception.reraise e
 
 let add_use_edge env (name, kind) =
   let src = env.current in

--- a/lang_cpp/parsing/parse_cpp.ml
+++ b/lang_cpp/parsing/parse_cpp.ml
@@ -355,12 +355,13 @@ let parse_with_lang ?(lang=Flag_parsing_cpp.Cplusplus) file : (Ast.program, T.to
          (* Call parser *)
          (* -------------------------------------------------- *)
          parse_toplevel tr lexbuf_fake
-       with e ->
+       with exn ->
+         let e = Exception.catch exn in
          if not !Flag.error_recovery
          then raise (Parse_info.Parsing_error (TH.info_of_tok tr.PI.current));
 
          if !Flag.show_parsing_error then
-           (match e with
+           (match exn with
             (* ocamlyacc *)
             | Parsing.Parse_error
             (* dypgen *)
@@ -370,7 +371,8 @@ let parse_with_lang ?(lang=Flag_parsing_cpp.Cplusplus) file : (Ast.program, T.to
                 pr2 ("parse error \n = " ^ error_msg_tok tr.PI.current)
             | Parse_info.Other_error (s, _i) ->
                 pr2 ("semantic error " ^s^ "\n ="^ error_msg_tok tr.PI.current)
-            | e -> raise e
+            | _ ->
+                Exception.reraise e
            );
 
          let line_error = TH.line_of_tok tr.PI.current in

--- a/lang_java/analyze/graph_code_java.ml
+++ b/lang_java/analyze/graph_code_java.ml
@@ -109,11 +109,12 @@ let parse ~show_parse_error file =
   try
     Parse_java.parse_program file
   with
-  | Timeout _ as e -> raise e
+  | Timeout _ as exn -> Exception.catch_and_reraise exn
   | exn ->
+      let e = Exception.catch exn in
       if show_parse_error
       then pr2_once (spf "PARSE ERROR with %s, exn = %s" file
-                       (Common.exn_to_s exn));
+                       (Exception.to_string e));
       []
 
 

--- a/lang_java/parsing/test_parsing_java.ml
+++ b/lang_java/parsing/test_parsing_java.ml
@@ -43,8 +43,9 @@ let test_parse xs  =
             Parse_java.parse file
           ))
       with exn ->
+        let e = Exception.catch exn in
         pr2 (spf "PB with %s (exn = %s)" file (Common.exn_to_s exn));
-        raise exn
+        Exception.reraise e
     in
     Common.push stat stat_list;
     let s = spf "bad = %d" stat.PI.error_line_count in

--- a/lang_js/analyze/graph_code_js.ml
+++ b/lang_js/analyze/graph_code_js.ml
@@ -108,12 +108,14 @@ let parse file =
     try
       Parse_js.parse_program file
     with
-    | Timeout _ as e -> raise e
+    | Timeout _ as exn -> Exception.catch_and_reraise exn
     | exn ->
-        pr2 (spf "PARSE ERROR with %s, exn = %s" file (Common.exn_to_s exn));
+        let e = Exception.catch exn in
+        pr2 (spf "PARSE ERROR with %s, exn = %s" file (Exception.to_string e));
         if !error_recovery
         then []
-        else raise exn
+        else
+          Exception.reraise e
   )
 
 (*****************************************************************************)

--- a/lang_lisp/analyze/graph_code_lisp.ml
+++ b/lang_lisp/analyze/graph_code_lisp.ml
@@ -67,9 +67,11 @@ let parse file =
     try
       Parse_lisp.parse_program file
     with
-    | Timeout _ as e -> raise e
+    | Timeout _ as exn -> Exception.catch_and_reraise exn
     | exn ->
-        pr2_once (spf "PARSE ERROR with %s, exn = %s" file (Common.exn_to_s exn));
+        let e = Exception.catch exn in
+        pr2_once (spf "PARSE ERROR with %s, exn = %s"
+                    file (Exception.to_string e));
         []
   )
 

--- a/lang_lisp/parsing/parse_lisp.ml
+++ b/lang_lisp/parsing/parse_lisp.ml
@@ -151,7 +151,7 @@ let parse2 filename =
         stat.PI.error_line_count <- stat.PI.total_line_count;
         None
     | exn ->
-        raise exn
+        Exception.catch_and_reraise exn
   in
   (ast, toks_orig), stat
 

--- a/lang_ml/analyze/test_analyze_ml.ml
+++ b/lang_ml/analyze/test_analyze_ml.ml
@@ -20,7 +20,7 @@ let test_parse_ast_ml xs =
             (*             let _gen = Ml_to_generic.program ast in *)
             ()
           )))
-    with exn -> raise exn
+    with exn -> Exception.catch_and_reraise exn
   ))
 
 let test_dump_ml file =

--- a/lang_php/analyze/graph_code_php.ml
+++ b/lang_php/analyze/graph_code_php.ml
@@ -154,11 +154,12 @@ let parse env file =
       ast
     )
   with
-  | Timeout _ as e -> raise e
+  | Timeout _ as exn -> Exception.catch_and_reraise exn
   | exn ->
+      let e = Exception.catch exn in
       env.stats.G.parse_errors |> Common.push file;
       env.pr2_and_log (spf "PARSE ERROR with %s, exn = %s" (env.path file)
-                         (Common.exn_to_s exn));
+                         (Exception.to_string e));
       []
 
 

--- a/lang_ruby/parsing/parse_ruby.ml
+++ b/lang_ruby/parsing/parse_ruby.ml
@@ -207,5 +207,5 @@ let any_of_string ?timeout str =
         with (Dyp.Syntax_error
              | Failure _ | Stack.Empty | Parse_ruby_timeout
              ) as exn ->
-            raise exn
+            Exception.catch_and_reraise exn
       )))

--- a/lang_scala/parsing/Parser_scala_recursive_descent.ml
+++ b/lang_scala/parsing/Parser_scala_recursive_descent.ml
@@ -3605,10 +3605,13 @@ let try_rule toks frule =
 let parse toks =
   try
     try_rule toks compilationUnit
-  with PI.Parsing_error _ as err1 ->
-  try
-    try_rule toks block
-  with PI.Parsing_error _ -> raise err1
+  with
+  | PI.Parsing_error _ as err1 ->
+      let e1 = Exception.catch err1 in
+      try
+        try_rule toks block
+      with PI.Parsing_error _ ->
+        Exception.reraise e1
 
 
 


### PR DESCRIPTION
Semgrep found 26 cases of `raise` that were losing the stack trace.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
