### PR TITLE
fix scala parsing for imports

### DIFF
--- a/lang_scala/parsing/AST_scala.ml
+++ b/lang_scala/parsing/AST_scala.ml
@@ -122,7 +122,7 @@ type import_selector = ident_or_wildcard * alias option
 and alias = tok (* => *) * ident_or_wildcard
 [@@deriving show]
 
-type import_expr = stable_id * import_spec
+type import_expr = (ident, stable_id * import_spec) either
 and import_spec =
   | ImportId of ident
   | ImportWildcard of tok (* '_' *)

--- a/lang_scala/parsing/Token_helpers_scala.ml
+++ b/lang_scala/parsing/Token_helpers_scala.ml
@@ -246,6 +246,13 @@ let isIdent = function
 
   | _ -> None
 
+let isMetavar = function
+  | ID_LOWER (s, _) ->
+    (try String.get s 0 = '$' 
+    with Invalid_argument _ -> false
+    )
+  | _ -> false
+
 let isIdentBool x =
   isIdent x <> None
 


### PR DESCRIPTION
**What:**
Scala `import` parsing is currently broken, and both does not conform to the specification, and does not handle metavariables properly. This manifests in Semgrep patterns such as `import $X` being rejected as invalid patterns at parse time. 

**Why:**
We should fix this because the above import pattern is useful to be able to do, particularly when `$X` is a metavariable regex or something.

**How:**
Via [scala-lang](https://www.scala-lang.org/files/archive/spec/2.11/13-syntax-summary.html), we obtain:
<img width="564" alt="Screen Shot 2022-07-19 at 10 38 23 PM" src="https://user-images.githubusercontent.com/49291449/179904979-998c1b01-9a92-493f-834d-7d3e62ca8f97.png">

Unrolling this once, we see that we get something like:
```
StableId ::= id
           | StableId '.' `id`
           | [id '.'] `this` `.` id
           | [id '.'] `super` [ClassQualifier] '.' id
```

Basically, a `StableId` starts as either a single `id`, or a `id.this.id2`, or a `id.super [class qualifier]`, and then sees some number of identifiers. Notably, because we have:
<img width="554" alt="Screen Shot 2022-07-19 at 10 43 17 PM" src="https://user-images.githubusercontent.com/49291449/179905578-8456766a-a7f1-442d-b011-975fdd4c4358.png">

in the case of an `import`, it must be at least one.

This means that something like `import X` is not actually syntactically permissible Scala. This is why, currently, `import $X` fails. But this is still something that would be nice to be able to do, so I went ahead and changed things so that we can support it.

Essentially, I've made it such that `import_expr`s are either what they normally are understood to be, _or_ they can be a metavariable. This makes it so that we don't parse things like `import x`, but we can parse `import $X`.

The previous code also permitted non-dots following an identifier, and I don't think that should actually be possible.

Fixes #5219.

**Test plan:**
So, ideally I'd like to write a ton of tests showing that things which do not conform to the Scala grammar do not parse. Unfortunately, the parsing tests seem to be more about what things _do_ parse, so I don't actually know how to do this. Feedback appreciated.

In the meantime, the test plan can be to try testing dumping patterns on the following `.sgrep` patterns. I've verified the following using `sc -dump_pattern test.sgrep -lang scala`:
| example | status |
|:-|:-|
| `import this.a` | FAILS |
| `import this.a._` | SUCCEEDS |
| `import $X` | SUCCEEDS |
| `import $X._` | SUCCEEDS |
| `import a.$X._` | SUCCEEDS |
| `import a` | FAILS |
| `import a.this.b` | FAILS |
| `import a.this.b._` | SUCCEEDS |

Not sure how to carve this in stone, so to speak, however. Let me know what you think.

### Security

- [X] Change has no security implications (otherwise, ping the security team)
