### PR TITLE
Scala fix import parse2

### DIFF
--- a/lang_scala/parsing/AST_scala.ml
+++ b/lang_scala/parsing/AST_scala.ml
@@ -122,7 +122,7 @@ type import_selector = ident_or_wildcard * alias option
 and alias = tok (* => *) * ident_or_wildcard
 [@@deriving show]
 
-type import_expr = stable_id * import_spec
+type import_expr = (ident, stable_id * import_spec) either
 and import_spec =
   | ImportId of ident
   | ImportWildcard of tok (* '_' *)

--- a/lang_scala/parsing/AST_scala.ml
+++ b/lang_scala/parsing/AST_scala.ml
@@ -122,6 +122,7 @@ type import_selector = ident_or_wildcard * alias option
 and alias = tok (* => *) * ident_or_wildcard
 [@@deriving show]
 
+(* semgrep-ext: we allow single identifiers here so we can support import $X *)
 type import_expr = (ident, stable_id * import_spec) either
 and import_spec =
   | ImportId of ident

--- a/lang_scala/parsing/Parser_scala_recursive_descent.ml
+++ b/lang_scala/parsing/Parser_scala_recursive_descent.ml
@@ -2372,10 +2372,9 @@ let importExpr in_ : import_expr =
       nextToken in_; (* 'this' *)
       (* AST: val t = This(name) *)
       accept (DOT ab) in_;
-      (*let result = selector (*t*) in_ in
+      let result = selector (*t*) in_ in
       accept (DOT ab) in_;
-      *)
-      This (nameopt, ii), []
+      This (nameopt, ii), [result]
     in
     (** Walks down import `foo.bar.baz.{ ... }` until it ends at
      * an underscore, a left brace, or an undotted identifier.
@@ -2414,10 +2413,11 @@ let importExpr in_ : import_expr =
         thisDotted (Some id) in_
       | _ -> Id id, [] in
       Right (loop start in_) in
-    match (pr2 (show_token in_.token); in_.token) with
+    match in_.token with
     | Kthis _ -> 
       let start = thisDotted None (*ast: empty*) in_ in
       Right (loop start in_)
+    (* We should allow single metavariables to be imported. *)
     | ID_LOWER id when TH.isMetavar in_.token ->
       nextToken in_;
       (match in_.token with

--- a/lang_scala/parsing/Parser_scala_recursive_descent.ml
+++ b/lang_scala/parsing/Parser_scala_recursive_descent.ml
@@ -2409,23 +2409,23 @@ let importExpr in_ : import_expr =
     in
     let handle_potential_this_with_id id in_ =
       let start = match in_.token with
-      | Kthis _ ->
-        thisDotted (Some id) in_
-      | _ -> Id id, [] in
+        | Kthis _ ->
+            thisDotted (Some id) in_
+        | _ -> Id id, [] in
       Right (loop start in_) in
     match in_.token with
-    | Kthis _ -> 
-      let start = thisDotted None (*ast: empty*) in_ in
-      Right (loop start in_)
+    | Kthis _ ->
+        let start = thisDotted None (*ast: empty*) in_ in
+        Right (loop start in_)
     (* We should allow single metavariables to be imported. *)
     | ID_LOWER id when TH.isMetavar in_.token ->
-      nextToken in_;
-      (match in_.token with
-      | DOT _ -> 
-        nextToken in_; 
-        handle_potential_this_with_id id in_
-      (* If there is no dot next, then it must be a lone metavariable. *)
-      | _ -> Left id)
+        nextToken in_;
+        (match in_.token with
+         | DOT _ ->
+             nextToken in_;
+             handle_potential_this_with_id id in_
+         (* If there is no dot next, then it must be a lone metavariable. *)
+         | _ -> Left id)
     | _ ->
         (* AST: Ident() *)
         let id = ident in_ in

--- a/lang_scala/parsing/Parser_scala_recursive_descent.ml
+++ b/lang_scala/parsing/Parser_scala_recursive_descent.ml
@@ -2362,7 +2362,9 @@ let importSelectors in_ : import_selector list bracket =
   inBracesOrNil (commaSeparated importSelector) in_
 
 (** {{{
- *  ImportExpr ::= StableId `.` (Id | `_` | ImportSelectors) | metavariable
+ *  ImportExpr ::= StableId `.` (Id | `_` | ImportSelectors)
+                 | (* scala-ext: allow this for things like `import $X` *)
+                   metavariable
  *  }}}
 *)
 let importExpr in_ : import_expr =
@@ -2418,7 +2420,7 @@ let importExpr in_ : import_expr =
         let start = thisDotted None (*ast: empty*) in_ in
         Right (loop start in_)
     (* We should allow single metavariables to be imported. *)
-    | ID_LOWER id when TH.isMetavar in_.token ->
+    | ID_LOWER ((s, _) as id) when AST_generic_.is_metavar_name s ->
         nextToken in_;
         (match in_.token with
          | DOT _ ->

--- a/lang_scala/parsing/Token_helpers_scala.ml
+++ b/lang_scala/parsing/Token_helpers_scala.ml
@@ -246,6 +246,13 @@ let isIdent = function
 
   | _ -> None
 
+let isMetavar = function
+  | ID_LOWER (s, _) ->
+    (try String.get s 0 = '$' 
+    with Invalid_argument _ -> false
+    )
+  | _ -> false
+
 let isIdentBool x =
   isIdent x <> None
 

--- a/lang_scala/parsing/Token_helpers_scala.ml
+++ b/lang_scala/parsing/Token_helpers_scala.ml
@@ -248,9 +248,9 @@ let isIdent = function
 
 let isMetavar = function
   | ID_LOWER (s, _) ->
-    (try String.get s 0 = '$' 
-    with Invalid_argument _ -> false
-    )
+      (try String.get s 0 = '$'
+       with Invalid_argument _ -> false
+      )
   | _ -> false
 
 let isIdentBool x =

--- a/lang_scala/parsing/Token_helpers_scala.ml
+++ b/lang_scala/parsing/Token_helpers_scala.ml
@@ -246,13 +246,6 @@ let isIdent = function
 
   | _ -> None
 
-let isMetavar = function
-  | ID_LOWER (s, _) ->
-      (try String.get s 0 = '$'
-       with Invalid_argument _ -> false
-      )
-  | _ -> false
-
 let isIdentBool x =
   isIdent x <> None
 

--- a/lang_scala/parsing/Unit_parsing_scala.ml
+++ b/lang_scala/parsing/Unit_parsing_scala.ml
@@ -20,4 +20,17 @@ let tests =
             file (Common.exn_to_s exn)
       )
     );
+    "rejecting bad code", (fun () ->
+      let dir = Config_pfff.tests_path "scala/parsing_errors" in
+      let files = Common2.glob (spf "%s/*.scala" dir) in
+      files |> List.iter (fun file ->
+        try
+          let _ast = Parse_scala.parse file in
+          Alcotest.failf "it should have thrown a Parse_error %s" file
+        with
+        | Parse_info.Parsing_error _ -> ()
+        | exn -> Alcotest.failf "throwing wrong exn %s on %s"
+                   (Common.exn_to_s exn) file
+      )
+    );
   ]

--- a/tests/scala/parsing/import_metavar.scala
+++ b/tests/scala/parsing/import_metavar.scala
@@ -1,0 +1,1 @@
+import $X

--- a/tests/scala/parsing_errors/import_short_this.scala
+++ b/tests/scala/parsing_errors/import_short_this.scala
@@ -1,0 +1,1 @@
+import a.this.b

--- a/tests/scala/parsing_errors/import_short_this_no_prefix.scala
+++ b/tests/scala/parsing_errors/import_short_this_no_prefix.scala
@@ -1,0 +1,1 @@
+import this.a

--- a/tests/scala/parsing_errors/import_single.scala
+++ b/tests/scala/parsing_errors/import_single.scala
@@ -1,0 +1,1 @@
+import a


### PR DESCRIPTION
**What:**
Scala `import` parsing is currently broken, and both does not conform to the specification, and does not handle metavariables properly. This manifests in Semgrep patterns such as `import $X` being rejected as invalid patterns at parse time. 

**Why:**
We should fix this because the above import pattern is useful to be able to do, particularly when `$X` is a metavariable regex or something.

**How:**
Via [scala-lang](https://www.scala-lang.org/files/archive/spec/2.11/13-syntax-summary.html), we obtain:
<img width="564" alt="Screen Shot 2022-07-19 at 10 38 23 PM" src="https://user-images.githubusercontent.com/49291449/179904979-998c1b01-9a92-493f-834d-7d3e62ca8f97.png">

Unrolling this once, we see that we get something like:
```
StableId ::= id
           | StableId '.' `id`
           | [id '.'] `this` `.` id
           | [id '.'] `super` [ClassQualifier] '.' id
```

Basically, a `StableId` starts as either a single `id`, or a `id.this.id2`, or a `id.super [class qualifier]`, and then sees some number of identifiers. Notably, because we have:
<img width="554" alt="Screen Shot 2022-07-19 at 10 43 17 PM" src="https://user-images.githubusercontent.com/49291449/179905578-8456766a-a7f1-442d-b011-975fdd4c4358.png">

in the case of an `import`, it must be at least one.

This means that something like `import X` is not actually syntactically permissible Scala. This is why, currently, `import $X` fails. But this is still something that would be nice to be able to do, so I went ahead and changed things so that we can support it.

Essentially, I've made it such that `import_expr`s are either what they normally are understood to be, _or_ they can be a metavariable. This makes it so that we don't parse things like `import x`, but we can parse `import $X`.

The previous code also permitted non-dots following an identifier, and I don't think that should actually be possible.

**Test plan:**
So, ideally I'd like to write a ton of tests showing that things which do not conform to the Scala grammar do not parse. Unfortunately, the parsing tests seem to be more about what things _do_ parse, so I don't actually know how to do this. Feedback appreciated.

In the meantime, the test plan can be to try testing dumping patterns on the following `.sgrep` patterns. I've verified the following using `sc -dump_pattern test.sgrep -lang scala`:
| example | status |
|:-|:-|
| `import this.a` | FAILS |
| `import this.a._` | SUCCEEDS |
| `import $X` | SUCCEEDS |
| `import $X._` | SUCCEEDS |
| `import a.$X._` | SUCCEEDS |
| `import a` | FAILS |
| `import a.this.b` | FAILS |
| `import a.this.b._` | SUCCEEDS |

Not sure how to carve this in stone, so to speak, however. Let me know what you think.

### Security

- [X] Change has no security implications (otherwise, ping the security team)

### Security

- [X] Change has no security implications (otherwise, ping the security team)
