### PR TITLE
allowed decorators in method patterns

### DIFF
--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -412,16 +412,43 @@ sgrep_spatch_pattern:
  | T_LCURLY_SEMGREP listc(property_name_and_value) ","? "}"
      { Expr (Obj ($1, $2, $4)) }
 
- (* we would like to just use method_definition, but too many r/r conflicts *)
- | (* TODO decorators ioption(T_ASYNC) ioption(method_get_set_star)
+  | (* decorators, no body *)
+    decorators_nonempty T_ID
+    T_LPAREN formal_parameter_list_opt ")" annotation?
+    EOF
+   {
+     Partial (PartialDef (mk_def (Some $2,
+      FuncDef
+       { f_kind = (Method, $3)
+       ; f_params = $4
+       ; f_body = Block (fb $3 [])
+       ; f_rettype = $6
+       ; f_attrs = $1
+       }
+     )))
+   }
+
+  | (* decorators, with body *)
+    decorators_nonempty T_ID
+    T_LPAREN formal_parameter_list_opt ")" annotation?
+    "{" function_body "}" EOF
+   {
+     let sig_ = (None, ($3, $4, $5), $6) in
+     let fun_ = mk_Fun ~attrs:$1 (Method, $3) sig_ ($7, $8, $9) in
+     Property (mk_Field (PN $2) (Some fun_))
+   }
+
+
+  | (* TODO decorators ioption(T_ASYNC) ioption(method_get_set_star)
     * but need also to modify parsing hack for T_LPAREN_METHOD_SEMGREP
     *)
     T_ID
     T_LPAREN_METHOD_SEMGREP formal_parameter_list_opt ")" annotation?
     "{" function_body "}" EOF
-   { let sig_ = (None, ($2, $3, $4), $5) in
+   {
+     let sig_ = (None, ($2, $3, $4), $5) in
      let fun_ = mk_Fun (Method, $2) sig_ ($6, $7, $8) in
-     Property (mk_Field (PN $1) (Some fun_))
+     Property (mk_Field (PN $1) (Some fun_));
    }
 
  | assignment_expr_no_stmt  EOF  { Expr $1 }
@@ -870,6 +897,9 @@ enum_member:
 decorators:
  | (* empty *) { [] }
  | decorator+   { $1 }
+
+decorators_nonempty:
+ | decorator+ { $1 }
 
 decorator_name:
  | T_ID { [$1] }

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -413,7 +413,7 @@ sgrep_spatch_pattern:
      { Expr (Obj ($1, $2, $4)) }
 
   | (* decorators, no body *)
-    decorators_nonempty T_ID
+    decorator+ T_ID
     T_LPAREN formal_parameter_list_opt ")" annotation?
     EOF
    {
@@ -429,7 +429,7 @@ sgrep_spatch_pattern:
    }
 
   | (* decorators, with body *)
-    decorators_nonempty T_ID
+    decorator+ T_ID
     T_LPAREN formal_parameter_list_opt ")" annotation?
     "{" function_body "}" EOF
    {
@@ -897,9 +897,6 @@ enum_member:
 decorators:
  | (* empty *) { [] }
  | decorator+   { $1 }
-
-decorators_nonempty:
- | decorator+ { $1 }
 
 decorator_name:
  | T_ID { [$1] }


### PR DESCRIPTION
I added parsing for patterns which look like methods (with body and without body) that have decorators.

**Test plan:**
`@$DECORATOR('...') $NAME(): string`
parses as 
```Partial(
  PartialDef(
    ({
      name=EN(
             Id(("$NAME", ()),
               {id_info_id=1; id_hidden=false; id_resolved=Ref(None);
                id_type=Ref(None); id_svalue=Ref(None); }));
      attrs=[NamedAttr((),
               Id(("$DECORATOR", ()),
                 {id_info_id=2; id_hidden=false; id_resolved=Ref(None);
                  id_type=Ref(None); id_svalue=Ref(None); }),
               [Arg(L(String(("...", ()))))])];
      tparams=[]; },
     FuncDef(
       {fkind=(Method, ()); fparams=[];
        frettype=Some({t_attrs=[];
                       t=TyN(
                           Id(("string", ()),
                             {id_info_id=3; id_hidden=false;
                              id_resolved=Ref(None); id_type=Ref(None);
                              id_svalue=Ref(None); }));
                       });
        fbody=FBStmt(Block([])); }))))
```

and 

`@$DECORATOR $NAME(): string { }`
parses as
```
Fld(
  F(
    DefStmt(
      ({
        name=EN(
               Id(("$NAME", ()),
                 {id_info_id=1; id_hidden=false; id_resolved=Ref(None);
                  id_type=Ref(None); id_svalue=Ref(None); }));
        attrs=[NamedAttr((),
                 Id(("$DECORATOR", ()),
                   {id_info_id=2; id_hidden=false; id_resolved=Ref(None);
                    id_type=Ref(None); id_svalue=Ref(None); }), [])];
        tparams=[]; },
       FuncDef(
         {fkind=(Method, ()); fparams=[];
          frettype=Some({t_attrs=[];
                         t=TyN(
                             Id(("string", ()),
                               {id_info_id=3; id_hidden=false;
                                id_resolved=Ref(None); id_type=Ref(None);
                                id_svalue=Ref(None); }));
                         });
          fbody=FBStmt(Block([])); })))))
```

### Security

- [x] Change has no security implications (otherwise, ping the security team)
