### PR TITLE
Include start and end tokens of Python f strings

### DIFF
--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -153,7 +153,7 @@ type expr =
   | ExprStar of expr (* less: expr_context? always Store anyway no? *)
   (* python3: f-strings
    * reference: https://www.python.org/dev/peps/pep-0498/ *)
-  | InterpolatedString of interpolated list
+  | InterpolatedString of tok * interpolated list * tok
   | ConcatenatedString of interpolated list (* always Str *)
 
   (* python3: *)

--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -775,11 +775,11 @@ testlist1:
 string:
   | STR { let (s, pre, tok) = $1 in
           if pre = "" then Str (s, tok) else EncodedStr ((s, tok), pre) }
-  | FSTRING_START interpolated* FSTRING_END { InterpolatedString $2 }
+  | FSTRING_START interpolated* FSTRING_END { InterpolatedString ($1, $2, $3) }
 
 interpolated:
   | FSTRING_STRING { Str $1 }
-  | FSTRING_LBRACE interpolant fstring_print_spec "}" { InterpolatedString ($2::$3) }
+  | FSTRING_LBRACE interpolant fstring_print_spec "}" { InterpolatedString ($1, $2::$3, $4) }
 
 fstring_print_spec:
   |     fstring_format_clause { $1 }

--- a/lang_python/parsing/Visitor_python.ml
+++ b/lang_python/parsing/Visitor_python.ml
@@ -106,7 +106,11 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
       | Num v1 -> let v1 = v_number v1 in ()
       | Str v1 -> let v1 = v_wrap v_string v1 in ()
       | EncodedStr (v1, v2) -> let v1 = v_wrap v_string v1 in let v2 = v_string v2 in ()
-      | InterpolatedString v1 -> let v1 = v_list v_expr v1 in ()
+      | InterpolatedString (v1, v2, v3) ->
+          let v1 = v_info v1 in
+          let v2 = v_list v_expr v2 in
+          let v3 = v_info v3 in
+          ()
       | ConcatenatedString v1 -> let v1 = v_list v_expr v1 in ()
       | Name (v1, v2, v3) ->
           let v1 = v_name v1


### PR DESCRIPTION
Previously, these were discarded. Now they are included in the AST.

Test plan: Incorporate these changes into Semgrep. Run existing
automated tests. Manually verify that
https://github.com/returntocorp/semgrep/issues/2995 is fixed.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
