### PR TITLE
change pfff python

### DIFF
--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -156,10 +156,6 @@ type expr =
   | InterpolatedString of interpolated list
   | ConcatenatedString of interpolated list (* always Str *)
 
-  (* python3: *)
-  (* inside an Assign (or ExprStmt) *)
-  | TypedExpr of expr * type_
-
   | BoolOp of boolop wrap (* op *) * expr list (* values *)
   | BinOp of expr (* left *) * operator wrap (* op *) * expr (* right *)
   | UnaryOp of unaryop wrap (* op *) * expr (* operand *)
@@ -350,7 +346,7 @@ type stmt =
    * For example in 'a = b = c', we will have 'Assign ([a;b], c)'.
    * TODO: lhs should be expr * type_ option
   *)
-  | Assign of expr(*lhs*) list (* targets *) * tok * expr (* value *)
+  | Assign of (expr * (tok * type_) option) (*lhs*) list (* targets *) * tok * expr (* value *)
   | AugAssign of expr (* target *) * operator wrap (* op *) * expr (* value *)
 
   | For of tok * pattern (* (pattern) introduce new vars *) *
@@ -362,6 +358,11 @@ type stmt =
           stmt list option (* orelse *)
   (* https://docs.python.org/2.5/whatsnew/pep-343.html *)
   | With of tok * with_clause * stmt list (* body *)
+
+  | Switch of
+      tok
+      * expr
+      * case_and_body list
 
   | Return of tok * expr option (* value *)
   | Break of tok | Continue of tok
@@ -404,6 +405,14 @@ type stmt =
   | FunctionDef of function_definition
 
   | ClassDef of class_definition
+
+and case_and_body =
+  | CasesAndBody of case list * stmt list
+  (* sgrep-ext: *)
+  | CaseEllipsis of (* ... *) tok
+
+and case =
+  | Case of tok * pattern
 
 and excepthandler =
     ExceptHandler of

--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -349,6 +349,8 @@ type stmt =
   | Assign of (expr * (tok * type_) option) (*lhs*) list (* targets *) * tok * expr (* value *)
   | AugAssign of expr (* target *) * operator wrap (* op *) * expr (* value *)
 
+  | Cast of expr * tok * type_
+
   | For of tok * pattern (* (pattern) introduce new vars *) *
            tok * expr (* 'in' iter *) *
            stmt list (* body *) * stmt list (* orelse *)

--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -292,8 +292,8 @@ dot_level:
   | "..." dot_level { $1::$2 }
 
 import_as_name:
-  | NAME         { $1, None }
-  | NAME AS NAME { $1, Some $3 }
+  | NAME         { failwith "ood" }
+  | NAME AS NAME { failwith "ood" }
 
 (*************************************************************************)
 (* Variable definition *)

--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -303,17 +303,9 @@ expr_stmt:
   | tuple(test_or_star_expr)
       { ExprStmt (tuple_expr $1) }
   (* typing-ext: *)
-  | tuple(test_or_star_expr) ":" test
+  (*| tuple(test_or_star_expr) ":" test
       { ExprStmt (TypedExpr (tuple_expr $1, $3)) }
-  | tuple(test_or_star_expr) ":" test "=" test
-      { Assign ([TypedExpr (tuple_expr_store $1, $3)], $4, $5) }
-
-  | tuple(test_or_star_expr) augassign yield_expr
-      { AugAssign (tuple_expr_store $1, $2, $3) }
-  | tuple(test_or_star_expr) augassign tuple(test)
-      { AugAssign (tuple_expr_store $1, $2, tuple_expr $3) }
-  | tuple(test_or_star_expr) "=" expr_stmt_rhs_list
-      { Assign ((tuple_expr_store $1)::(fst $3), $2, snd $3) }
+  *)
 
 test_or_star_expr:
   | test      { $1 }
@@ -324,29 +316,6 @@ expr_or_star_expr:
   | star_expr { $1 }
 
 exprlist: tuple(expr_or_star_expr) { $1 }
-
-expr_stmt_rhs_list:
-  | expr_stmt_rhs                         { [], $1 }
-  | expr_stmt_rhs "=" expr_stmt_rhs_list  { (expr_store $1)::(fst $3), snd $3 }
-
-expr_stmt_rhs:
-  | yield_expr               { $1 }
-  | tuple(test_or_star_expr) { tuple_expr $1 }
-
-augassign:
-  | ADDEQ   { Add, $1 }
-  | SUBEQ   { Sub, $1 }
-  | MULTEQ  { Mult, $1 }
-  | DIVEQ   { Div, $1 }
-  | POWEQ   { Pow, $1 }
-  | MODEQ   { Mod, $1 }
-  | LSHEQ   { LShift, $1 }
-  | RSHEQ   { RShift, $1 }
-  | OREQ    { BitOr, $1 }
-  | XOREQ   { BitXor, $1 }
-  | ANDEQ   { BitAnd, $1 }
-  | FDIVEQ  { FloorDiv, $1 }
-
 
 namedexpr_test:
   | test { $1 }

--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -291,7 +291,7 @@ dot_level:
   | "." dot_level  { $1::$2 }
   | "..." dot_level { $1::$2 }
 
-(* ood for "out of date", this will no longer be necessary later )
+(* ood for "out of date", this will no longer be necessary later *)
 import_as_name:
   | NAME         { failwith "ood" }
   | NAME AS NAME { failwith "ood" }

--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -291,6 +291,7 @@ dot_level:
   | "." dot_level  { $1::$2 }
   | "..." dot_level { $1::$2 }
 
+(* ood for "out of date", this will no longer be necessary later )
 import_as_name:
   | NAME         { failwith "ood" }
   | NAME AS NAME { failwith "ood" }

--- a/lang_python/parsing/Visitor_python.ml
+++ b/lang_python/parsing/Visitor_python.ml
@@ -363,6 +363,8 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           let v1 = v_list v_annot v1 and v2 = v_tok v2 and v3 = v_expr v3 in ()
       | AugAssign (v1, v2, v3) ->
           let v1 = v_expr v1 and v2 = v_wrap v_operator v2 and v3 = v_expr v3 in ()
+      | Cast (expr, t, ty) ->
+          v_expr expr; v_info t; v_type_ ty; ()
       | Raise (t, v1) ->
           let t = v_info t in
           let v1 =

--- a/lang_python/parsing/Visitor_python.ml
+++ b/lang_python/parsing/Visitor_python.ml
@@ -323,7 +323,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           let v1 = v_list v_annot v1 and v2 = v_tok v2 and v3 = v_expr v3 in ()
       | AugAssign (v1, v2, v3) ->
           let v1 = v_expr v1 and v2 = v_wrap v_operator v2 and v3 = v_expr v3 in ()
-
       | Return (t, v1) ->
           let t = v_info t in
           let v1 = v_option v_expr v1 in ()

--- a/lang_python/parsing/Visitor_python.ml
+++ b/lang_python/parsing/Visitor_python.ml
@@ -113,10 +113,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           and v2 = v_expr_context v2
           and v3 = v_ref_do_not_visit v_resolved_name v3
           in ()
-      | TypedExpr (v1, v2) ->
-          let v1 = v_expr v1 in
-          let v2 = v_type_ v2 in
-          ()
       | TypedMetavar (v1, v2, v3) ->
           let v1 = v_name v1 in
           let v2 = v_tok v2 in
@@ -319,10 +315,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           and v3 = v_list v_stmt v3
           and v4 = v_list v_decorator v4
           in ()
-      | Assign (v1, v2, v3) ->
-          let v1 = v_list v_expr v1 and v2 = v_tok v2 and v3 = v_expr v3 in ()
-      | AugAssign (v1, v2, v3) ->
-          let v1 = v_expr v1 and v2 = v_wrap v_operator v2 and v3 = v_expr v3 in ()
       | Return (t, v1) ->
           let t = v_info t in
           let v1 = v_option v_expr v1 in ()
@@ -358,6 +350,19 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           and v2 = v_option v_expr v2
           and v3 = v_list v_stmt v3
           in ()
+      | Switch (t, exp, cases) ->
+          let t = v_info t in
+          let exp = v_expr exp
+          and cases = v_list v_cases_and_body cases in
+          ()
+      | Assign (v1, v2, v3) ->
+          let v_annot (expr, tt_opt) =
+            v_expr expr;
+            v_option (fun (tk, ty) -> v_info tk; v_type_ ty; ()) tt_opt
+          in
+          let v1 = v_list v_annot v1 and v2 = v_tok v2 and v3 = v_expr v3 in ()
+      | AugAssign (v1, v2, v3) ->
+          let v1 = v_expr v1 and v2 = v_wrap v_operator v2 and v3 = v_expr v3 in ()
       | Raise (t, v1) ->
           let t = v_info t in
           let v1 =
@@ -416,6 +421,19 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     in
     vin.kstmt (k, all_functions) x
 
+  and v_cases_and_body = function
+    | CasesAndBody (cases, stmts) ->
+        let cases = v_list v_case cases
+        and stmts = v_list v_stmt stmts in
+        ()
+    | CaseEllipsis v1 ->
+        let v1 = v_tok v1 in ()
+
+  and v_case = function
+    | Case (t, pat) ->
+        let t = v_info t in
+        let pat = v_expr pat in
+        ()
 
   and v_excepthandler =
     function

--- a/lang_python/parsing/Visitor_python.ml
+++ b/lang_python/parsing/Visitor_python.ml
@@ -315,6 +315,15 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           and v3 = v_list v_stmt v3
           and v4 = v_list v_decorator v4
           in ()
+      | Assign (v1, v2, v3) ->
+          let v_annot (expr, tt_opt) =
+            v_expr expr;
+            v_option (fun (tk, ty) -> v_info tk; v_type_ ty; ()) tt_opt
+          in
+          let v1 = v_list v_annot v1 and v2 = v_tok v2 and v3 = v_expr v3 in ()
+      | AugAssign (v1, v2, v3) ->
+          let v1 = v_expr v1 and v2 = v_wrap v_operator v2 and v3 = v_expr v3 in ()
+
       | Return (t, v1) ->
           let t = v_info t in
           let v1 = v_option v_expr v1 in ()
@@ -355,14 +364,6 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           let exp = v_expr exp
           and cases = v_list v_cases_and_body cases in
           ()
-      | Assign (v1, v2, v3) ->
-          let v_annot (expr, tt_opt) =
-            v_expr expr;
-            v_option (fun (tk, ty) -> v_info tk; v_type_ ty; ()) tt_opt
-          in
-          let v1 = v_list v_annot v1 and v2 = v_tok v2 and v3 = v_expr v3 in ()
-      | AugAssign (v1, v2, v3) ->
-          let v1 = v_expr v1 and v2 = v_wrap v_operator v2 and v3 = v_expr v3 in ()
       | Cast (expr, t, ty) ->
           v_expr expr; v_info t; v_type_ ty; ()
       | Raise (t, v1) ->


### PR DESCRIPTION
I am attempting a migration from `pfff` python parsing to `tree-sitter`.

These changes enable that migration by changing the type, and removing the problematic parts of the existing `pfff` parser that would otherwise cause things to not type-check.

### Security

- [X] Change has no security implications (otherwise, ping the security team)
