### PR TITLE
JS: Add PartialSwitchCase to the AST

### DIFF
--- a/lang_js/parsing/ast_js.ml
+++ b/lang_js/parsing/ast_js.ml
@@ -596,6 +596,7 @@ and partial =
   | PartialSingleField of string wrap (* an id or str *) * tok (* : *) * expr
   (* not really a partial, but the partial machinery can help with that *)
   | PartialFunOrFuncDef of tok (* ... *) * function_definition
+  | PartialSwitchCase of case
 
 (* this is now mutually recursive with the previous types because of StmtTodo*)
 and any =

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -446,6 +446,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | PartialCatch (v1) -> v_catch_block v1
     | PartialSingleField (v1, v2, v3) ->
         v_wrap v_string v1; v_tok v2; v_expr v3
+    | PartialSwitchCase x -> v_case x
 
   and v_program v = v_list v_toplevel v
 


### PR DESCRIPTION
This is meant for patterns such as `case 5: ...`

See related ocaml-tree-sitter-semgrep PR for context https://github.com/returntocorp/ocaml-tree-sitter-semgrep/pull/338

### Security

- [x] Change has no security implications (otherwise, ping the security team)
