### PR TITLE
Fix typos

### DIFF
--- a/commons_core/macro.ml4
+++ b/commons_core/macro.ml4
@@ -67,7 +67,7 @@ pb let obj' = f obj
      #load "pa_extend.cmo";;
     add Extend rule, copy paste in interpreter
     Grammar.Entry.parse expr (Stream.of_string "2 + 3");;
-      expr is already binded with the expr for caml
+      expr is already bound with the expr for caml
     can use the exception tricks to display (as in exception Print of type_decl)
 
    using p4 in p4 (with pattern that are quotation) is confusing

--- a/lang_cpp/parsing/old_glr/parser_cpp2.dyp
+++ b/lang_cpp/parsing/old_glr/parser_cpp2.dyp
@@ -1172,7 +1172,7 @@ template_id:
     { IdTemplateId ($1, ($2, $3, $4)) }
 
 /*
-(*c++ext: in the c++ grammar they have also 'template-name' but this is catched
+(*c++ext: in the c++ grammar they have also 'template-name' but this is caught
  * in my case by type_id and its generic TypedefIdent, or will be parsed
  * as an Ident and so assign_expr. In this later case may need a ast post
  * disambiguation analysis for some false positive.

--- a/lang_cpp/parsing/parser_cpp.mly
+++ b/lang_cpp/parsing/parser_cpp.mly
@@ -1024,7 +1024,7 @@ template_id:
     { IdTemplated(IdIdent $1, ($2, $3, $4)) }
 
 (*c++ext: in the c++ grammar they have also 'template-name' but this is
- * catched in my case by type_id and its generic TypedefIdent, or will be
+ * caught in my case by type_id and its generic TypedefIdent, or will be
  * parsed as an Ident and so assign_expr. In this later case may need an AST
  * post-disambiguation analysis for some false positives.
  *)

--- a/lang_php/analyze/graph_code_php.ml
+++ b/lang_php/analyze/graph_code_php.ml
@@ -971,7 +971,7 @@ and expr env x =
 
   (* -------------------------------------------------- *)
   (* This should be executed only for access to class constants or static
-   * class variable; calls should have been catched in the Call pattern above.
+   * class variable; calls should have been caught in the Call pattern above.
   *)
   | Class_get (e1, tok, e2) ->
       (match e1, e2 with

--- a/lang_scala/parsing/Parser_scala_recursive_descent.ml
+++ b/lang_scala/parsing/Parser_scala_recursive_descent.ml
@@ -1420,7 +1420,7 @@ and pattern2 in_ : pattern =
        (* ast: Bind(name, body), if WILDCARD then ... *)
        | PatVarid varid -> PatBind (varid, ii, y)
        (* stricter? *)
-       | _ -> error "binded patterns work only with a varid" in_
+       | _ -> error "bound patterns work only with a varid" in_
       )
   | _ -> x
 


### PR DESCRIPTION
### Security

- [x] Change has no security implications (otherwise, ping the security team)
