### PR TITLE
Add max_len parameter to read_file for partial reads

### DIFF
--- a/commons/Common.ml
+++ b/commons/Common.ml
@@ -1246,7 +1246,7 @@ let cat file =
    Why such a function is not provided by the ocaml standard library is
    unclear.
 *)
-let read_file2 path =
+let read_file2 ?(max_len = max_int) path =
   let buf_len = 4096 in
   let extbuf = Buffer.create 4096 in
   let buf = Bytes.create buf_len in
@@ -1257,15 +1257,18 @@ let read_file2 path =
         assert (num_bytes > 0);
         assert (num_bytes <= buf_len);
         Buffer.add_subbytes extbuf buf 0 num_bytes;
-        loop fd
+        if Buffer.length extbuf >= max_len then
+          Buffer.sub extbuf 0 max_len
+        else
+          loop fd
   in
   let fd = Unix.openfile path [Unix.O_RDONLY] 0 in
   Fun.protect
     ~finally:(fun () -> Unix.close fd)
     (fun () -> loop fd)
 
-let read_file a =
-  profile_code "Common.read_file" (fun () -> read_file2 a)
+let read_file ?max_len a =
+  profile_code "Common.read_file" (fun () -> read_file2 ?max_len a)
 
 let write_file ~file s =
   let chan = open_out_bin file in

--- a/commons/Common.mli
+++ b/commons/Common.mli
@@ -77,8 +77,10 @@ val write_file : file:filename -> string -> unit
      my-ocaml-program <(echo contents)
 
    * https://www.gnu.org/software/bash/manual/html_node/Process-Substitution.html
+
+   If max_len is specified, at most that many bytes are read from the file.
 *)
-val read_file : filename -> string
+val read_file : ?max_len:int -> filename -> string
 
 val with_open_outfile :
   filename -> ((string -> unit) * out_channel -> 'a) -> 'a

--- a/h_program-lang/Parse_info.mli
+++ b/h_program-lang/Parse_info.mli
@@ -60,6 +60,7 @@ val pp_full_token_info: bool ref
 val pp : Format.formatter -> t -> unit
 val pp_token_location: Format.formatter -> token_location -> unit
 val equal_token_location: token_location -> token_location -> bool
+val show_token_location: token_location -> string
 
 (* mostly for the fuzzy AST builder *)
 type token_kind =


### PR DESCRIPTION
This is used by spacegrep, which will now be able to read from named pipes created with bash e.g.
```
$ spacegrep hello <(echo 'hello world')
```

Test plan for `read_file`:
```
make test
```
Tests for named pipes would be too complicated (involving a fork). For testing them, try `semgrep-core -lang js -e x <(echo 'x')`, which should return a match.

This PR also exposes the `show_token_location` function which is occasionally useful for debugging semgrep.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
