### PR TITLE
add is directory

### DIFF
--- a/commons/Common.mli
+++ b/commons/Common.mli
@@ -336,6 +336,7 @@ val cache_computation :
 
 val filename_without_leading_path : string -> filename -> filename
 val readable: root:string -> filename -> filename
+val is_directory : filename -> bool 
 
 val follow_symlinks: bool ref
 val files_of_dir_or_files_no_vcs_nofilter:


### PR DESCRIPTION
Added `is_directory` to the `Common` interface.

Side note: Why is it that we keep `Common` in `pfff`? If it's just for legacy reasons, can we move it?

### Security

- [X] Change has no security implications (otherwise, ping the security team)
