### PR TITLE
allow equality checking for taint traces in parse_info

### DIFF
--- a/h_program-lang/Parse_info.ml
+++ b/h_program-lang/Parse_info.ml
@@ -92,7 +92,7 @@ type token_origin =
    * polluate in debug mode.
   *)
   | Ab
-[@@deriving show { with_path = false} ] (* with tarzan *)
+[@@deriving show { with_path = false}, eq ] (* with tarzan *)
 
 type token_mutable = {
   (* contains among other things the position of the token through
@@ -116,7 +116,7 @@ and add =
   | AddStr of string
   | AddNewlineAndIdent
 
-[@@deriving show { with_path = false} ] (* with tarzan *)
+[@@deriving show { with_path = false}, eq ] (* with tarzan *)
 
 exception NoTokenLocation of string
 
@@ -200,6 +200,7 @@ and esthet =
 
 (* shortcut *)
 type t = token_mutable
+[@@deriving eq]
 type info_ = t
 
 

--- a/h_program-lang/Parse_info.mli
+++ b/h_program-lang/Parse_info.mli
@@ -51,6 +51,7 @@ and add =
  * It's just a lexeme, but the word lexeme is not as known as token.
 *)
 type t = token_mutable
+[@@deriving eq]
 
 (* deprecated *)
 type info_ = t


### PR DESCRIPTION
## What:
Currently, `Parse_info.t`s ignore the taint traces when comparing for equality.

This means, in particular, that later assumptions on this equality function make deduplication remove taint traces which have different call sites.

## Why:
We should not do this, because we would like multiple findings from different call-sites, even if to the same sink (and from the same rule)

## How:
Made the equality function properly derived.

### Security

- [X] Change has no security implications (otherwise, ping the security team)
