### PR TITLE
Limit who can approve pull requests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# Together with the correct GitHub project setting, this limits who can
+# approve pull requests.
+# It's also used by GitHub to suggest reviewers.
+
+# Default owners:
+# Program Analysis team at r2c
+* @returntocorp/pa


### PR DESCRIPTION
Same thing as https://github.com/returntocorp/ocaml-tree-sitter-core/pull/49

### Security

- [x] Change has no security implications (otherwise, ping the security team)
