### PR TITLE
feat(js): opt chaining

### DIFF
--- a/lang_js/analyze/graph_code_js.ml
+++ b/lang_js/analyze/graph_code_js.ml
@@ -546,7 +546,7 @@ and expr env e =
             add_locals env [v]
       in
       class_ env c
-  | ObjAccess (e, _, _, prop) ->
+  | ObjAccess (e, _, prop) ->
       (match e with
        | Id (n (*, scope*)) when not (is_local env n) ->
            add_use_edge_candidates env (n, E.Class) (*scope*)

--- a/lang_js/analyze/graph_code_js.ml
+++ b/lang_js/analyze/graph_code_js.ml
@@ -546,7 +546,7 @@ and expr env e =
             add_locals env [v]
       in
       class_ env c
-  | ObjAccess (e, _, prop) ->
+  | ObjAccess (e, _, _, prop) ->
       (match e with
        | Id (n (*, scope*)) when not (is_local env n) ->
            add_use_edge_candidates env (n, E.Class) (*scope*)

--- a/lang_js/parsing/ast_js.ml
+++ b/lang_js/parsing/ast_js.ml
@@ -213,7 +213,7 @@ and expr =
   (* ident is None when assigned in module.exports  *)
   | Class of class_definition * a_ident option
 
-  | ObjAccess of expr * tok * property_name
+  | ObjAccess of expr * tok * (* is optional `?.` *) bool * property_name
   (* this can also be used to access object fields dynamically *)
   | ArrAccess of expr * expr bracket
 

--- a/lang_js/parsing/ast_js.ml
+++ b/lang_js/parsing/ast_js.ml
@@ -213,7 +213,7 @@ and expr =
   (* ident is None when assigned in module.exports  *)
   | Class of class_definition * a_ident option
 
-  | ObjAccess of expr * tok * (* is optional `?.` *) bool * property_name
+  | ObjAccess of expr * dot_operator wrap * property_name
   (* this can also be used to access object fields dynamically *)
   | ArrAccess of expr * expr bracket
 
@@ -340,6 +340,10 @@ and catch =
   | BoundCatch of tok * a_pattern * stmt
   (* js-ext: es2019, catch {...} *)
   | UnboundCatch of tok * stmt
+
+and dot_operator =
+  | Dot
+  | QuestDot
 
 (*****************************************************************************)
 (* Pattern (destructuring binding) *)

--- a/lang_js/parsing/lexer_js.mll
+++ b/lang_js/parsing/lexer_js.mll
@@ -301,6 +301,7 @@ rule initial = parse
   | "," { T_COMMA (tokinfo lexbuf) }
   | ":" { T_COLON (tokinfo lexbuf) }
   | "?" { T_PLING (tokinfo lexbuf) }
+  | "?." { T_QUESTDOT (tokinfo lexbuf) }
   | "&&" { T_AND (tokinfo lexbuf) } | "||" { T_OR (tokinfo lexbuf) }
   | "===" { T_STRICT_EQUAL (tokinfo lexbuf) }
   | "!==" { T_STRICT_NOT_EQUAL (tokinfo lexbuf) }

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -224,6 +224,7 @@ let mk_Encaps opt (t1, xs, _t2) =
  T_LPAREN "(" T_RPAREN ")"
  T_LBRACKET "[" T_RBRACKET "]"
  T_SEMICOLON ";" T_COMMA "," T_PERIOD "." T_COLON ":"
+ T_QUESTDOT "?."
  T_PLING "?"
  T_ARROW "->"
  (* regular JS token and also semgrep: *)
@@ -1333,7 +1334,7 @@ call_expr(x):
  | member_expr(x) arguments          { Apply ($1, $2) }
  | call_expr(x) arguments            { Apply ($1, $2) }
  | call_expr(x) "[" expr "]"         { ArrAccess ($1, ($2, $3,$4))}
- | call_expr(x) "." method_name      { ObjAccess ($1, $2, PN $3) }
+ | call_expr(x) access method_name      { ObjAccess ($1, fst $2, snd $2, PN $3) }
  (* es6: *)
  | call_expr(x) template_literal     { mk_Encaps (Some $1) $2 }
  | T_SUPER arguments                 { Apply (mk_Super($1), $2) }
@@ -1352,15 +1353,19 @@ new_expr(x):
  | member_expr(x)    { $1 }
  | T_NEW new_expr(d1) { New ($1, $2, fb $1 []) }
 
+access:
+  | "." { $1, false }
+  | T_QUESTDOT { $1, true }
+
 member_expr(x):
  | primary_expr(x)                   { $1 }
  | member_expr(x) "[" expr "]"       { ArrAccess($1, ($2, $3, $4)) }
- | member_expr(x) "." field_name     { ObjAccess($1, $2, PN $3) }
+ | member_expr(x) access field_name  { ObjAccess($1, fst $2, snd $2, PN $3) }
  | T_NEW member_expr(d1) arguments   { New ($1, $2, $3) }
  (* es6: *)
  | member_expr(x) template_literal   { mk_Encaps (Some $1) $2 }
  | T_SUPER "[" expr "]"              { ArrAccess(mk_Super($1),($2,$3,$4))}
- | T_SUPER "." field_name            { ObjAccess(mk_Super($1), $2, PN $3) }
+ | T_SUPER access field_name            { ObjAccess(mk_Super($1), fst $2, snd $2, PN $3) }
  | T_NEW "." id {
      if fst $3 = "target"
      then special NewTarget $1 []

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -1334,7 +1334,7 @@ call_expr(x):
  | member_expr(x) arguments          { Apply ($1, $2) }
  | call_expr(x) arguments            { Apply ($1, $2) }
  | call_expr(x) "[" expr "]"         { ArrAccess ($1, ($2, $3,$4))}
- | call_expr(x) access method_name      { ObjAccess ($1, fst $2, snd $2, PN $3) }
+ | call_expr(x) access method_name      { ObjAccess ($1, $2, PN $3) }
  (* es6: *)
  | call_expr(x) template_literal     { mk_Encaps (Some $1) $2 }
  | T_SUPER arguments                 { Apply (mk_Super($1), $2) }
@@ -1354,18 +1354,18 @@ new_expr(x):
  | T_NEW new_expr(d1) { New ($1, $2, fb $1 []) }
 
 access:
-  | "." { $1, false }
-  | T_QUESTDOT { $1, true }
+  | "." { Dot, $1 }
+  | T_QUESTDOT { QuestDot, $1 }
 
 member_expr(x):
  | primary_expr(x)                   { $1 }
  | member_expr(x) "[" expr "]"       { ArrAccess($1, ($2, $3, $4)) }
- | member_expr(x) access field_name  { ObjAccess($1, fst $2, snd $2, PN $3) }
+ | member_expr(x) access field_name  { ObjAccess($1, $2, PN $3) }
  | T_NEW member_expr(d1) arguments   { New ($1, $2, $3) }
  (* es6: *)
  | member_expr(x) template_literal   { mk_Encaps (Some $1) $2 }
  | T_SUPER "[" expr "]"              { ArrAccess(mk_Super($1),($2,$3,$4))}
- | T_SUPER access field_name            { ObjAccess(mk_Super($1), fst $2, snd $2, PN $3) }
+ | T_SUPER access field_name            { ObjAccess(mk_Super($1), $2, PN $3) }
  | T_NEW "." id {
      if fst $3 = "target"
      then special NewTarget $1 []

--- a/lang_js/parsing/token_helpers_js.ml
+++ b/lang_js/parsing/token_helpers_js.ml
@@ -128,6 +128,7 @@ let visitor_info_of_tok f = function
   | T_PLUS_ASSIGN ii -> T_PLUS_ASSIGN (f ii)
   | T_ASSIGN ii -> T_ASSIGN (f ii)
   | T_PLING ii -> T_PLING (f ii)
+  | T_QUESTDOT ii -> T_QUESTDOT (f ii)
   | T_COLON ii -> T_COLON (f ii)
   | T_OR ii -> T_OR (f ii)
   | T_AND ii -> T_AND (f ii)

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -175,8 +175,8 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           let t = v_tok t in
           ()
       | Class (v1, v2) -> let v1 = v_class_definition v1 in let v2 = v_option v_name v2 in ()
-      | ObjAccess (v1, t, v2) ->
-          let v1 = v_expr v1 and v2 = v_property_name v2 in
+      | ObjAccess (v1, t, b, v2) ->
+          let v1 = v_expr v1 and v2 = v_property_name v2 and b = v_bool b in
           let t = v_tok t in
           ()
       | Fun (v1, v2) -> let v1 = v_function_definition v1 and v2 = v_option v_name v2 in ()

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -175,9 +175,9 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
           let t = v_tok t in
           ()
       | Class (v1, v2) -> let v1 = v_class_definition v1 in let v2 = v_option v_name v2 in ()
-      | ObjAccess (v1, t, b, v2) ->
-          let v1 = v_expr v1 and v2 = v_property_name v2 and b = v_bool b in
-          let t = v_tok t in
+      | ObjAccess (v1, dot, v2) ->
+          let v1 = v_expr v1 and v2 = v_property_name v2 in
+          let t = v_dot_operator dot in
           ()
       | Fun (v1, v2) -> let v1 = v_function_definition v1 and v2 = v_option v_name v2 in ()
       | Apply (v1, v2) -> let v1 = v_expr v1 and v2 = v_bracket (v_list v_expr) v2 in ()
@@ -280,6 +280,8 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
     | Default (t, v1) ->
         let t = v_tok t in
         let v1 = v_stmt v1 in ()
+
+  and v_dot_operator _ = ()
 
   and v_resolved_name _ = ()
 


### PR DESCRIPTION
## What:
Added support for parsing opt chaining in object accesses especially.

## Why:
This will let us do matching where we differentiate the difference between `x.y` and `x?.y`.

## How:
Added a Boolean signifying an optional chain to the JS AST.

### Security

- [X] Change has no security implications (otherwise, ping the security team)
