### PR TITLE
feat(lsif): exposed `type` nonterminal for LSIF

### DIFF
--- a/lang_js/parsing/parse_js.ml
+++ b/lang_js/parsing/parse_js.ml
@@ -324,35 +324,6 @@ let type_of_string s =
   in
   let ty = Parser_js.type_for_lsif lexer lexbuf in
   ty
-(*let type_of_string s =
-  Common2.with_tmp_file ~str:s ~ext:"js" (fun file ->
-    let toks = tokens file in
-    let toks = Parsing_hacks_js.fix_tokens toks in
-    let toks = Parsing_hacks_js.fix_tokens_ASI toks in
-
-    let tr, lexer, lexbuf_fake = PI.mk_lexer_for_yacc toks TH.is_comment in
-    let last_charpos_error = ref 0 in
-
-    let rec parse_type tr =
-      try
-        Parser_js.type_for_lsif lexer lexbuf_fake
-
-      with Parsing.Parse_error ->
-        let cur = tr.PI.current in
-        let info = TH.info_of_tok cur in
-        let charpos = Parse_info.pos_of_info info in
-        (* try Automatic Semicolon Insertion *)
-        (match asi_opportunity charpos last_charpos_error cur tr with
-          | None -> raise Parsing.Parse_error
-          | Some (passed_before, passed_offending, passed_after) ->
-              asi_insert charpos last_charpos_error tr
-                (passed_before, passed_offending, passed_after);
-              parse_type tr
-        )
-    in
-    parse_type tr
-  )
-*)
 
 (* for sgrep/spatch *)
 let any_of_string s =

--- a/lang_js/parsing/parse_js.ml
+++ b/lang_js/parsing/parse_js.ml
@@ -314,6 +314,46 @@ let (program_of_string: string -> Ast_js.a_program) = fun s ->
     parse_program file
   )
 
+let type_of_string s =
+  let lexbuf = Lexing.from_string s in
+  let rec lexer lexbuf =
+    let res = Lexer_js.initial lexbuf in
+    if TH.is_comment res
+    then lexer lexbuf
+    else res
+  in
+  let ty = Parser_js.type_for_lsif lexer lexbuf in
+  ty
+(*let type_of_string s =
+  Common2.with_tmp_file ~str:s ~ext:"js" (fun file ->
+    let toks = tokens file in
+    let toks = Parsing_hacks_js.fix_tokens toks in
+    let toks = Parsing_hacks_js.fix_tokens_ASI toks in
+
+    let tr, lexer, lexbuf_fake = PI.mk_lexer_for_yacc toks TH.is_comment in
+    let last_charpos_error = ref 0 in
+
+    let rec parse_type tr =
+      try
+        Parser_js.type_for_lsif lexer lexbuf_fake
+
+      with Parsing.Parse_error ->
+        let cur = tr.PI.current in
+        let info = TH.info_of_tok cur in
+        let charpos = Parse_info.pos_of_info info in
+        (* try Automatic Semicolon Insertion *)
+        (match asi_opportunity charpos last_charpos_error cur tr with
+          | None -> raise Parsing.Parse_error
+          | Some (passed_before, passed_offending, passed_after) ->
+              asi_insert charpos last_charpos_error tr
+                (passed_before, passed_offending, passed_after);
+              parse_type tr
+        )
+    in
+    parse_type tr
+  )
+*)
+
 (* for sgrep/spatch *)
 let any_of_string s =
   Common.save_excursion Flag_parsing.sgrep_mode true (fun () ->

--- a/lang_js/parsing/parse_js.mli
+++ b/lang_js/parsing/parse_js.mli
@@ -19,6 +19,10 @@ val parse_string :
 val any_of_string:
   string -> Ast_js.any
 
+(* for lsif *)
+val type_of_string:
+  string -> Ast_js.type_
+
 (* to help write test code *)
 val program_of_string: string -> Ast_js.a_program
 

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -327,7 +327,7 @@ let mk_Encaps opt (t1, xs, _t2) =
 (* for lang_json/ *)
 %start <Ast_js.expr> json
 %start <Ast_js.any> json_pattern
-%start <Ast_js.type_> type_for_lsif 
+%start <Ast_js.type_> type_for_lsif
 
 (* just for better type error *)
 %type <Ast_js.stmt list> stmt item module_item

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -327,6 +327,7 @@ let mk_Encaps opt (t1, xs, _t2) =
 (* for lang_json/ *)
 %start <Ast_js.expr> json
 %start <Ast_js.any> json_pattern
+%start <Ast_js.type_> type_for_lsif 
 
 (* just for better type error *)
 %type <Ast_js.stmt list> stmt item module_item
@@ -931,6 +932,9 @@ complex_annotation:
 (*----------------------------*)
 (* Types *)
 (*----------------------------*)
+
+type_for_lsif:
+  | type_ EOF { $1 }
 
 (* can't use 'type'; generate syntax error in parser_js.ml *)
 type_:


### PR DESCRIPTION
## What:
This PR exposes the `type` parsing nonterminal for TS, which is used by the `lsif` experiment in order to process the obtained type hover information.

## Why:
We are trying to explore using LSIF to get type information for Typescript programs. Since the information we get back out is in the form of a string, we need to expose a way to parse Typescript types from strings, hence this PR. See the scope doc here: https://www.notion.so/r2cdev/Semgrep-LSIF-Querying-e9261a3fbee94084a129014d599045bd


### Security

- [X] Change has no security implications (otherwise, ping the security team)
