### PR TITLE
Add str and unix as explicit dependencies to Common

### DIFF
--- a/commons/dune
+++ b/commons/dune
@@ -4,6 +4,7 @@
  (libraries
    yojson easy_logging_yojson
    pfff-testutil
+   str unix
  )
  (preprocess (pps ppx_deriving.show ppx_deriving.eq))
 )


### PR DESCRIPTION
This should hopefully fix the failures on nightly build (see https://github.com/returntocorp/semgrep/actions/runs/3248938664/jobs/5330752887)

Test plan: merge into develop and run workflow

### Security

- [x] Change has no security implications (otherwise, ping the security team)
