### PR TITLE
enhanced `type_for_lsif` to interpret function types

### DIFF
--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -319,6 +319,8 @@ and param_pattern =
 *)
 and type_ = expr
 
+and lsif_type = Type of type_ | Arrow of parameters * type_
+
 (* used in inheritance, to allow default value for metaclass *)
 and type_parent = argument
 

--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -319,9 +319,10 @@ and param_pattern =
 *)
 and type_ = expr
 
-(* This is purely for LSIF type parsing, which is needed since Python types
-   do not natively have arrows in them.
-   So we expose this type to get that data out in the LSIF type parsing.
+(* This is exposed for `semgrep-proprietary`, which uses this to parse
+   type hover information from the Language Server Index Format (https://lsif.dev/).
+   Python types do not natively have arrows in them, so we must expose this type to
+   get that data out.
 *)
 and lsif_type = Type of type_ | Arrow of parameters * type_
 

--- a/lang_python/parsing/AST_python.ml
+++ b/lang_python/parsing/AST_python.ml
@@ -319,6 +319,10 @@ and param_pattern =
 *)
 and type_ = expr
 
+(* This is purely for LSIF type parsing, which is needed since Python types
+   do not natively have arrows in them.
+   So we expose this type to get that data out in the LSIF type parsing.
+*)
 and lsif_type = Type of type_ | Arrow of parameters * type_
 
 (* used in inheritance, to allow default value for metaclass *)

--- a/lang_python/parsing/Parse_python.ml
+++ b/lang_python/parsing/Parse_python.ml
@@ -182,6 +182,19 @@ let (program_of_string: string -> AST_python.program) = fun s ->
     parse_program file
   )
 
+let type_of_string ?(parsing_mode=Python) s =
+  let lexbuf = Lexing.from_string s in
+  let is_python2 = parsing_mode = Python2 in
+  let state = Lexer.create () in
+  let rec lexer  lexbuf =
+    let res = Lexer_python.token is_python2 state lexbuf in
+    if TH.is_comment res
+    then lexer lexbuf
+    else res
+  in
+  let ty = Parser_python.type_for_lsif lexer lexbuf in
+  ty
+
 (* for sgrep/spatch *)
 let any_of_string ?(parsing_mode=Python) s =
   Common.save_excursion Flag_parsing.sgrep_mode true (fun () ->

--- a/lang_python/parsing/Parse_python.mli
+++ b/lang_python/parsing/Parse_python.mli
@@ -25,6 +25,10 @@ val parse_program:
 val any_of_string:
   ?parsing_mode:parsing_mode -> string -> AST_python.any
 
+(* for lsif *)
+val type_of_string:
+  ?parsing_mode:parsing_mode -> string -> AST_python.type_
+
 (* for sgrep via fuzzy AST *)
 (*
 val parse_fuzzy:

--- a/lang_python/parsing/Parse_python.mli
+++ b/lang_python/parsing/Parse_python.mli
@@ -27,7 +27,7 @@ val any_of_string:
 
 (* for lsif *)
 val type_of_string:
-  ?parsing_mode:parsing_mode -> string -> AST_python.type_
+  ?parsing_mode:parsing_mode -> string -> AST_python.lsif_type
 
 (* for sgrep via fuzzy AST *)
 (*

--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -193,7 +193,7 @@ let mk_str ii =
 (*************************************************************************)
 %start <AST_python.program> main
 %start <AST_python.any> sgrep_spatch_pattern
-%start <AST_python.type_> type_for_lsif
+%start <AST_python.lsif_type> type_for_lsif
 %%
 
 (*************************************************************************)
@@ -761,7 +761,11 @@ atom_and_trailers:
     { Flag_parsing.sgrep_guard (DotAccessEllipsis ($1, $3)) }
 
 type_for_lsif:
-  | expr EOF { $1 }
+  | expr EOF { Type $1 }
+  (* This introduces some shift-reduce conflicts. But, it should be a relatively
+     unimportant warning, as this doesn't affect normal Python parsing.
+   *)
+  | parameters SUB GT expr EOF { Arrow ($1, $4) }
 
 (*----------------------------*)
 (* Atom *)

--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -764,6 +764,10 @@ type_for_lsif:
   | expr EOF { Type $1 }
   (* This introduces some shift-reduce conflicts. But, it should be a relatively
      unimportant warning, as this doesn't affect normal Python parsing.
+
+     We need this because our normal Python type parser does not understand function
+     types. However, the output from the LSIF hover info might have these function
+     types. So we need to be able to interpret it.
    *)
   | parameters SUB GT expr EOF { Arrow ($1, $4) }
 

--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -766,8 +766,8 @@ type_for_lsif:
      unimportant warning, as this doesn't affect normal Python parsing.
 
      We need this because our normal Python type parser does not understand function
-     types. However, the output from the LSIF hover info might have these function
-     types. So we need to be able to interpret it.
+     types. However, `semgrep-proprietary` needs to use it to parse type hover info,
+     which may contain function types. So we need to be able to interpret it.
    *)
   | parameters SUB GT expr EOF { Arrow ($1, $4) }
 

--- a/lang_python/parsing/Parser_python.mly
+++ b/lang_python/parsing/Parser_python.mly
@@ -193,6 +193,7 @@ let mk_str ii =
 (*************************************************************************)
 %start <AST_python.program> main
 %start <AST_python.any> sgrep_spatch_pattern
+%start <AST_python.type_> type_for_lsif
 %%
 
 (*************************************************************************)
@@ -758,6 +759,9 @@ atom_and_trailers:
   (* sgrep-ext: *)
   | atom_and_trailers "." "..."
     { Flag_parsing.sgrep_guard (DotAccessEllipsis ($1, $3)) }
+
+type_for_lsif:
+  | expr EOF { $1 }
 
 (*----------------------------*)
 (* Atom *)


### PR DESCRIPTION
## What:
Our normal Python type parser does not understand function types. The output of LSIF hover info may be a function type, however.

So this just modifies our `type_for_lsif` nonterminal to allow these things which look like function types.

## Why:
This will let us interpret more of the results from the LSIF information, increasing type coverage.

### Security

- [X] Change has no security implications (otherwise, ping the security team)
