### PR TITLE
fix(php): Fix DotAccessEllipsis parsing

### DIFF
--- a/lang_php/parsing/parser_php.mly
+++ b/lang_php/parsing/parser_php.mly
@@ -1089,6 +1089,8 @@ member_expr:
  | member_expr "->" primary_expr {  ObjGet($1, $2, $3) }
  | member_expr "->" "{" expr "}"
      { ObjGet($1,$2, (BraceIdent ($3, $4, $5))) }
+ | member_expr "->" "..."
+    { Flag_parsing.sgrep_guard (ObjGet($1, $2, Ellipsis $3)) }
  | member_expr "::" primary_expr { ClassGet($1, $2, $3) }
  (* conflicts: special rule to avoid conflicts in primary_expr *)
  | member_expr "::" keyword_as_ident_for_field


### PR DESCRIPTION
Looks like 2cb5bd77db775c4dab75b403e44f3d933ce754a5 missed a case.

Test plan: Tested with automated tests in Semgrep

### Security

- [x] Change has no security implications (otherwise, ping the security team)
