### PR TITLE
ruby: Fix translation of foo[:bar]

### DIFF
--- a/lang_ruby/parsing/parser_ruby.dyp
+++ b/lang_ruby/parsing/parser_ruby.dyp
@@ -488,7 +488,7 @@ primary:
   | T_USCOPE<pos> variable<id>       { ScopedId(TopScope(pos, id)) }
 
   | primary<p> T_LBRACK_ARG<t1> eols arg_comma_list_trail<xs> eols T_RBRACK<t2>
-     { M.methodcall (DotAccess(p,(t1), MethodOperator(Op_AREF,t2))) (fb xs) None }
+     { M.methodcall (DotAccess(p,(t1), MethodOperator(Op_AREF,t1))) (t1, xs, t2) None }
 
   | lambda { $1 }
 


### PR DESCRIPTION
It was translated as `foo.](bar)`, where `foo.]` had the same range as `foo[:bar]` itself. This caused problems with taint-mode and field sensitivity. If `foo[:bar]` is tainted then `foo.]` is tainted by side-effect, and then `foo[:other]` ends up being tainted too.

We now translate it as `foo.[(bar)` instead... we use `[` and `]` tokens instead of the fake `(` and `)` ones so the range of the Call node is the correct one.

Helps PA-2087

test plan:
Dump the AST of `foo[:bar]` and check it

### Security

- [x] Change has no security implications (otherwise, ping the security team)
