### PR TITLE
ruby: Fix translation of foo[bar]

### DIFF
--- a/lang_ruby/parsing/parser_ruby.dyp
+++ b/lang_ruby/parsing/parser_ruby.dyp
@@ -706,8 +706,8 @@ array_body_rest:
 array_item:
   | arg<e> { e }
   | constant<c> T_LBRACK<t1> eols call_args<xs> eols T_RBRACK<t2>
-      { M.methodcall (DotAccess(c, (t1), MethodOperator(Op_AREF,t2))) (* TODO: Wrong pos Binop, and probably all the following Binop in this file *)
-                     (fb xs) None }
+      { M.methodcall (DotAccess(c, (t1), MethodOperator(Op_AREF,t1))) (* TODO: Wrong pos Binop, and probably all the following Binop in this file *)
+                     (t1, xs, t2) None }
 
 
 hash: T_LBRACE eols hash_elem_list eols T_RBRACE { Hash(true, ($1, $3, $5)) }
@@ -860,7 +860,7 @@ lhs:
   | K_TRUE            { Literal(Bool (true,$1)) }
   | K_FALSE           { Literal(Bool (false,$1)) }
   | primary<p> T_LBRACK_ARG<t1> eols arg_comma_star_list<xs> eols T_RBRACK<t2>
-      { M.methodcall (DotAccess(p,(t1),MethodOperator(Op_AREF,t2))) (fb xs) None}
+      { M.methodcall (DotAccess(p,(t1),MethodOperator(Op_AREF,t1))) (t1, xs, t2) None}
   | primary<p> T_DOT<t> eols message_identifier<m>
       { M.methodcall (DotAccess(p,(t), (m))) (fb []) None}
 


### PR DESCRIPTION
It was translated as `foo.](bar)`, where `foo.]` had the same range as `foo[:bar]` itself. This caused problems with taint-mode and field sensitivity. If `foo[bar]` is tainted then `foo.]` is tainted by side-effect, and then `foo[other]` ends up being tainted too.

We now translate it as `foo.[(bar)` instead... we use `[` and `]` tokens instead of the fake `(` and `)` ones so the range of the Call node is the correct one.

Helps PA-2087

Fixes: 129c24294a8 ("ruby: Fix translation of foo[:bar]")

test plan:
Dump the AST of `foo[:bar]` and check it

### Security

- [x] Change has no security implications (otherwise, ping the security team)
