### PR TITLE
fix(deep-semgrep): change ast to support parsing multiple vardefs

### DIFF
--- a/lang_java/analyze/graph_code_java.ml
+++ b/lang_java/analyze/graph_code_java.ml
@@ -654,6 +654,7 @@ and stmt env = function
       exprs env (e::Common2.option_to_list eopt)
   (* The modification of env.params_locals is done in decls() *)
   | LocalVar f -> field env f
+  | LocalVarList xs -> stmts env xs
   | DeclStmt x -> decl env (x, 0)
   | DirectiveStmt _ -> raise Todo
 

--- a/lang_java/analyze/graph_code_java.ml
+++ b/lang_java/analyze/graph_code_java.ml
@@ -666,8 +666,8 @@ and stmts env xs =
           match x with
           | LocalVarList flds ->
               List.fold_right (fun fld env ->
-              { env with
-                params_or_locals = p_or_l fld.f_var :: env.params_or_locals }) flds env
+                { env with
+                  params_or_locals = p_or_l fld.f_var :: env.params_or_locals }) flds env
           (* also add LocalClass case? no, 'lookup env ...' handles that *)
           | _ -> env
         in

--- a/lang_java/analyze/graph_code_java.ml
+++ b/lang_java/analyze/graph_code_java.ml
@@ -653,8 +653,7 @@ and stmt env = function
   | Assert (_, e, eopt) ->
       exprs env (e::Common2.option_to_list eopt)
   (* The modification of env.params_locals is done in decls() *)
-  | LocalVar f -> field env f
-  | LocalVarList xs -> stmts env xs
+  | LocalVarList xs -> List.iter (field env) xs
   | DeclStmt x -> decl env (x, 0)
   | DirectiveStmt _ -> raise Todo
 
@@ -665,9 +664,10 @@ and stmts env xs =
         stmt env x;
         let env =
           match x with
-          | LocalVar fld ->
+          | LocalVarList flds ->
+              List.fold_right (fun fld env ->
               { env with
-                params_or_locals = p_or_l fld.f_var :: env.params_or_locals }
+                params_or_locals = p_or_l fld.f_var :: env.params_or_locals }) flds env
           (* also add LocalClass case? no, 'lookup env ...' handles that *)
           | _ -> env
         in

--- a/lang_java/analyze/highlight_java.ml
+++ b/lang_java/analyze/highlight_java.ml
@@ -95,9 +95,10 @@ let visit_toplevel ~tag_hook _prefs (ast, toks) =
                                );
                                V.kstmt = (fun (k, _) x ->
                                  (match x with
-                                  | LocalVar v ->
+                                  | LocalVarList vs ->
+                                      List.iter (fun v ->
                                       let ident = v.f_var.name in
-                                      tag_ident ident (Local Def)
+                                      tag_ident ident (Local Def)) vs
                                   | _ -> ()
                                  );
                                  k x

--- a/lang_java/analyze/highlight_java.ml
+++ b/lang_java/analyze/highlight_java.ml
@@ -97,8 +97,8 @@ let visit_toplevel ~tag_hook _prefs (ast, toks) =
                                  (match x with
                                   | LocalVarList vs ->
                                       List.iter (fun v ->
-                                      let ident = v.f_var.name in
-                                      tag_ident ident (Local Def)) vs
+                                        let ident = v.f_var.name in
+                                        tag_ident ident (Local Def)) vs
                                   | _ -> ()
                                  );
                                  k x

--- a/lang_java/parsing/ast_java.ml
+++ b/lang_java/parsing/ast_java.ml
@@ -289,6 +289,8 @@ and stmt =
 
   (* decl as statement *)
   | LocalVar of var_with_init
+  (* helper to desugar `int a = 1, b = 2` into two DefStmts later *)
+  | LocalVarList of stmts
   (* in recent Java, used to be only LocalClass *)
   | DeclStmt of decl
   | DirectiveStmt of directive

--- a/lang_java/parsing/ast_java.ml
+++ b/lang_java/parsing/ast_java.ml
@@ -288,9 +288,7 @@ and stmt =
   | Throw of tok * expr
 
   (* decl as statement *)
-  | LocalVar of var_with_init
-  (* helper to desugar `int a = 1, b = 2` into two DefStmts later *)
-  | LocalVarList of stmts
+  | LocalVarList of var_with_init list
   (* in recent Java, used to be only LocalClass *)
   | DeclStmt of decl
   | DirectiveStmt of directive

--- a/lang_java/parsing/parser_java.mly
+++ b/lang_java/parsing/parser_java.mly
@@ -367,7 +367,7 @@ item_other:
  | item_declaration         { [DeclStmt $1] }
  | import_declaration  { [DirectiveStmt $1] }
  | package_declaration { [DirectiveStmt $1] }
- | local_variable_declaration_statement { $1 }
+ | local_variable_declaration_statement { [$1] }
 
 item_declaration:
  | class_and_co_declaration { $1 }
@@ -883,13 +883,13 @@ statement_without_trailing_substatement:
 block: "{" block_statement* "}"  { Block ($1, List.flatten $2, $3) }
 
 block_statement:
- | local_variable_declaration_statement  { $1 }
+ | local_variable_declaration_statement  { [$1] }
  | statement          { [$1] }
  (* javaext: ? *)
  | class_declaration  { [DeclStmt (Class $1)] }
 
 local_variable_declaration_statement: local_variable_declaration ";"
-  { List.map (fun x -> LocalVar x) $1 }
+  { LocalVarList $1 }
 
 (* cant factorize with variable_modifier_opt, conflicts otherwise *)
 local_variable_declaration: modifiers_opt type_ listc(variable_declarator)

--- a/lang_java/parsing/visitor_java.ml
+++ b/lang_java/parsing/visitor_java.ml
@@ -321,8 +321,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
       | Throw (t, v1) ->
           let t = v_info t in
           let v1 = v_expr v1 in ()
-      | LocalVarList v1 -> let v1 = v_stmts v1 in ()
-      | LocalVar v1 -> let v1 = v_var_with_init v1 in ()
+      | LocalVarList v1 -> let v1 = v_list v_var_with_init v1 in ()
       | DeclStmt v1 -> let v1 = v_decl v1 in ()
       | DirectiveStmt v1 -> let v1 = v_directive v1 in ()
       | Assert (t, v1, v2) ->

--- a/lang_java/parsing/visitor_java.ml
+++ b/lang_java/parsing/visitor_java.ml
@@ -321,6 +321,7 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
       | Throw (t, v1) ->
           let t = v_info t in
           let v1 = v_expr v1 in ()
+      | LocalVarList v1 -> let v1 = v_stmts v1 in ()
       | LocalVar v1 -> let v1 = v_var_with_init v1 in ()
       | DeclStmt v1 -> let v1 = v_decl v1 in ()
       | DirectiveStmt v1 -> let v1 = v_directive v1 in ()


### PR DESCRIPTION
Support parsing `int a = 1, b = 2` into two DefStmts. Changes the ast to make the translation easier to `java_to_generic`

Test plan: see semgrep-proprietary PR

### Security

- [x] Change has no security implications (otherwise, ping the security team)
