### PR TITLE
js: Include the full list of imports in Import nodes

### DIFF
--- a/lang_js/analyze/graph_code_js.ml
+++ b/lang_js/analyze/graph_code_js.ml
@@ -344,26 +344,28 @@ and toplevel env x =
 
 and module_directive env x =
   match x with
-  | Import (_, (name1, name2opt), (file, tok)) ->
-      if env.phase = Uses then begin
-        let str1 = s_of_n name1 in
-        let str2_opt = Option.map s_of_n name2opt in
-        let path_opt = Module_path_js.resolve_path
-            ~root:env.root
-            ~pwd:(Filename.dirname env.file_readable)
-            file in
-        let readable =
-          match path_opt with
-          | None ->
-              env.pr2_and_log (spf "could not resolve path %s at %s" file
-                                 (Parse_info.string_of_info tok));
-              spf "NOTFOUND-|%s|.js" file
-          | Some fullpath -> Common.readable env.root fullpath
-        in
-        str2_opt |> Option.iter (fun str2 ->
-          Hashtbl.replace env.imports str2 (mk_qualified_name readable str1)
-        )
-      end
+  | Import (_, names, (file, tok)) ->
+      List.iter (fun (name1, name2opt) ->
+        if env.phase = Uses then begin
+          let str1 = s_of_n name1 in
+          let str2_opt = Option.map s_of_n name2opt in
+          let path_opt = Module_path_js.resolve_path
+              ~root:env.root
+              ~pwd:(Filename.dirname env.file_readable)
+              file in
+          let readable =
+            match path_opt with
+            | None ->
+                env.pr2_and_log (spf "could not resolve path %s at %s" file
+                                   (Parse_info.string_of_info tok));
+                spf "NOTFOUND-|%s|.js" file
+            | Some fullpath -> Common.readable env.root fullpath
+          in
+          str2_opt |> Option.iter (fun str2 ->
+            Hashtbl.replace env.imports str2 (mk_qualified_name readable str1)
+          )
+        end
+      ) names
   | Export (_t, name)
   | ReExportNamespace (_t, _, Some name, _, _) ->
       if env.phase = Defs then begin

--- a/lang_js/parsing/ast_js.ml
+++ b/lang_js/parsing/ast_js.ml
@@ -548,7 +548,7 @@ and module_directive =
    * when you do 'import "react"' to get a resolved path).
    * See Module_path_js to resolve paths.
   *)
-  | Import of tok * import_specifier * a_filename
+  | Import of tok * import_specifier list * a_filename
   | Export of tok * a_ident
   (* export * from 'foo'
      export * as bar from 'foo' *)

--- a/lang_js/parsing/parser_js.mly
+++ b/lang_js/parsing/parser_js.mly
@@ -517,16 +517,20 @@ import_clause:
  |                    import_names    { $1 }
 
 import_default: binding_id
-  { (fun t path -> [Import (t, ((default_entity, snd $1), Some $1), path)]) }
+  { (fun t path -> [Import (t, [((default_entity, snd $1), Some $1)], path)]) }
 
 import_names:
  | "*" T_AS binding_id
      { (fun t path -> [ModuleAlias (t, $3, path)]) }
  | named_imports
-     { (fun t path -> $1 |> Common.map_filter (fun x ->
-          match x with
-          | Some (n1, n2opt) -> Some (Import (t, (n1, n2opt), path))
-          | None -> None))
+     { (fun t path ->
+          let imports = $1 |> Common.map_filter (fun x ->
+            match x with
+            | Some (n1, n2opt) -> Some (n1, n2opt)
+            | None -> None)
+          in
+          [Import (t, imports, path)]
+       )
      }
  (* typing-ext: *)
  | T_TYPE named_imports

--- a/lang_js/parsing/visitor_js.ml
+++ b/lang_js/parsing/visitor_js.ml
@@ -414,9 +414,13 @@ let (mk_visitor: visitor_in -> visitor_out) = fun vin ->
          | Some name -> v_name name
          | None -> ());
         v_tok v4; v_filename v5
-    | Import (t, (v1, v2), v3) ->
+    | Import (t, v1, v2) ->
         let t = v_tok t in
-        let v1 = v_name v1 and v2 = v_option v_name v2 and v3 = v_filename v3
+        let v1 = v_list (fun (v1, v2) ->
+          let v1 = v_name v1 and v2 = v_option v_name v2 in
+          ()
+        ) v1 in
+        let v2 = v_filename v2
         in ()
     | ImportFile (t, v1) ->
         let t = v_tok t in


### PR DESCRIPTION
Instead of desugaring something like:

```import {x, y} from 'z';```

into two `Import` nodes, now each `Import` node can contain multiple
imported names.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
