### PR TITLE
Add option to register a hook to clean up tmp files

### DIFF
--- a/commons/common2.ml
+++ b/commons/common2.ml
@@ -3431,13 +3431,19 @@ let (with_open_outfile_append: filename -> (((string -> unit) * out_channel) -> 
     res)
     (fun _e -> close_out chan)
 
+let tmp_file_cleanup_hooks = ref []
+
 let with_tmp_file ~(str: string) ~(ext: string) (f: string -> 'a) : 'a =
   let tmpfile = Common.new_temp_file "tmp" ("." ^ ext) in
   write_file ~file:tmpfile str;
   Common.finalize (fun () ->
     f tmpfile
-  ) (fun () -> Common.erase_this_temp_file tmpfile)
+  ) (fun () ->
+    !tmp_file_cleanup_hooks |> List.iter (fun f -> f tmpfile);
+    Common.erase_this_temp_file tmpfile)
 
+let register_tmp_file_cleanup_hook f =
+  Common.push f tmp_file_cleanup_hooks
 
 let with_tmp_dir f =
   let tmp_dir = Filename.temp_file (spf "with-tmp-dir-%d" (Unix.getpid())) "" in

--- a/commons/common2.mli
+++ b/commons/common2.mli
@@ -1154,6 +1154,10 @@ val with_open_stringbuf :
   (((string -> unit) * Buffer.t) -> unit) -> string
 
 val with_tmp_file: str:string -> ext:string -> (filename -> 'a) -> 'a
+(* Runs just before a tmp file is deleted. Multiple hooks can be added, but the
+ * order in which they are called is unspecified. *)
+val register_tmp_file_cleanup_hook: (string -> unit) -> unit
+
 val with_tmp_dir: (dirname -> 'a) -> 'a
 
 (* If the user use some exit 0 in his code, then no one can intercept this


### PR DESCRIPTION
This is useful for cache invalidation when we cache information about files. We've run into issues where collisions in tmp file names lead to incorrect information in caches.
https://github.com/returntocorp/semgrep/issues/5277 is one example, and I just investigated another (see test plan).

Test plan: Automated tests in Semgrep and DeepSemgrep, plus `semgrep --deep --config=p/deepsemgrep ./NodeBB/ --verbose -j 1` where `NodeBB` is a fresh clone of the `NodeBB` repo, after using this new function to clean up the cache in Semgrep's `Range.ml`. Previously, that crashed.

### Security

- [x] Change has no security implications (otherwise, ping the security team)
